### PR TITLE
feat: StreamDeck-style deck with per-device pages, artwork, and actions

### DIFF
--- a/.cursor/rules/release-and-board-publishing.mdc
+++ b/.cursor/rules/release-and-board-publishing.mdc
@@ -1,0 +1,50 @@
+---
+description: Project-specific workflow for publishing Stream32 desktop releases and board support
+alwaysApply: true
+---
+
+# Stream32 releases and board support
+
+Follow the repository automation; do not manually attach build outputs or commit generated binaries.
+
+## Publish a desktop application release
+
+1. Start from an up-to-date `main` with no unrelated changes.
+2. From `desktop/`, run `npm ci`, `npm test`, and `npm run check`.
+3. Set the SemVer version in both manifests with `npm version <version> --no-git-tag-version`.
+4. Commit only `desktop/package.json` and `desktop/package-lock.json`, using
+   `chore(desktop): prepare v<version>`.
+5. Create tag `v<version>` on that commit. The tag must exactly equal `v` plus
+   `desktop/package.json`'s version.
+6. Push the commit to `main`, then push the tag:
+   `git push origin main` and `git push origin v<version>`.
+7. Verify the `Release Desktop` workflow and its generated GitHub Release.
+   It must contain Windows NSIS/portable, macOS DMG/ZIP, Linux AppImage/DEB,
+   updater metadata, and blockmaps. A hyphenated version is a prerelease.
+
+The workflow runs checks and packages x64 builds on all three operating
+systems. macOS artifacts are unsigned unless signing/notarization is configured,
+so do not claim that automatic macOS installation works for unsigned builds.
+
+## Add, update, and publish board support
+
+1. Create a lowercase stable directory under `boards/` with `board.json` and an
+   ESP-IDF project; use an existing board as the structural reference.
+2. Add its relative `board.json` path to `boards/catalog.json`.
+3. Keep `board.json`'s firmware SemVer, versioned `imageName`, and firmware
+   `CMakeLists.txt` `PROJECT_VER` identical. If firmware bytes change, bump the
+   version; published firmware asset names are immutable.
+4. Use precise USB VID/PID filters and correct hardware-revision warnings.
+   Catalog schema 1 currently accepts only ESP32-S3 and protocol 1.
+5. Build with ESP-IDF 5.4.4 from the firmware directory:
+   `bash ../../tools/build-firmware.sh`.
+6. Run `node boards/tools/build-catalog.js --validate-only` from the repository
+   root. Never commit `boards/dist/` or compiled firmware.
+7. Open and merge a PR. `Board CI` builds every listed profile. A merged
+   `boards/**` change on `main` runs `Publish Board Support`, which updates the
+   non-latest rolling `boards-current` release and publishes `catalog-v1.json`
+   only after versioned firmware and dependency locks succeed.
+
+Existing schema-1/protocol-1/flashing transport profiles need no desktop
+release. For a new protocol, chip, or transport, update the desktop, catalog
+tooling, and hardcoded board CI first; set `minimumDesktopVersion` accordingly.

--- a/boards/README.md
+++ b/boards/README.md
@@ -62,26 +62,62 @@ New protocols, chips, or transports require corresponding desktop support.
 ## USB protocol v1
 
 Firmware and desktop exchange bounded newline-delimited JSON over the
-ESP32-S3 USB Serial/JTAG port.
+ESP32-S3 USB Serial/JTAG port. Lines are limited to 4096 bytes on both
+sides.
 
 Desktop messages:
 
 ```json
 {"type":"hello","protocol":1}
 {"type":"ping","id":1}
+{"type":"layout","page":0,"of":2,"rows":3,"cols":3,"keys":[{"index":0,"label":"OBS","color":"#ff5533","imageCrc":"9a3f11d2","goPage":1}]}
+{"type":"image","page":0,"index":0,"seq":0,"of":13,"w":150,"h":150,"data":"<base64 RGB565>"}
+{"type":"page","index":1}
 ```
 
 Firmware messages:
 
 ```json
-{"type":"hello","protocol":1,"boardId":"waveshare-esp32-s3-touch-lcd-4-v3","firmwareVersion":"0.1.2","deviceId":"aabbccddeeff"}
+{"type":"hello","protocol":1,"boardId":"waveshare-esp32-s3-touch-lcd-4-v3","firmwareVersion":"0.2.0","deviceId":"aabbccddeeff"}
 {"type":"pong","id":1}
 {"type":"touch","phase":"down","x":120,"y":240}
+{"type":"layout-ack","page":0,"rows":3,"cols":3,"keyPx":150,"needImages":[0,4]}
+{"type":"image-ack","page":0,"index":0,"seq":0}
+{"type":"page","index":1}
+{"type":"press","page":0,"index":4,"phase":"down"}
 ```
 
 The desktop does not mark a port connected until the hello response has the
 expected protocol, a catalog board ID, a semantic firmware version, and a
 valid MAC-derived device ID.
+
+### Deck messages
+
+The deck extension is additive to protocol 1; firmware without it answers
+`error: unknown-type` and the desktop reports that a reflash is needed.
+
+- `layout` describes one page of the desired deck state (up to 8 pages of
+  1–5 × 1–5 keys). The desktop pushes every page in order after each
+  handshake or edit. `imageCrc` is the CRC-32 of the key's rendered RGB565
+  pixels; `goPage` marks a navigation key the firmware handles locally so
+  page switching works without a host.
+- `layout-ack` reports `keyPx`, the on-screen key size in pixels. The host
+  renders artwork at exactly that size, which keeps the protocol
+  resolution-independent across board types. `needImages` lists only the
+  keys whose artwork is missing from the device's flash pool, so a
+  steady-state reconnect streams nothing.
+- `image` chunks stream RGB565 artwork base64-encoded, stop-and-wait: the
+  desktop sends the next chunk only after the matching `image-ack`. The
+  final chunk is verified against `imageCrc` and persisted.
+- `page` selects the visible page. The firmware also emits it when a
+  `goPage` key switches pages locally.
+- `press` reports key touches with their page so the desktop can run the
+  configured action.
+
+The firmware persists layouts and artwork to the dedicated `deck` flash
+partition (header last, CRC-checked), so a standalone device boots straight
+into its deck. Artwork is pooled by CRC and garbage-collected after each
+full sync.
 
 ## Flash recovery
 

--- a/boards/tools/build-catalog.js
+++ b/boards/tools/build-catalog.js
@@ -165,6 +165,39 @@ function validateProfile(source, profilePath) {
     fail(`${profilePath} firmware version does not match CMakeLists.txt.`);
   }
 
+  let deck;
+
+  if (source.deck !== undefined) {
+    if (
+      !source.deck ||
+      typeof source.deck !== 'object' ||
+      Array.isArray(source.deck)
+    ) {
+      fail(`${profilePath} deck limits are invalid.`);
+    }
+
+    deck = {
+      maxRows: requireInteger(
+        source.deck.maxRows ?? 5,
+        `${profilePath} deck maxRows`,
+        1,
+        5,
+      ),
+      maxCols: requireInteger(
+        source.deck.maxCols ?? 5,
+        `${profilePath} deck maxCols`,
+        1,
+        5,
+      ),
+      maxPages: requireInteger(
+        source.deck.maxPages ?? 8,
+        `${profilePath} deck maxPages`,
+        1,
+        8,
+      ),
+    };
+  }
+
   return {
     id,
     name: requireString(source.name, `${profilePath} name`),
@@ -177,6 +210,7 @@ function validateProfile(source, profilePath) {
     protocolVersion,
     minimumDesktopVersion,
     usbFilters,
+    ...(deck ? { deck } : {}),
     firmware: {
       imageName,
       offset: requireInteger(
@@ -281,6 +315,7 @@ const boards = profiles.map((profile) => {
     protocolVersion: profile.protocolVersion,
     minimumDesktopVersion: profile.minimumDesktopVersion,
     usbFilters: profile.usbFilters,
+    ...(profile.deck ? { deck: profile.deck } : {}),
     capabilities: profile.capabilities,
     recoveryInstructions: profile.recoveryInstructions,
     firmware: {

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -13,6 +13,11 @@
       "usbProductId": 4097
     }
   ],
+  "deck": {
+    "maxRows": 5,
+    "maxCols": 5,
+    "maxPages": 8
+  },
   "firmware": {
     "version": "0.1.2",
     "projectPath": "firmware",

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -19,9 +19,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.2",
+    "version": "0.2.0",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.1.2.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.2.0.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.1.2")
+set(PROJECT_VER "0.2.0")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v3)

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/CMakeLists.txt
@@ -1,10 +1,12 @@
 idf_component_register(
-    SRCS "main.c"
+    SRCS "main.c" "deck_storage.c" "deck_ui.c"
     INCLUDE_DIRS "."
     REQUIRES
         esp_app_format
         esp_driver_usb_serial_jtag
         esp_hw_support
+        esp_partition
         json
+        mbedtls
         waveshare_bsp
 )

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_storage.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_storage.c
@@ -1,0 +1,408 @@
+#include "deck_storage.h"
+
+#include <stddef.h>
+#include <string.h>
+
+#include "esp_log.h"
+#include "esp_partition.h"
+#include "esp_rom_crc.h"
+
+#define DECK_HEADER_MAGIC 0x44323353u /* "S32D" */
+#define DECK_PAGE_MAGIC 0x50323353u   /* "S32P" */
+#define DECK_STORAGE_VERSION 1u
+#define DECK_SECTOR 4096u
+#define DECK_POOL_OFFSET ((uint32_t)DECK_SECTOR * (1u + DECK_MAX_PAGES))
+#define DECK_PARTITION_SUBTYPE 0x40
+
+typedef struct __attribute__((packed)) {
+    uint32_t crc;
+    uint32_t size;
+} deck_slot_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;
+    uint32_t version;
+    uint8_t page_count;
+    uint8_t active_page;
+    uint8_t reserved[2];
+    deck_slot_t slots[DECK_MAX_SLOTS];
+    uint32_t header_crc;
+} deck_header_t;
+
+typedef struct __attribute__((packed)) {
+    uint32_t magic;
+    uint32_t length;
+    uint32_t json_crc;
+} deck_page_header_t;
+
+_Static_assert(
+    sizeof(deck_header_t) <= DECK_SECTOR,
+    "Deck header must fit one erase sector"
+);
+_Static_assert(
+    sizeof(deck_page_header_t) + DECK_PAGE_JSON_CAPACITY <= DECK_SECTOR,
+    "Deck page metadata must fit one erase sector"
+);
+
+static const char *TAG = "deck_storage";
+static const esp_partition_t *s_partition;
+static deck_header_t s_header;
+static bool s_header_valid;
+/* The USB protocol task is the only writer, so one scratch sector is safe. */
+static uint8_t s_sector[DECK_SECTOR];
+
+static uint32_t compute_header_crc(const deck_header_t *header)
+{
+    return esp_rom_crc32_le(
+        0,
+        (const uint8_t *)header,
+        offsetof(deck_header_t, header_crc)
+    );
+}
+
+static void reset_header(void)
+{
+    memset(&s_header, 0, sizeof(s_header));
+    s_header.magic = DECK_HEADER_MAGIC;
+    s_header.version = DECK_STORAGE_VERSION;
+    s_header_valid = false;
+}
+
+static esp_err_t write_header(void)
+{
+    s_header.header_crc = compute_header_crc(&s_header);
+
+    esp_err_t error = esp_partition_erase_range(s_partition, 0, DECK_SECTOR);
+
+    if (error == ESP_OK) {
+        error = esp_partition_write(s_partition, 0, &s_header, sizeof(s_header));
+    }
+
+    if (error == ESP_OK) {
+        s_header_valid = true;
+    } else {
+        ESP_LOGW(TAG, "Header write failed: %s", esp_err_to_name(error));
+    }
+
+    return error;
+}
+
+esp_err_t deck_storage_init(void)
+{
+    s_partition = esp_partition_find_first(
+        ESP_PARTITION_TYPE_DATA,
+        DECK_PARTITION_SUBTYPE,
+        "deck"
+    );
+    reset_header();
+
+    if (s_partition == NULL) {
+        ESP_LOGE(TAG, "Deck partition is missing from the partition table");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    deck_header_t stored;
+    esp_err_t error = esp_partition_read(s_partition, 0, &stored, sizeof(stored));
+
+    if (error != ESP_OK) {
+        return error;
+    }
+
+    if (stored.magic == DECK_HEADER_MAGIC &&
+        stored.version == DECK_STORAGE_VERSION &&
+        stored.page_count >= 1 &&
+        stored.page_count <= DECK_MAX_PAGES &&
+        stored.active_page < stored.page_count &&
+        stored.header_crc == compute_header_crc(&stored)) {
+        s_header = stored;
+        s_header_valid = true;
+    }
+
+    return ESP_OK;
+}
+
+bool deck_storage_has_state(void)
+{
+    return s_header_valid && s_header.page_count >= 1;
+}
+
+uint8_t deck_storage_page_count(void)
+{
+    return s_header.page_count;
+}
+
+uint8_t deck_storage_active_page(void)
+{
+    return s_header.active_page;
+}
+
+bool deck_storage_read_page_json(
+    uint8_t page,
+    char *out,
+    size_t capacity,
+    size_t *length_out
+)
+{
+    if (s_partition == NULL || page >= DECK_MAX_PAGES) {
+        return false;
+    }
+
+    const uint32_t offset = DECK_SECTOR * (1u + page);
+    deck_page_header_t page_header;
+
+    if (esp_partition_read(
+            s_partition,
+            offset,
+            &page_header,
+            sizeof(page_header)
+        ) != ESP_OK) {
+        return false;
+    }
+
+    if (page_header.magic != DECK_PAGE_MAGIC ||
+        page_header.length == 0 ||
+        page_header.length > DECK_PAGE_JSON_CAPACITY ||
+        page_header.length + 1 > capacity) {
+        return false;
+    }
+
+    if (esp_partition_read(
+            s_partition,
+            offset + sizeof(page_header),
+            out,
+            page_header.length
+        ) != ESP_OK) {
+        return false;
+    }
+
+    if (esp_rom_crc32_le(0, (const uint8_t *)out, page_header.length) !=
+        page_header.json_crc) {
+        return false;
+    }
+
+    out[page_header.length] = '\0';
+
+    if (length_out != NULL) {
+        *length_out = page_header.length;
+    }
+
+    return true;
+}
+
+esp_err_t deck_storage_write_page_json(
+    uint8_t page,
+    const char *json,
+    size_t length,
+    uint8_t page_count
+)
+{
+    if (s_partition == NULL || page >= DECK_MAX_PAGES ||
+        page_count < 1 || page_count > DECK_MAX_PAGES ||
+        length == 0 || length > DECK_PAGE_JSON_CAPACITY) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const uint32_t json_crc = esp_rom_crc32_le(0, (const uint8_t *)json, length);
+    const uint32_t offset = DECK_SECTOR * (1u + page);
+    deck_page_header_t existing;
+    const bool page_matches =
+        esp_partition_read(s_partition, offset, &existing, sizeof(existing)) ==
+            ESP_OK &&
+        existing.magic == DECK_PAGE_MAGIC &&
+        existing.length == length &&
+        existing.json_crc == json_crc;
+
+    if (!page_matches) {
+        deck_page_header_t page_header = {
+            .magic = DECK_PAGE_MAGIC,
+            .length = (uint32_t)length,
+            .json_crc = json_crc,
+        };
+
+        memset(s_sector, 0xff, sizeof(s_sector));
+        memcpy(s_sector, &page_header, sizeof(page_header));
+        memcpy(s_sector + sizeof(page_header), json, length);
+
+        esp_err_t error = esp_partition_erase_range(
+            s_partition,
+            offset,
+            DECK_SECTOR
+        );
+
+        if (error == ESP_OK) {
+            error = esp_partition_write(
+                s_partition,
+                offset,
+                s_sector,
+                sizeof(page_header) + length
+            );
+        }
+
+        if (error != ESP_OK) {
+            ESP_LOGW(TAG, "Page %u write failed: %s", page, esp_err_to_name(error));
+            return error;
+        }
+    }
+
+    if (!s_header_valid || s_header.page_count != page_count ||
+        s_header.active_page >= page_count) {
+        s_header.page_count = page_count;
+
+        if (s_header.active_page >= page_count) {
+            s_header.active_page = 0;
+        }
+
+        return write_header();
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t deck_storage_set_active_page(uint8_t page)
+{
+    if (!s_header_valid || page >= s_header.page_count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (s_header.active_page == page) {
+        return ESP_OK;
+    }
+
+    s_header.active_page = page;
+    return write_header();
+}
+
+static int find_slot(uint32_t crc)
+{
+    if (crc == 0) {
+        return -1;
+    }
+
+    for (int index = 0; index < DECK_MAX_SLOTS; index++) {
+        if (s_header.slots[index].size > 0 &&
+            s_header.slots[index].crc == crc) {
+            return index;
+        }
+    }
+
+    return -1;
+}
+
+bool deck_storage_slot_find(uint32_t crc, uint32_t *size_out)
+{
+    const int slot = find_slot(crc);
+
+    if (slot < 0) {
+        return false;
+    }
+
+    if (size_out != NULL) {
+        *size_out = s_header.slots[slot].size;
+    }
+
+    return true;
+}
+
+esp_err_t deck_storage_slot_read(uint32_t crc, uint8_t *out, uint32_t size)
+{
+    const int slot = find_slot(crc);
+
+    if (slot < 0 || s_header.slots[slot].size != size) {
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    esp_err_t error = esp_partition_read(
+        s_partition,
+        DECK_POOL_OFFSET + (uint32_t)slot * DECK_SLOT_BYTES,
+        out,
+        size
+    );
+
+    if (error != ESP_OK) {
+        return error;
+    }
+
+    if (esp_rom_crc32_le(0, out, size) != crc) {
+        return ESP_ERR_INVALID_CRC;
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t deck_storage_slot_write(
+    uint32_t crc,
+    const uint8_t *data,
+    uint32_t size
+)
+{
+    if (s_partition == NULL || crc == 0 || size == 0 ||
+        size > DECK_SLOT_BYTES) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (find_slot(crc) >= 0) {
+        return ESP_OK; /* Identical artwork is stored once. */
+    }
+
+    int slot = -1;
+
+    for (int index = 0; index < DECK_MAX_SLOTS; index++) {
+        if (s_header.slots[index].size == 0) {
+            slot = index;
+            break;
+        }
+    }
+
+    if (slot < 0) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    const uint32_t offset = DECK_POOL_OFFSET + (uint32_t)slot * DECK_SLOT_BYTES;
+    const uint32_t erase_bytes = (size + DECK_SECTOR - 1) & ~(DECK_SECTOR - 1);
+    esp_err_t error = esp_partition_erase_range(s_partition, offset, erase_bytes);
+
+    if (error == ESP_OK) {
+        error = esp_partition_write(s_partition, offset, data, size);
+    }
+
+    if (error != ESP_OK) {
+        ESP_LOGW(TAG, "Slot write failed: %s", esp_err_to_name(error));
+        return error;
+    }
+
+    s_header.slots[slot].crc = crc;
+    s_header.slots[slot].size = size;
+    return write_header();
+}
+
+void deck_storage_gc(const uint32_t *live_crcs, size_t live_count)
+{
+    bool changed = false;
+
+    for (int index = 0; index < DECK_MAX_SLOTS; index++) {
+        if (s_header.slots[index].size == 0) {
+            continue;
+        }
+
+        bool live = false;
+
+        for (size_t entry = 0; entry < live_count; entry++) {
+            if (live_crcs[entry] == s_header.slots[index].crc) {
+                live = true;
+                break;
+            }
+        }
+
+        if (!live) {
+            /* ponytail: the pool is append-only between GCs; a linear scan
+               over 190 slots is plenty at this scale. */
+            s_header.slots[index].crc = 0;
+            s_header.slots[index].size = 0;
+            changed = true;
+        }
+    }
+
+    if (changed) {
+        write_header();
+    }
+}

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_storage.h
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_storage.h
@@ -1,0 +1,72 @@
+// Persistence for deck layouts and key artwork on the raw "deck" flash
+// partition, so a powered device shows its deck without the desktop.
+//
+// Partition layout (4 KB erase sectors):
+//   sector 0        main header: page count, active page, image slot table
+//   sectors 1..8    one layout JSON per page
+//   sector 9+       pool of 64 KB image slots keyed by CRC32 of the pixels
+//
+// Writes are ordered slots -> page sectors -> header, so a power cut leaves
+// an invalid header and the device falls back to the self-test screen.
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "esp_err.h"
+
+#define DECK_MAX_PAGES 8
+#define DECK_MAX_KEYS 25
+#define DECK_MAX_SLOTS 190
+#define DECK_SLOT_BYTES 0x10000
+#define DECK_PAGE_JSON_CAPACITY 4084
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Loads the header (or starts blank when missing/corrupt). Returns
+// ESP_ERR_NOT_FOUND when the deck partition is absent from the table.
+esp_err_t deck_storage_init(void);
+
+bool deck_storage_has_state(void);
+uint8_t deck_storage_page_count(void);
+uint8_t deck_storage_active_page(void);
+
+// Reads a stored page layout JSON. Returns false when the page is missing
+// or fails its CRC.
+bool deck_storage_read_page_json(
+    uint8_t page,
+    char *out,
+    size_t capacity,
+    size_t *length_out
+);
+
+// Persists one page's layout JSON and the page count. Skips flash writes
+// when the stored bytes already match.
+esp_err_t deck_storage_write_page_json(
+    uint8_t page,
+    const char *json,
+    size_t length,
+    uint8_t page_count
+);
+
+// Persists the active page shown at boot (no-op when unchanged).
+esp_err_t deck_storage_set_active_page(uint8_t page);
+
+bool deck_storage_slot_find(uint32_t crc, uint32_t *size_out);
+esp_err_t deck_storage_slot_read(uint32_t crc, uint8_t *out, uint32_t size);
+esp_err_t deck_storage_slot_write(
+    uint32_t crc,
+    const uint8_t *data,
+    uint32_t size
+);
+
+// Drops pool slots whose CRC is not in the live set (runs after a full
+// sync so replaced artwork stops occupying slots).
+void deck_storage_gc(const uint32_t *live_crcs, size_t live_count);
+
+#ifdef __cplusplus
+}
+#endif

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.c
@@ -1,0 +1,780 @@
+#include "deck_ui.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "bsp/esp-bsp.h"
+#include "deck_storage.h"
+#include "esp_heap_caps.h"
+#include "esp_log.h"
+#include "esp_rom_crc.h"
+#include "lvgl.h"
+#include "mbedtls/base64.h"
+
+#define DECK_SCREEN_PX 480
+#define DECK_KEY_GAP 8
+/* 180 px keys are the largest that fit a 64 KB flash slot in RGB565. */
+#define DECK_KEY_MAX_PX 180
+#define DECK_MAX_ROWS 5
+#define DECK_MAX_COLS 5
+#define DECK_LABEL_CAPACITY 33
+#define DECK_LINE_CAPACITY 128
+
+typedef struct {
+    bool used;
+    bool has_color;
+    int8_t go_page; /* -1 = plain key */
+    uint32_t color;
+    uint32_t image_crc; /* 0 = no artwork */
+    char label[DECK_LABEL_CAPACITY];
+} deck_key_t;
+
+typedef struct {
+    uint8_t rows;
+    uint8_t cols;
+    deck_key_t keys[DECK_MAX_KEYS];
+} deck_page_t;
+
+static const char *TAG = "deck_ui";
+static deck_notify_fn s_notify;
+static deck_page_t s_pages[DECK_MAX_PAGES];
+static uint8_t s_page_count;
+static uint8_t s_visible_page;
+static bool s_active;
+static volatile int s_pending_page = -1;
+
+static lv_obj_t *s_deck_screen;
+static lv_obj_t *s_key_objects[DECK_MAX_KEYS];
+static uint8_t *s_key_buffers[DECK_MAX_KEYS];
+static lv_image_dsc_t s_key_dsc[DECK_MAX_KEYS];
+
+static uint8_t *s_staging;
+static int s_staging_page = -1;
+static int s_staging_index = -1;
+static uint32_t s_staging_expected_seq;
+static uint32_t s_staging_received;
+
+static int compute_key_px(int rows, int cols)
+{
+    const int width = (DECK_SCREEN_PX - DECK_KEY_GAP * (cols + 1)) / cols;
+    const int height = (DECK_SCREEN_PX - DECK_KEY_GAP * (rows + 1)) / rows;
+    const int size = width < height ? width : height;
+
+    return size > DECK_KEY_MAX_PX ? DECK_KEY_MAX_PX : size;
+}
+
+static void notify_line(const char *line)
+{
+    if (s_notify != NULL) {
+        s_notify(line);
+    }
+}
+
+static void key_event_handler(lv_event_t *event)
+{
+    const lv_event_code_t code = lv_event_get_code(event);
+
+    if (code != LV_EVENT_PRESSED && code != LV_EVENT_RELEASED) {
+        return;
+    }
+
+    const int index = (int)(intptr_t)lv_event_get_user_data(event);
+    const char *phase = code == LV_EVENT_PRESSED ? "down" : "up";
+    char line[DECK_LINE_CAPACITY];
+
+    snprintf(
+        line,
+        sizeof(line),
+        "{\"type\":\"press\",\"page\":%d,\"index\":%d,\"phase\":\"%s\"}",
+        s_visible_page,
+        index,
+        phase
+    );
+    notify_line(line);
+
+    /* The raw touch stream stays alive for the desktop's touch test. */
+    lv_indev_t *input = lv_indev_active();
+
+    if (input != NULL) {
+        lv_point_t point;
+        lv_indev_get_point(input, &point);
+        snprintf(
+            line,
+            sizeof(line),
+            "{\"type\":\"touch\",\"phase\":\"%s\",\"x\":%d,\"y\":%d}",
+            phase,
+            (int)point.x,
+            (int)point.y
+        );
+        notify_line(line);
+    }
+
+    const deck_key_t *key = &s_pages[s_visible_page].keys[index];
+
+    if (code == LV_EVENT_PRESSED && key->go_page >= 0 &&
+        key->go_page < s_page_count) {
+        /* Rebuilding the grid needs the display lock, so defer the switch
+           to the USB task instead of doing it inside this LVGL callback. */
+        s_pending_page = key->go_page;
+    }
+}
+
+static void free_key_buffers(void)
+{
+    for (int index = 0; index < DECK_MAX_KEYS; index++) {
+        if (s_key_buffers[index] != NULL) {
+            heap_caps_free(s_key_buffers[index]);
+            s_key_buffers[index] = NULL;
+        }
+    }
+}
+
+static void set_key_image_dsc(int index, int key_px)
+{
+    memset(&s_key_dsc[index], 0, sizeof(s_key_dsc[index]));
+    s_key_dsc[index].header.magic = LV_IMAGE_HEADER_MAGIC;
+    s_key_dsc[index].header.cf = LV_COLOR_FORMAT_RGB565;
+    s_key_dsc[index].header.w = key_px;
+    s_key_dsc[index].header.h = key_px;
+    s_key_dsc[index].header.stride = key_px * 2;
+    s_key_dsc[index].data_size = (uint32_t)key_px * key_px * 2;
+    s_key_dsc[index].data = s_key_buffers[index];
+}
+
+static void attach_key_image(lv_obj_t *parent, int index)
+{
+    lv_obj_t *image = lv_image_create(parent);
+
+    lv_image_set_src(image, &s_key_dsc[index]);
+    lv_obj_center(image);
+    /* Labels stay above artwork. */
+    lv_obj_move_to_index(image, 0);
+}
+
+/* Loads the artwork for every key on the page into PSRAM. Runs before the
+   grid is (re)built so image descriptors point at valid pixels. */
+static void load_key_buffers(const deck_page_t *page, int key_px)
+{
+    const uint32_t size = (uint32_t)key_px * key_px * 2;
+
+    for (int index = 0; index < page->rows * page->cols; index++) {
+        const deck_key_t *key = &page->keys[index];
+        uint32_t stored_size = 0;
+
+        if (!key->used || key->image_crc == 0 ||
+            !deck_storage_slot_find(key->image_crc, &stored_size) ||
+            stored_size != size) {
+            continue;
+        }
+
+        s_key_buffers[index] = heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
+
+        if (s_key_buffers[index] == NULL) {
+            ESP_LOGW(TAG, "Out of PSRAM for key %d artwork", index);
+            continue;
+        }
+
+        if (deck_storage_slot_read(
+                key->image_crc,
+                s_key_buffers[index],
+                size
+            ) != ESP_OK) {
+            heap_caps_free(s_key_buffers[index]);
+            s_key_buffers[index] = NULL;
+        }
+    }
+}
+
+static void build_page(uint8_t page_index)
+{
+    if (page_index >= s_page_count) {
+        return;
+    }
+
+    const deck_page_t *page = &s_pages[page_index];
+    const int key_px = compute_key_px(page->rows, page->cols);
+    const int grid_width =
+        page->cols * key_px + (page->cols - 1) * DECK_KEY_GAP;
+    const int grid_height =
+        page->rows * key_px + (page->rows - 1) * DECK_KEY_GAP;
+    const int origin_x = (DECK_SCREEN_PX - grid_width) / 2;
+    const int origin_y = (DECK_SCREEN_PX - grid_height) / 2;
+
+    if (!bsp_display_lock(1000)) {
+        ESP_LOGW(TAG, "Could not lock LVGL to build the deck");
+        return;
+    }
+
+    if (s_deck_screen == NULL) {
+        s_deck_screen = lv_obj_create(NULL);
+        lv_obj_set_style_bg_color(
+            s_deck_screen,
+            lv_color_hex(0x0b1116),
+            LV_PART_MAIN
+        );
+        lv_obj_set_style_text_color(
+            s_deck_screen,
+            lv_color_hex(0xf3f7f9),
+            LV_PART_MAIN
+        );
+    }
+
+    lv_obj_clean(s_deck_screen);
+    memset(s_key_objects, 0, sizeof(s_key_objects));
+    s_visible_page = page_index;
+
+    free_key_buffers();
+    load_key_buffers(page, key_px);
+
+    for (int index = 0; index < page->rows * page->cols; index++) {
+        const deck_key_t *key = &page->keys[index];
+        const int row = index / page->cols;
+        const int col = index % page->cols;
+        lv_obj_t *cell = lv_obj_create(s_deck_screen);
+
+        s_key_objects[index] = cell;
+        lv_obj_set_size(cell, key_px, key_px);
+        lv_obj_set_pos(
+            cell,
+            origin_x + col * (key_px + DECK_KEY_GAP),
+            origin_y + row * (key_px + DECK_KEY_GAP)
+        );
+        lv_obj_set_style_radius(cell, 14, LV_PART_MAIN);
+        lv_obj_set_style_border_width(cell, 2, LV_PART_MAIN);
+        lv_obj_set_style_border_color(
+            cell,
+            lv_color_hex(0x29404d),
+            LV_PART_MAIN
+        );
+        lv_obj_set_style_border_color(
+            cell,
+            lv_color_hex(0xffad22),
+            LV_PART_MAIN | LV_STATE_PRESSED
+        );
+        lv_obj_set_style_bg_color(
+            cell,
+            key->used && key->has_color ? lv_color_hex(key->color)
+                                        : lv_color_hex(0x172630),
+            LV_PART_MAIN
+        );
+        lv_obj_set_style_pad_all(cell, 2, LV_PART_MAIN);
+        lv_obj_remove_flag(cell, LV_OBJ_FLAG_SCROLLABLE);
+        lv_obj_add_flag(cell, LV_OBJ_FLAG_CLICKABLE);
+        lv_obj_add_event_cb(
+            cell,
+            key_event_handler,
+            LV_EVENT_ALL,
+            (void *)(intptr_t)index
+        );
+
+        if (key->used && key->label[0] != '\0') {
+            lv_obj_t *label = lv_label_create(cell);
+
+            lv_label_set_text(label, key->label);
+            lv_label_set_long_mode(label, LV_LABEL_LONG_DOT);
+            lv_obj_set_width(label, key_px - 12);
+            lv_obj_set_style_text_align(
+                label,
+                LV_TEXT_ALIGN_CENTER,
+                LV_PART_MAIN
+            );
+            lv_obj_align(
+                label,
+                s_key_buffers[index] != NULL ? LV_ALIGN_BOTTOM_MID
+                                             : LV_ALIGN_CENTER,
+                0,
+                0
+            );
+        }
+
+        if (s_key_buffers[index] != NULL) {
+            set_key_image_dsc(index, key_px);
+            attach_key_image(cell, index);
+        }
+    }
+
+    lv_screen_load(s_deck_screen);
+    bsp_display_unlock();
+    s_active = true;
+}
+
+/* ---- Layout parsing ---------------------------------------------------- */
+
+static bool parse_color(const char *text, uint32_t *out)
+{
+    if (text == NULL || text[0] != '#' || strlen(text) != 7) {
+        return false;
+    }
+
+    char *end = NULL;
+    const unsigned long value = strtoul(text + 1, &end, 16);
+
+    if (end == NULL || *end != '\0') {
+        return false;
+    }
+
+    *out = (uint32_t)value;
+    return true;
+}
+
+static bool parse_crc(const char *text, uint32_t *out)
+{
+    if (text == NULL || strlen(text) != 8) {
+        return false;
+    }
+
+    char *end = NULL;
+    const unsigned long value = strtoul(text, &end, 16);
+
+    if (end == NULL || *end != '\0') {
+        return false;
+    }
+
+    *out = (uint32_t)value;
+    return true;
+}
+
+static const char *parse_page_message(
+    const cJSON *message,
+    deck_page_t *out,
+    int *page_out,
+    int *page_count_out
+)
+{
+    const cJSON *page = cJSON_GetObjectItemCaseSensitive(message, "page");
+    const cJSON *of = cJSON_GetObjectItemCaseSensitive(message, "of");
+    const cJSON *rows = cJSON_GetObjectItemCaseSensitive(message, "rows");
+    const cJSON *cols = cJSON_GetObjectItemCaseSensitive(message, "cols");
+    const cJSON *keys = cJSON_GetObjectItemCaseSensitive(message, "keys");
+
+    if (!cJSON_IsNumber(page) || !cJSON_IsNumber(of) ||
+        !cJSON_IsNumber(rows) || !cJSON_IsNumber(cols) ||
+        !cJSON_IsArray(keys)) {
+        return "layout-invalid";
+    }
+
+    const int page_index = page->valueint;
+    const int page_count = of->valueint;
+
+    if (page_index < 0 || page_count < 1 || page_count > DECK_MAX_PAGES ||
+        page_index >= page_count || rows->valueint < 1 ||
+        rows->valueint > DECK_MAX_ROWS || cols->valueint < 1 ||
+        cols->valueint > DECK_MAX_COLS) {
+        return "layout-invalid";
+    }
+
+    memset(out, 0, sizeof(*out));
+    out->rows = (uint8_t)rows->valueint;
+    out->cols = (uint8_t)cols->valueint;
+
+    for (int index = 0; index < DECK_MAX_KEYS; index++) {
+        out->keys[index].go_page = -1;
+    }
+
+    const int key_count = out->rows * out->cols;
+    const cJSON *entry = NULL;
+
+    cJSON_ArrayForEach(entry, keys) {
+        const cJSON *key_index = cJSON_GetObjectItemCaseSensitive(entry, "index");
+
+        if (!cJSON_IsNumber(key_index) || key_index->valueint < 0 ||
+            key_index->valueint >= key_count) {
+            return "layout-invalid";
+        }
+
+        deck_key_t *key = &out->keys[key_index->valueint];
+
+        if (key->used) {
+            return "layout-invalid";
+        }
+
+        key->used = true;
+
+        const cJSON *label = cJSON_GetObjectItemCaseSensitive(entry, "label");
+        const cJSON *color = cJSON_GetObjectItemCaseSensitive(entry, "color");
+        const cJSON *image_crc =
+            cJSON_GetObjectItemCaseSensitive(entry, "imageCrc");
+        const cJSON *go_page = cJSON_GetObjectItemCaseSensitive(entry, "goPage");
+
+        if (label != NULL) {
+            if (!cJSON_IsString(label) ||
+                strlen(label->valuestring) >= DECK_LABEL_CAPACITY) {
+                return "layout-invalid";
+            }
+
+            strcpy(key->label, label->valuestring);
+        }
+
+        if (color != NULL) {
+            if (!cJSON_IsString(color) ||
+                !parse_color(color->valuestring, &key->color)) {
+                return "layout-invalid";
+            }
+
+            key->has_color = true;
+        }
+
+        if (image_crc != NULL) {
+            if (!cJSON_IsString(image_crc) ||
+                !parse_crc(image_crc->valuestring, &key->image_crc)) {
+                return "layout-invalid";
+            }
+        }
+
+        if (go_page != NULL) {
+            if (!cJSON_IsNumber(go_page) || go_page->valueint < 0 ||
+                go_page->valueint >= page_count) {
+                return "layout-invalid";
+            }
+
+            key->go_page = (int8_t)go_page->valueint;
+        }
+    }
+
+    *page_out = page_index;
+    *page_count_out = page_count;
+    return NULL;
+}
+
+/* ---- Public API --------------------------------------------------------- */
+
+esp_err_t deck_ui_init(deck_notify_fn notify)
+{
+    s_notify = notify;
+
+    const esp_err_t error = deck_storage_init();
+
+    if (error != ESP_OK) {
+        return error;
+    }
+
+    if (!deck_storage_has_state()) {
+        return ESP_OK;
+    }
+
+    static char json[DECK_PAGE_JSON_CAPACITY + 1];
+    const uint8_t page_count = deck_storage_page_count();
+    uint8_t restored = 0;
+
+    for (uint8_t page = 0; page < page_count; page++) {
+        size_t length = 0;
+
+        if (!deck_storage_read_page_json(page, json, sizeof(json), &length)) {
+            ESP_LOGW(TAG, "Stored page %u is unreadable", page);
+            return ESP_OK;
+        }
+
+        cJSON *message = cJSON_ParseWithLength(json, length);
+
+        if (message == NULL) {
+            return ESP_OK;
+        }
+
+        int page_index = 0;
+        int stored_count = 0;
+        const char *parse_error = parse_page_message(
+            message,
+            &s_pages[page],
+            &page_index,
+            &stored_count
+        );
+
+        cJSON_Delete(message);
+
+        if (parse_error != NULL || page_index != page) {
+            ESP_LOGW(TAG, "Stored page %u is invalid", page);
+            return ESP_OK;
+        }
+
+        restored++;
+    }
+
+    if (restored == page_count) {
+        s_page_count = page_count;
+        build_page(deck_storage_active_page());
+        ESP_LOGI(TAG, "Restored %u deck page(s) from flash", restored);
+    }
+
+    return ESP_OK;
+}
+
+bool deck_ui_active(void)
+{
+    return s_active;
+}
+
+void deck_ui_poll(void)
+{
+    const int pending = s_pending_page;
+
+    if (pending < 0) {
+        return;
+    }
+
+    s_pending_page = -1;
+
+    if (pending >= s_page_count) {
+        return;
+    }
+
+    build_page((uint8_t)pending);
+
+    char line[DECK_LINE_CAPACITY];
+
+    snprintf(line, sizeof(line), "{\"type\":\"page\",\"index\":%d}", pending);
+    notify_line(line);
+}
+
+const char *deck_ui_handle_layout(
+    const cJSON *message,
+    const char *raw_line,
+    size_t raw_length,
+    char *reply,
+    size_t reply_capacity
+)
+{
+    deck_page_t parsed;
+    int page_index = 0;
+    int page_count = 0;
+    const char *error =
+        parse_page_message(message, &parsed, &page_index, &page_count);
+
+    if (error != NULL) {
+        return error;
+    }
+
+    if (raw_length > DECK_PAGE_JSON_CAPACITY) {
+        return "layout-too-large";
+    }
+
+    s_pages[page_index] = parsed;
+    s_page_count = (uint8_t)page_count;
+
+    if (deck_storage_write_page_json(
+            (uint8_t)page_index,
+            raw_line,
+            raw_length,
+            (uint8_t)page_count
+        ) != ESP_OK) {
+        return "storage-failed";
+    }
+
+    /* The desktop pushes pages in order, so the last page marks a complete
+       sync; unreferenced artwork can be dropped now. */
+    if (page_index == page_count - 1) {
+        uint32_t live[DECK_MAX_PAGES * DECK_MAX_KEYS];
+        size_t live_count = 0;
+
+        for (int page = 0; page < page_count; page++) {
+            for (int key = 0; key < DECK_MAX_KEYS; key++) {
+                const uint32_t crc = s_pages[page].keys[key].image_crc;
+
+                if (s_pages[page].keys[key].used && crc != 0) {
+                    live[live_count++] = crc;
+                }
+            }
+        }
+
+        deck_storage_gc(live, live_count);
+    }
+
+    if (!s_active) {
+        /* First contact: show the first page; the host restores the real
+           active page right after the sync. */
+        if (page_index == 0) {
+            build_page(0);
+        }
+    } else if (s_visible_page == page_index) {
+        build_page((uint8_t)page_index);
+    } else if (s_visible_page >= page_count) {
+        build_page((uint8_t)(page_count - 1));
+    }
+
+    const int key_px = compute_key_px(parsed.rows, parsed.cols);
+    int written = snprintf(
+        reply,
+        reply_capacity,
+        "{\"type\":\"layout-ack\",\"page\":%d,\"rows\":%d,\"cols\":%d,"
+        "\"keyPx\":%d,\"needImages\":[",
+        page_index,
+        parsed.rows,
+        parsed.cols,
+        key_px
+    );
+    bool first = true;
+
+    for (int index = 0; index < parsed.rows * parsed.cols; index++) {
+        const deck_key_t *key = &parsed.keys[index];
+        const uint32_t expected_size = (uint32_t)key_px * key_px * 2;
+        uint32_t stored_size = 0;
+
+        if (!key->used || key->image_crc == 0) {
+            continue;
+        }
+
+        if (deck_storage_slot_find(key->image_crc, &stored_size) &&
+            stored_size == expected_size) {
+            continue;
+        }
+
+        written += snprintf(
+            reply + written,
+            reply_capacity - written,
+            "%s%d",
+            first ? "" : ",",
+            index
+        );
+        first = false;
+    }
+
+    snprintf(reply + written, reply_capacity - written, "]}");
+    return NULL;
+}
+
+const char *deck_ui_handle_image(
+    const cJSON *message,
+    char *reply,
+    size_t reply_capacity
+)
+{
+    const cJSON *page = cJSON_GetObjectItemCaseSensitive(message, "page");
+    const cJSON *index = cJSON_GetObjectItemCaseSensitive(message, "index");
+    const cJSON *seq = cJSON_GetObjectItemCaseSensitive(message, "seq");
+    const cJSON *of = cJSON_GetObjectItemCaseSensitive(message, "of");
+    const cJSON *width = cJSON_GetObjectItemCaseSensitive(message, "w");
+    const cJSON *height = cJSON_GetObjectItemCaseSensitive(message, "h");
+    const cJSON *data = cJSON_GetObjectItemCaseSensitive(message, "data");
+
+    if (!cJSON_IsNumber(page) || !cJSON_IsNumber(index) ||
+        !cJSON_IsNumber(seq) || !cJSON_IsNumber(of) ||
+        !cJSON_IsNumber(width) || !cJSON_IsNumber(height) ||
+        !cJSON_IsString(data)) {
+        return "image-invalid";
+    }
+
+    const int page_index = page->valueint;
+    const int key_index = index->valueint;
+
+    if (page_index < 0 || page_index >= s_page_count || key_index < 0 ||
+        key_index >= s_pages[page_index].rows * s_pages[page_index].cols) {
+        return "image-invalid";
+    }
+
+    const deck_key_t *key = &s_pages[page_index].keys[key_index];
+    const uint32_t total_size = (uint32_t)width->valueint * height->valueint * 2;
+
+    if (!key->used || key->image_crc == 0 || width->valueint < 1 ||
+        height->valueint < 1 || total_size > DECK_SLOT_BYTES) {
+        return "image-invalid";
+    }
+
+    if (s_staging == NULL) {
+        s_staging = heap_caps_malloc(DECK_SLOT_BYTES, MALLOC_CAP_SPIRAM);
+
+        if (s_staging == NULL) {
+            return "image-no-memory";
+        }
+    }
+
+    if (seq->valueint == 0) {
+        s_staging_page = page_index;
+        s_staging_index = key_index;
+        s_staging_expected_seq = 0;
+        s_staging_received = 0;
+    }
+
+    if (page_index != s_staging_page || key_index != s_staging_index ||
+        (uint32_t)seq->valueint != s_staging_expected_seq) {
+        s_staging_page = -1;
+        return "image-sequence";
+    }
+
+    size_t decoded = 0;
+    const size_t data_length = strlen(data->valuestring);
+
+    if (mbedtls_base64_decode(
+            s_staging + s_staging_received,
+            DECK_SLOT_BYTES - s_staging_received,
+            &decoded,
+            (const unsigned char *)data->valuestring,
+            data_length
+        ) != 0) {
+        s_staging_page = -1;
+        return "image-invalid";
+    }
+
+    s_staging_received += decoded;
+    s_staging_expected_seq++;
+
+    if ((int)s_staging_expected_seq == of->valueint) {
+        s_staging_page = -1;
+
+        if (s_staging_received != total_size) {
+            return "image-size-mismatch";
+        }
+
+        if (esp_rom_crc32_le(0, s_staging, total_size) != key->image_crc) {
+            return "image-crc-mismatch";
+        }
+
+        if (deck_storage_slot_write(
+                key->image_crc,
+                s_staging,
+                total_size
+            ) != ESP_OK) {
+            return "storage-failed";
+        }
+
+        /* Show the artwork immediately when its page is on screen. */
+        if (s_active && s_visible_page == page_index &&
+            s_key_objects[key_index] != NULL) {
+            const int key_px =
+                compute_key_px(s_pages[page_index].rows, s_pages[page_index].cols);
+
+            if ((uint32_t)key_px * key_px * 2 == total_size &&
+                bsp_display_lock(1000)) {
+                if (s_key_buffers[key_index] == NULL) {
+                    s_key_buffers[key_index] =
+                        heap_caps_malloc(total_size, MALLOC_CAP_SPIRAM);
+
+                    if (s_key_buffers[key_index] != NULL) {
+                        memcpy(s_key_buffers[key_index], s_staging, total_size);
+                        set_key_image_dsc(key_index, key_px);
+                        attach_key_image(s_key_objects[key_index], key_index);
+                    }
+                } else {
+                    memcpy(s_key_buffers[key_index], s_staging, total_size);
+                    lv_obj_invalidate(s_key_objects[key_index]);
+                }
+
+                bsp_display_unlock();
+            }
+        }
+    }
+
+    snprintf(
+        reply,
+        reply_capacity,
+        "{\"type\":\"image-ack\",\"page\":%d,\"index\":%d,\"seq\":%d}",
+        page_index,
+        key_index,
+        seq->valueint
+    );
+    return NULL;
+}
+
+const char *deck_ui_handle_page(const cJSON *message)
+{
+    const cJSON *index = cJSON_GetObjectItemCaseSensitive(message, "index");
+
+    if (!cJSON_IsNumber(index) || index->valueint < 0 ||
+        index->valueint >= s_page_count) {
+        return "page-invalid";
+    }
+
+    build_page((uint8_t)index->valueint);
+    deck_storage_set_active_page((uint8_t)index->valueint);
+    return NULL;
+}

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.h
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.h
@@ -1,0 +1,48 @@
+// LVGL deck grid driven by the desktop's layout/image/page messages and by
+// the persisted state in deck_storage. Presses and local page switches are
+// reported through the notify callback as ready-to-send JSON lines.
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "cJSON.h"
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*deck_notify_fn)(const char *json_line);
+
+// Restores the persisted deck (when present) and shows it. The notify
+// callback runs in LVGL task context and must only queue the line.
+esp_err_t deck_ui_init(deck_notify_fn notify);
+
+// True once a deck layout is on screen instead of the self-test UI.
+bool deck_ui_active(void);
+
+// Runs deferred work (local goPage switches) outside LVGL context. Call
+// regularly from the USB protocol task.
+void deck_ui_poll(void);
+
+// Message handlers return NULL on success or a short error code for the
+// protocol error reply. On success, reply (when non-NULL) holds a JSON
+// line to send back.
+const char *deck_ui_handle_layout(
+    const cJSON *message,
+    const char *raw_line,
+    size_t raw_length,
+    char *reply,
+    size_t reply_capacity
+);
+const char *deck_ui_handle_image(
+    const cJSON *message,
+    char *reply,
+    size_t reply_capacity
+);
+const char *deck_ui_handle_page(const cJSON *message);
+
+#ifdef __cplusplus
+}
+#endif

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
@@ -5,6 +5,7 @@
 
 #include "bsp/esp-bsp.h"
 #include "cJSON.h"
+#include "deck_ui.h"
 #include "driver/usb_serial_jtag.h"
 #include "esp_app_desc.h"
 #include "esp_err.h"
@@ -17,17 +18,14 @@
 
 #define STREAM32_BOARD_ID "waveshare-esp32-s3-touch-lcd-4-v3"
 #define STREAM32_PROTOCOL_VERSION 1
-#define STREAM32_LINE_CAPACITY 256
-#define STREAM32_USB_BUFFER_SIZE 1024
-
-typedef struct {
-    const char *phase;
-    int16_t x;
-    int16_t y;
-} touch_message_t;
+/* Matches the desktop's protocol line limit; image chunks fill whole lines. */
+#define STREAM32_LINE_CAPACITY 4096
+#define STREAM32_USB_BUFFER_SIZE 4096
+#define STREAM32_EVENT_LINE_CAPACITY 128
+#define STREAM32_REPLY_CAPACITY 384
 
 static const char *TAG = "stream32";
-static QueueHandle_t touch_queue;
+static QueueHandle_t event_queue;
 static lv_obj_t *connection_label;
 static lv_obj_t *touch_label;
 static lv_obj_t *touch_surface;
@@ -56,6 +54,15 @@ static void usb_write_line(const char *json)
 {
     usb_write_all(json, strlen(json));
     usb_write_all("\n", 1);
+}
+
+/* Queues a ready-to-send JSON line from LVGL/event context. */
+static void queue_event_line(const char *json)
+{
+    char line[STREAM32_EVENT_LINE_CAPACITY];
+
+    strlcpy(line, json, sizeof(line));
+    (void)xQueueSend(event_queue, line, 0);
 }
 
 static void update_connection_label(const char *text)
@@ -109,6 +116,7 @@ static void send_error(const char *code)
 static void handle_host_message(const char *line, size_t length)
 {
     cJSON *message = cJSON_ParseWithLength(line, length);
+    static char reply[STREAM32_REPLY_CAPACITY];
 
     if (message == NULL) {
         send_error("invalid-json");
@@ -148,26 +156,39 @@ static void handle_host_message(const char *line, size_t length)
             );
             usb_write_line(response);
         }
+    } else if (strcmp(type->valuestring, "layout") == 0) {
+        const char *error = deck_ui_handle_layout(
+            message,
+            line,
+            length,
+            reply,
+            sizeof(reply)
+        );
+
+        if (error != NULL) {
+            send_error(error);
+        } else {
+            usb_write_line(reply);
+        }
+    } else if (strcmp(type->valuestring, "image") == 0) {
+        const char *error = deck_ui_handle_image(message, reply, sizeof(reply));
+
+        if (error != NULL) {
+            send_error(error);
+        } else {
+            usb_write_line(reply);
+        }
+    } else if (strcmp(type->valuestring, "page") == 0) {
+        const char *error = deck_ui_handle_page(message);
+
+        if (error != NULL) {
+            send_error(error);
+        }
     } else {
         send_error("unknown-type");
     }
 
     cJSON_Delete(message);
-}
-
-static void send_touch_message(const touch_message_t *touch)
-{
-    char message[128];
-
-    snprintf(
-        message,
-        sizeof(message),
-        "{\"type\":\"touch\",\"phase\":\"%s\",\"x\":%d,\"y\":%d}",
-        touch->phase,
-        touch->x,
-        touch->y
-    );
-    usb_write_line(message);
 }
 
 static void usb_protocol_task(void *argument)
@@ -176,8 +197,9 @@ static void usb_protocol_task(void *argument)
         .tx_buffer_size = STREAM32_USB_BUFFER_SIZE,
         .rx_buffer_size = STREAM32_USB_BUFFER_SIZE,
     };
-    uint8_t incoming[64];
-    char line[STREAM32_LINE_CAPACITY];
+    uint8_t incoming[256];
+    /* Static: a 4 KB line does not belong on the task stack. */
+    static char line[STREAM32_LINE_CAPACITY];
     size_t line_length = 0;
     bool dropping_oversized_line = false;
 
@@ -212,10 +234,12 @@ static void usb_protocol_task(void *argument)
             }
         }
 
-        touch_message_t touch;
+        deck_ui_poll();
 
-        while (xQueueReceive(touch_queue, &touch, 0) == pdTRUE) {
-            send_touch_message(&touch);
+        char event_line[STREAM32_EVENT_LINE_CAPACITY];
+
+        while (xQueueReceive(event_queue, event_line, 0) == pdTRUE) {
+            usb_write_line(event_line);
         }
     }
 }
@@ -253,13 +277,17 @@ static void touch_event_handler(lv_event_t *event)
         LV_PART_MAIN
     );
 
-    const touch_message_t touch = {
-        .phase = phase,
-        .x = (int16_t)point.x,
-        .y = (int16_t)point.y,
-    };
+    char line[STREAM32_EVENT_LINE_CAPACITY];
 
-    (void)xQueueSend(touch_queue, &touch, 0);
+    snprintf(
+        line,
+        sizeof(line),
+        "{\"type\":\"touch\",\"phase\":\"%s\",\"x\":%d,\"y\":%d}",
+        phase,
+        (int)point.x,
+        (int)point.y
+    );
+    queue_event_line(line);
 }
 
 static void create_self_test_ui(void)
@@ -324,10 +352,10 @@ static void create_self_test_ui(void)
 
 void app_main(void)
 {
-    touch_queue = xQueueCreate(16, sizeof(touch_message_t));
+    event_queue = xQueueCreate(24, STREAM32_EVENT_LINE_CAPACITY);
 
-    if (touch_queue == NULL) {
-        ESP_LOGE(TAG, "Could not allocate the touch event queue");
+    if (event_queue == NULL) {
+        ESP_LOGE(TAG, "Could not allocate the event queue");
         return;
     }
 
@@ -346,10 +374,16 @@ void app_main(void)
     create_self_test_ui();
     bsp_display_unlock();
 
+    /* Restores the persisted deck; the self-test screen stays visible when
+       no deck has ever been synced. */
+    if (deck_ui_init(queue_event_line) != ESP_OK) {
+        ESP_LOGW(TAG, "Deck storage is unavailable; decks will not persist");
+    }
+
     const BaseType_t task_created = xTaskCreate(
         usb_protocol_task,
         "stream32_usb",
-        6144,
+        8192,
         NULL,
         5,
         NULL

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/partitions.csv
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/partitions.csv
@@ -2,3 +2,4 @@
 nvs,      data, nvs,     0x9000,   24K,
 phy_init, data, phy,     0xf000,   4K,
 factory,  app,  factory, 0x10000,  4M,
+deck,     data, 0x40,    0x410000, 0xBF0000,

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build:renderer": "esbuild src/renderer/renderer.js --bundle --platform=browser --format=iife --target=chrome142 --outfile=src/renderer/renderer.bundle.js",
     "start": "npm run build:renderer && electron .",
-    "check": "npm run build:renderer && node --check src/main.js && node --check src/preload.js && node --check src/tray.js && node --check src/updater.js && node --check src/autostart.js && node --check src/boards.js && node --check src/serial.js && node --check src/settings.js && node --check src/renderer/device.js && node --check src/renderer/firmware-hash.js && node --check src/renderer/protocol.js && node --check src/renderer/renderer.js",
+    "check": "npm run build:renderer && node --check src/main.js && node --check src/preload.js && node --check src/tray.js && node --check src/updater.js && node --check src/autostart.js && node --check src/actions.js && node --check src/boards.js && node --check src/deck-store.js && node --check src/keymap.js && node --check src/serial.js && node --check src/settings.js && node --check src/renderer/deck.js && node --check src/renderer/device.js && node --check src/renderer/firmware-hash.js && node --check src/renderer/protocol.js && node --check src/renderer/renderer.js",
     "test": "node --test",
     "prepack": "npm run build:renderer",
     "pack": "electron-builder --dir",

--- a/desktop/src/actions.js
+++ b/desktop/src/actions.js
@@ -1,0 +1,227 @@
+const { shell } = require('electron');
+const { spawn } = require('node:child_process');
+
+const {
+  KEY_TABLE,
+  MEDIA_VK,
+  MODIFIER_MAC,
+  MODIFIER_VK,
+  MODIFIER_X,
+} = require('./keymap');
+
+const MODIFIER_ORDER = ['ctrl', 'shift', 'alt', 'meta'];
+const URL_PATTERN = /^https?:\/\//i;
+
+// Runs inside one persistent PowerShell child. Each stdin line is a
+// space-separated press sequence of "<vk>" or "<vk>e" (extended) tokens;
+// keys go down in order and up in reverse, like a human chord.
+const WINDOWS_KEY_SCRIPT = `
+$definition = '[DllImport("user32.dll")] public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, System.UIntPtr dwExtraInfo);'
+Add-Type -Namespace Stream32 -Name Keys -MemberDefinition $definition
+while ($line = [Console]::In.ReadLine()) {
+  $tokens = $line.Trim().Split(' ') | Where-Object { $_ }
+  $codes = @()
+  foreach ($token in $tokens) {
+    $extended = $token.EndsWith('e')
+    $codes += ,@([byte]$token.TrimEnd('e'), $extended)
+  }
+  foreach ($code in $codes) {
+    [Stream32.Keys]::keybd_event($code[0], 0, $(if ($code[1]) { 1 } else { 0 }), [UIntPtr]::Zero)
+  }
+  [array]::Reverse($codes)
+  foreach ($code in $codes) {
+    [Stream32.Keys]::keybd_event($code[0], 0, $(if ($code[1]) { 3 } else { 2 }), [UIntPtr]::Zero)
+  }
+}
+`;
+
+function vkToken(vk, extended) {
+  return `${vk}${extended ? 'e' : ''}`;
+}
+
+function hotkeyModifiers(action) {
+  return MODIFIER_ORDER.filter((modifier) => action[modifier]);
+}
+
+// Windows: one stdin line for the persistent key-injection child.
+function windowsKeyLine(action) {
+  if (action.type === 'media') {
+    return vkToken(MEDIA_VK[action.command], true);
+  }
+
+  const key = KEY_TABLE[action.key];
+  const tokens = hotkeyModifiers(action).map((modifier) =>
+    vkToken(MODIFIER_VK[modifier], false),
+  );
+
+  tokens.push(vkToken(key.vk, Boolean(key.ext)));
+  return tokens.join(' ');
+}
+
+// ponytail: Linux media/hotkeys shell out to playerctl/pactl/xdotool and are
+// best-effort; xdotool needs X11 (no Wayland) and missing tools surface as a
+// spawn error in the deck status.
+function linuxInvocation(action) {
+  if (action.type === 'media') {
+    switch (action.command) {
+      case 'mute':
+        return { command: 'pactl', args: ['set-sink-mute', '@DEFAULT_SINK@', 'toggle'] };
+      case 'volume-up':
+        return { command: 'pactl', args: ['set-sink-volume', '@DEFAULT_SINK@', '+5%'] };
+      case 'volume-down':
+        return { command: 'pactl', args: ['set-sink-volume', '@DEFAULT_SINK@', '-5%'] };
+      case 'play-pause':
+      case 'next':
+      case 'previous':
+        return { command: 'playerctl', args: [action.command] };
+      default:
+        throw new TypeError(`Unknown media command: ${action.command}`);
+    }
+  }
+
+  const combo = [
+    ...hotkeyModifiers(action).map((modifier) => MODIFIER_X[modifier]),
+    KEY_TABLE[action.key].x,
+  ].join('+');
+  return { command: 'xdotool', args: ['key', '--clearmodifiers', combo] };
+}
+
+// ponytail: macOS transport keys have no scriptable system control without a
+// helper app, so only volume works; hotkeys need the Accessibility permission.
+function macInvocation(action) {
+  if (action.type === 'media') {
+    switch (action.command) {
+      case 'mute':
+        return {
+          command: 'osascript',
+          args: [
+            '-e',
+            'set volume output muted (not (output muted of (get volume settings)))',
+          ],
+        };
+      case 'volume-up':
+      case 'volume-down': {
+        const delta = action.command === 'volume-up' ? 6 : -6;
+        return {
+          command: 'osascript',
+          args: [
+            '-e',
+            `set volume output volume ((output volume of (get volume settings)) + ${delta})`,
+          ],
+        };
+      }
+      case 'play-pause':
+      case 'next':
+      case 'previous':
+        throw new Error('Media transport keys are not supported on macOS.');
+      default:
+        throw new TypeError(`Unknown media command: ${action.command}`);
+    }
+  }
+
+  const key = KEY_TABLE[action.key];
+  const modifiers = hotkeyModifiers(action).map(
+    (modifier) => MODIFIER_MAC[modifier],
+  );
+  const using = modifiers.length ? ` using {${modifiers.join(', ')}}` : '';
+  const stroke = key.char
+    ? `keystroke "${key.char}"${using}`
+    : `key code ${key.mac}${using}`;
+  return {
+    command: 'osascript',
+    args: ['-e', `tell application "System Events" to ${stroke}`],
+  };
+}
+
+function createActionRunner({ platform = process.platform } = {}) {
+  let keyChild = null;
+
+  function windowsKeyChild() {
+    if (keyChild && keyChild.exitCode === null && !keyChild.killed) {
+      return keyChild;
+    }
+
+    keyChild = spawn(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', WINDOWS_KEY_SCRIPT],
+      { stdio: ['pipe', 'ignore', 'ignore'], windowsHide: true },
+    );
+    keyChild.on('error', () => {
+      keyChild = null;
+    });
+    keyChild.on('exit', () => {
+      keyChild = null;
+    });
+    return keyChild;
+  }
+
+  function runDetached({ command, args }) {
+    const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+    child.on('error', () => {
+      // Missing optional tools (playerctl, xdotool) must not crash the app.
+    });
+    child.unref();
+  }
+
+  function runKeys(action) {
+    if (platform === 'win32') {
+      windowsKeyChild().stdin.write(`${windowsKeyLine(action)}\n`);
+      return;
+    }
+
+    runDetached(platform === 'darwin' ? macInvocation(action) : linuxInvocation(action));
+  }
+
+  async function runAction(action) {
+    switch (action?.type) {
+      case 'media':
+      case 'hotkey':
+        runKeys(action);
+        return;
+      case 'url':
+        if (typeof action.url !== 'string' || !URL_PATTERN.test(action.url)) {
+          throw new TypeError('Action URL must use http or https.');
+        }
+
+        await shell.openExternal(action.url);
+        return;
+      case 'launch':
+        if (typeof action.command !== 'string' || !action.command.trim()) {
+          throw new TypeError('Launch command is required.');
+        }
+
+        {
+          const child = spawn(action.command, {
+            detached: true,
+            shell: true,
+            stdio: 'ignore',
+          });
+          child.on('error', () => {
+            // The command line is user-authored; failures are theirs to fix.
+          });
+          child.unref();
+        }
+
+        return;
+      case 'page':
+        // Page switches are resolved renderer-side against the device session.
+        throw new TypeError('Page actions never reach the main process.');
+      default:
+        throw new TypeError(`Unknown action type: ${action?.type}`);
+    }
+  }
+
+  function dispose() {
+    keyChild?.kill();
+    keyChild = null;
+  }
+
+  return { dispose, runAction };
+}
+
+module.exports = {
+  createActionRunner,
+  linuxInvocation,
+  macInvocation,
+  windowsKeyLine,
+};

--- a/desktop/src/boards.js
+++ b/desktop/src/boards.js
@@ -166,6 +166,39 @@ function validateStringList(values, field, maximumItems) {
   );
 }
 
+const DEFAULT_DECK_LIMITS = { maxCols: 5, maxPages: 8, maxRows: 5 };
+
+function validateDeckLimits(deck, boardId) {
+  if (deck === undefined) {
+    return { ...DEFAULT_DECK_LIMITS };
+  }
+
+  if (!deck || typeof deck !== 'object' || Array.isArray(deck)) {
+    throw new TypeError(`${boardId} deck limits are invalid.`);
+  }
+
+  return {
+    maxCols: requireInteger(
+      deck.maxCols ?? DEFAULT_DECK_LIMITS.maxCols,
+      `${boardId} deck maxCols`,
+      1,
+      DEFAULT_DECK_LIMITS.maxCols,
+    ),
+    maxPages: requireInteger(
+      deck.maxPages ?? DEFAULT_DECK_LIMITS.maxPages,
+      `${boardId} deck maxPages`,
+      1,
+      DEFAULT_DECK_LIMITS.maxPages,
+    ),
+    maxRows: requireInteger(
+      deck.maxRows ?? DEFAULT_DECK_LIMITS.maxRows,
+      `${boardId} deck maxRows`,
+      1,
+      DEFAULT_DECK_LIMITS.maxRows,
+    ),
+  };
+}
+
 function validateImages(images, boardId) {
   if (!Array.isArray(images) || images.length === 0 || images.length > 8) {
     throw new TypeError(`${boardId} must define 1-8 firmware images.`);
@@ -286,6 +319,7 @@ function validateBoard(board, appVersion) {
       `${id} capabilities`,
       16,
     ),
+    deck: validateDeckLimits(board.deck, id),
     recoveryInstructions: validateStringList(
       board.recoveryInstructions,
       `${id} recoveryInstructions`,
@@ -441,6 +475,7 @@ function publicBoard(board) {
     compatible: board.compatible,
     usbFilters: board.usbFilters,
     capabilities: board.capabilities,
+    deck: board.deck,
     recoveryInstructions: board.recoveryInstructions,
     firmwareVersion: board.firmware.version,
   };

--- a/desktop/src/deck-store.js
+++ b/desktop/src/deck-store.js
@@ -1,0 +1,329 @@
+const { app } = require('electron');
+const path = require('node:path');
+
+const { HOTKEY_KEY_NAMES, MEDIA_COMMANDS } = require('./keymap');
+const { readSettings, writeSettings } = require('./settings');
+
+const DECKS_FILENAME = 'decks.json';
+const EXPORT_SCHEMA_VERSION = 1;
+const MAX_DEVICES = 32;
+const MAX_PAGES = 8;
+const MAX_ROWS = 5;
+const MAX_COLS = 5;
+const MAX_LABEL_LENGTH = 32;
+const MAX_NAME_LENGTH = 60;
+const MAX_URL_LENGTH = 2048;
+const MAX_COMMAND_LENGTH = 1024;
+const MAX_IMAGE_DATA_URL_LENGTH = 256 * 1024;
+const MAX_IMPORT_BYTES = 16 * 1024 * 1024;
+
+const DEVICE_ID_PATTERN = /^[a-f0-9]{12}$/;
+const BOARD_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
+const COLOR_PATTERN = /^#[0-9a-f]{6}$/;
+const IMAGE_DATA_URL_PATTERN =
+  /^data:image\/(?:png|jpeg|webp);base64,[A-Za-z0-9+/]+={0,2}$/;
+const KEY_PX_GRID_PATTERN = /^[1-5]x[1-5]$/;
+const URL_PATTERN = /^https?:\/\//i;
+
+function getDecksPath() {
+  return path.join(app.getPath('userData'), DECKS_FILENAME);
+}
+
+function requireInteger(value, field, minimum, maximum) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new TypeError(`${field} is outside the supported range.`);
+  }
+
+  return value;
+}
+
+function optionalString(value, field, maximumLength, pattern = null) {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maximumLength ||
+    (pattern && !pattern.test(value))
+  ) {
+    throw new TypeError(`${field} is invalid.`);
+  }
+
+  return value;
+}
+
+function validateAction(action, pageCount) {
+  if (!action || typeof action !== 'object' || Array.isArray(action)) {
+    throw new TypeError('Key action must be an object.');
+  }
+
+  switch (action.type) {
+    case 'media':
+      if (!MEDIA_COMMANDS.has(action.command)) {
+        throw new TypeError('Unknown media command.');
+      }
+
+      return { type: 'media', command: action.command };
+    case 'url': {
+      const url = optionalString(action.url, 'Action URL', MAX_URL_LENGTH);
+
+      if (!url || !URL_PATTERN.test(url)) {
+        throw new TypeError('Action URL must use http or https.');
+      }
+
+      return { type: 'url', url };
+    }
+    case 'launch': {
+      const command = optionalString(
+        action.command,
+        'Launch command',
+        MAX_COMMAND_LENGTH,
+      );
+
+      if (!command) {
+        throw new TypeError('Launch command is required.');
+      }
+
+      return { type: 'launch', command };
+    }
+    case 'hotkey': {
+      if (!HOTKEY_KEY_NAMES.has(action.key)) {
+        throw new TypeError('Unknown hotkey key name.');
+      }
+
+      return {
+        type: 'hotkey',
+        key: action.key,
+        alt: Boolean(action.alt),
+        ctrl: Boolean(action.ctrl),
+        meta: Boolean(action.meta),
+        shift: Boolean(action.shift),
+      };
+    }
+    case 'page':
+      return {
+        type: 'page',
+        page: requireInteger(action.page, 'Action page', 0, pageCount - 1),
+      };
+    default:
+      throw new TypeError(`Unknown action type: ${action?.type}`);
+  }
+}
+
+function validateKey(key, keyCount, pageCount) {
+  if (!key || typeof key !== 'object' || Array.isArray(key)) {
+    throw new TypeError('Deck key must be an object.');
+  }
+
+  const validated = {
+    index: requireInteger(key.index, 'Key index', 0, keyCount - 1),
+  };
+  const label = optionalString(key.label, 'Key label', MAX_LABEL_LENGTH);
+  const color = optionalString(key.color, 'Key color', 7, COLOR_PATTERN);
+
+  if (label !== undefined) {
+    validated.label = label;
+  }
+
+  if (color !== undefined) {
+    validated.color = color;
+  }
+
+  if (key.image !== undefined) {
+    validated.image = optionalString(
+      key.image,
+      'Key image',
+      MAX_IMAGE_DATA_URL_LENGTH,
+      IMAGE_DATA_URL_PATTERN,
+    );
+  }
+
+  if (key.action !== undefined) {
+    validated.action = validateAction(key.action, pageCount);
+  }
+
+  return validated;
+}
+
+function validatePage(page, pageCount) {
+  if (!page || typeof page !== 'object' || Array.isArray(page)) {
+    throw new TypeError('Deck page must be an object.');
+  }
+
+  const rows = requireInteger(page.rows, 'Page rows', 1, MAX_ROWS);
+  const cols = requireInteger(page.cols, 'Page cols', 1, MAX_COLS);
+  const keyCount = rows * cols;
+
+  if (!Array.isArray(page.keys) || page.keys.length > keyCount) {
+    throw new TypeError('Page keys are invalid.');
+  }
+
+  const seen = new Set();
+  const keys = page.keys.map((key) => {
+    const validated = validateKey(key, keyCount, pageCount);
+
+    if (seen.has(validated.index)) {
+      throw new TypeError('Page keys must have unique indexes.');
+    }
+
+    seen.add(validated.index);
+    return validated;
+  });
+
+  return {
+    name: optionalString(page.name, 'Page name', MAX_NAME_LENGTH) || 'Page',
+    rows,
+    cols,
+    keys,
+  };
+}
+
+function validateProfile(profile) {
+  if (!profile || typeof profile !== 'object' || Array.isArray(profile)) {
+    throw new TypeError('Deck profile must be an object.');
+  }
+
+  if (
+    typeof profile.boardId !== 'string' ||
+    !BOARD_ID_PATTERN.test(profile.boardId)
+  ) {
+    throw new TypeError('Deck profile board id is invalid.');
+  }
+
+  if (
+    !Array.isArray(profile.pages) ||
+    profile.pages.length === 0 ||
+    profile.pages.length > MAX_PAGES
+  ) {
+    throw new TypeError(`Deck profiles need 1-${MAX_PAGES} pages.`);
+  }
+
+  const pageCount = profile.pages.length;
+  const validated = {
+    name: optionalString(profile.name, 'Device name', MAX_NAME_LENGTH) ||
+      'Stream32 deck',
+    boardId: profile.boardId,
+    activePage: requireInteger(
+      profile.activePage ?? 0,
+      'Active page',
+      0,
+      pageCount - 1,
+    ),
+    pages: profile.pages.map((page) => validatePage(page, pageCount)),
+    keyPx: {},
+  };
+
+  if (profile.keyPx !== undefined) {
+    if (
+      !profile.keyPx ||
+      typeof profile.keyPx !== 'object' ||
+      Array.isArray(profile.keyPx)
+    ) {
+      throw new TypeError('Deck keyPx cache is invalid.');
+    }
+
+    for (const [grid, px] of Object.entries(profile.keyPx)) {
+      if (!KEY_PX_GRID_PATTERN.test(grid)) {
+        throw new TypeError('Deck keyPx grid key is invalid.');
+      }
+
+      validated.keyPx[grid] = requireInteger(px, 'Deck keyPx', 16, 512);
+    }
+  }
+
+  return validated;
+}
+
+function createDefaultProfile(boardId) {
+  return validateProfile({
+    boardId,
+    activePage: 0,
+    pages: [{ name: 'Main', rows: 3, cols: 3, keys: [] }],
+  });
+}
+
+function readDecks(decksPath) {
+  const raw = readSettings(decksPath);
+  const devices = {};
+
+  if (raw.devices && typeof raw.devices === 'object') {
+    for (const [deviceId, profile] of Object.entries(raw.devices)) {
+      if (!DEVICE_ID_PATTERN.test(deviceId)) {
+        continue;
+      }
+
+      try {
+        devices[deviceId] = validateProfile(profile);
+      } catch {
+        // A single corrupt profile must not take down the whole registry.
+      }
+    }
+  }
+
+  return { devices };
+}
+
+function saveDeviceProfile(deviceId, profile, decksPath) {
+  if (!DEVICE_ID_PATTERN.test(deviceId)) {
+    throw new TypeError('Device id is invalid.');
+  }
+
+  const validated = validateProfile(profile);
+  const registry = readDecks(decksPath);
+
+  if (
+    !registry.devices[deviceId] &&
+    Object.keys(registry.devices).length >= MAX_DEVICES
+  ) {
+    throw new Error(`At most ${MAX_DEVICES} devices are supported.`);
+  }
+
+  registry.devices[deviceId] = validated;
+  writeSettings(registry, decksPath);
+  return validated;
+}
+
+function exportProfile(profile) {
+  return `${JSON.stringify(
+    {
+      stream32Deck: EXPORT_SCHEMA_VERSION,
+      profile: validateProfile(profile),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function importProfile(text) {
+  if (typeof text !== 'string' || text.length > MAX_IMPORT_BYTES) {
+    throw new TypeError('Deck profile file is too large or unreadable.');
+  }
+
+  let parsed;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    throw new TypeError('Deck profile file is not valid JSON.');
+  }
+
+  if (!parsed || parsed.stream32Deck !== EXPORT_SCHEMA_VERSION) {
+    throw new TypeError('Deck profile file has an unsupported format.');
+  }
+
+  return validateProfile(parsed.profile);
+}
+
+module.exports = {
+  MAX_DEVICES,
+  MAX_IMPORT_BYTES,
+  createDefaultProfile,
+  exportProfile,
+  getDecksPath,
+  importProfile,
+  readDecks,
+  saveDeviceProfile,
+  validateProfile,
+};

--- a/desktop/src/keymap.js
+++ b/desktop/src/keymap.js
@@ -1,0 +1,128 @@
+// Canonical hotkey names shared by the renderer capture field, the deck
+// store validator, and the per-OS action executor. Values: Windows virtual-key
+// codes (ext = extended-key flag), X11 keysyms for xdotool, and macOS key
+// codes for keys AppleScript cannot type as characters.
+
+const LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+const DIGITS = '0123456789';
+
+const SPECIAL_KEYS = {
+  Backquote: { vk: 0xc0, x: 'grave', mac: 50 },
+  Backslash: { vk: 0xdc, x: 'backslash', mac: 42 },
+  Backspace: { vk: 0x08, x: 'BackSpace', mac: 51 },
+  BracketLeft: { vk: 0xdb, x: 'bracketleft', mac: 33 },
+  BracketRight: { vk: 0xdd, x: 'bracketright', mac: 30 },
+  Comma: { vk: 0xbc, x: 'comma', mac: 43 },
+  Delete: { vk: 0x2e, ext: true, x: 'Delete', mac: 117 },
+  Down: { vk: 0x28, ext: true, x: 'Down', mac: 125 },
+  End: { vk: 0x23, ext: true, x: 'End', mac: 119 },
+  Enter: { vk: 0x0d, x: 'Return', mac: 36 },
+  Equal: { vk: 0xbb, x: 'equal', mac: 24 },
+  Escape: { vk: 0x1b, x: 'Escape', mac: 53 },
+  Home: { vk: 0x24, ext: true, x: 'Home', mac: 115 },
+  Left: { vk: 0x25, ext: true, x: 'Left', mac: 123 },
+  Minus: { vk: 0xbd, x: 'minus', mac: 27 },
+  PageDown: { vk: 0x22, ext: true, x: 'Next', mac: 121 },
+  PageUp: { vk: 0x21, ext: true, x: 'Prior', mac: 116 },
+  Period: { vk: 0xbe, x: 'period', mac: 47 },
+  Quote: { vk: 0xde, x: 'apostrophe', mac: 39 },
+  Right: { vk: 0x27, ext: true, x: 'Right', mac: 124 },
+  Semicolon: { vk: 0xba, x: 'semicolon', mac: 41 },
+  Slash: { vk: 0xbf, x: 'slash', mac: 44 },
+  Space: { vk: 0x20, x: 'space', mac: 49 },
+  Tab: { vk: 0x09, x: 'Tab', mac: 48 },
+  Up: { vk: 0x26, ext: true, x: 'Up', mac: 126 },
+};
+
+const MAC_FUNCTION_KEYCODES = {
+  F1: 122,
+  F2: 120,
+  F3: 99,
+  F4: 118,
+  F5: 96,
+  F6: 97,
+  F7: 98,
+  F8: 100,
+  F9: 101,
+  F10: 109,
+  F11: 103,
+  F12: 111,
+};
+
+const KEY_TABLE = {};
+
+for (const letter of LETTERS) {
+  KEY_TABLE[letter] = {
+    vk: 0x41 + LETTERS.indexOf(letter),
+    x: letter.toLowerCase(),
+    char: letter.toLowerCase(),
+  };
+}
+
+for (const digit of DIGITS) {
+  KEY_TABLE[digit] = { vk: 0x30 + DIGITS.indexOf(digit), x: digit, char: digit };
+}
+
+for (let index = 1; index <= 12; index++) {
+  KEY_TABLE[`F${index}`] = {
+    vk: 0x70 + index - 1,
+    x: `F${index}`,
+    mac: MAC_FUNCTION_KEYCODES[`F${index}`],
+  };
+}
+
+Object.assign(KEY_TABLE, SPECIAL_KEYS);
+
+const HOTKEY_KEY_NAMES = new Set(Object.keys(KEY_TABLE));
+
+const MODIFIER_VK = { alt: 0x12, ctrl: 0x11, meta: 0x5b, shift: 0x10 };
+const MODIFIER_X = { alt: 'alt', ctrl: 'ctrl', meta: 'super', shift: 'shift' };
+const MODIFIER_MAC = {
+  alt: 'option down',
+  ctrl: 'control down',
+  meta: 'command down',
+  shift: 'shift down',
+};
+
+const MEDIA_VK = {
+  mute: 0xad,
+  next: 0xb0,
+  'play-pause': 0xb3,
+  previous: 0xb1,
+  'volume-down': 0xae,
+  'volume-up': 0xaf,
+};
+
+const MEDIA_COMMANDS = new Set(Object.keys(MEDIA_VK));
+
+// KeyboardEvent.code → canonical key name for the renderer capture field.
+function canonicalKeyFromCode(code) {
+  if (/^Key[A-Z]$/.test(code)) {
+    return code.slice(3);
+  }
+
+  if (/^Digit[0-9]$/.test(code)) {
+    return code.slice(5);
+  }
+
+  if (/^F([1-9]|1[0-2])$/.test(code)) {
+    return code;
+  }
+
+  if (/^Arrow(Up|Down|Left|Right)$/.test(code)) {
+    return code.slice(5);
+  }
+
+  return HOTKEY_KEY_NAMES.has(code) ? code : null;
+}
+
+module.exports = {
+  HOTKEY_KEY_NAMES,
+  KEY_TABLE,
+  MEDIA_COMMANDS,
+  MEDIA_VK,
+  MODIFIER_MAC,
+  MODIFIER_VK,
+  MODIFIER_X,
+  canonicalKeyFromCode,
+};

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -1,16 +1,27 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, dialog, ipcMain } = require('electron');
+const { readFile, writeFile } = require('node:fs/promises');
 const path = require('node:path');
 
+const { createActionRunner } = require('./actions');
 const {
   getAutoStartEnabled,
   setAutoStartEnabled,
   wasStartedHidden,
 } = require('./autostart');
 const { createDefaultBoardService } = require('./boards');
+const {
+  MAX_IMPORT_BYTES,
+  exportProfile,
+  getDecksPath,
+  importProfile,
+  readDecks,
+  saveDeviceProfile,
+} = require('./deck-store');
 const { configureSerialAccess } = require('./serial');
 const { createTray } = require('./tray');
 const { createUpdater } = require('./updater');
 
+const actionRunner = createActionRunner();
 let boardService = null;
 let isQuitting = false;
 let mainWindow = null;
@@ -117,6 +128,58 @@ function registerIpcHandlers() {
 
     return boardService.getFirmware(boardId);
   });
+  ipcMain.handle('deck:list', () => readDecks(getDecksPath()));
+  ipcMain.handle('deck:save', (_event, deviceId, profile) => {
+    if (typeof deviceId !== 'string') {
+      throw new TypeError('Device id must be a string.');
+    }
+
+    return saveDeviceProfile(deviceId, profile, getDecksPath());
+  });
+  ipcMain.handle('deck:export', async (_event, deviceId) => {
+    if (typeof deviceId !== 'string') {
+      throw new TypeError('Device id must be a string.');
+    }
+
+    const profile = readDecks(getDecksPath()).devices[deviceId];
+
+    if (!profile) {
+      throw new Error('This device has no saved deck profile.');
+    }
+
+    const { canceled, filePath } = await dialog.showSaveDialog(mainWindow, {
+      defaultPath: `stream32-deck-${deviceId}.json`,
+      filters: [{ name: 'Stream32 deck profile', extensions: ['json'] }],
+    });
+
+    if (canceled || !filePath) {
+      return { saved: false };
+    }
+
+    await writeFile(filePath, exportProfile(profile), 'utf8');
+    return { saved: true };
+  });
+  ipcMain.handle('deck:import', async () => {
+    const { canceled, filePaths } = await dialog.showOpenDialog(mainWindow, {
+      filters: [{ name: 'Stream32 deck profile', extensions: ['json'] }],
+      properties: ['openFile'],
+    });
+
+    if (canceled || filePaths.length === 0) {
+      return { profile: null };
+    }
+
+    const text = await readFile(filePaths[0], 'utf8');
+
+    if (text.length > MAX_IMPORT_BYTES) {
+      throw new Error('Deck profile file is too large.');
+    }
+
+    return { profile: importProfile(text) };
+  });
+  ipcMain.handle('action:run', (_event, action) =>
+    actionRunner.runAction(action),
+  );
 }
 
 function reportBackgroundError(error) {
@@ -177,6 +240,7 @@ if (!hasSingleInstanceLock) {
 
 app.on('before-quit', () => {
   isQuitting = true;
+  actionRunner.dispose();
 });
 
 app.on('window-all-closed', () => {

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -102,6 +102,7 @@ function registerIpcHandlers() {
     return actualState;
   });
   ipcMain.handle('updater:check', () => updaterController?.checkForUpdates());
+  ipcMain.handle('updater:install', installUpdate);
   ipcMain.handle('boards:list', (_event, force = false) => {
     if (typeof force !== 'boolean') {
       throw new TypeError('Board refresh flag must be a boolean.');

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -2,11 +2,17 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('stream32', {
   checkForUpdates: () => ipcRenderer.invoke('updater:check'),
+  exportDeck: (deviceId) => ipcRenderer.invoke('deck:export', deviceId),
   getBoardFirmware: (boardId) =>
     ipcRenderer.invoke('boards:firmware', boardId),
   getAutoStart: () => ipcRenderer.invoke('autostart:get'),
+  importDeck: () => ipcRenderer.invoke('deck:import'),
   installUpdate: () => ipcRenderer.invoke('updater:install'),
   listBoards: (force = false) => ipcRenderer.invoke('boards:list', force),
+  listDecks: () => ipcRenderer.invoke('deck:list'),
+  runAction: (action) => ipcRenderer.invoke('action:run', action),
+  saveDeck: (deviceId, profile) =>
+    ipcRenderer.invoke('deck:save', deviceId, profile),
   onBoardDownloadProgress(callback) {
     if (typeof callback !== 'function') {
       throw new TypeError('Board download listener must be a function.');

--- a/desktop/src/preload.js
+++ b/desktop/src/preload.js
@@ -5,6 +5,7 @@ contextBridge.exposeInMainWorld('stream32', {
   getBoardFirmware: (boardId) =>
     ipcRenderer.invoke('boards:firmware', boardId),
   getAutoStart: () => ipcRenderer.invoke('autostart:get'),
+  installUpdate: () => ipcRenderer.invoke('updater:install'),
   listBoards: (force = false) => ipcRenderer.invoke('boards:list', force),
   onBoardDownloadProgress(callback) {
     if (typeof callback !== 'function') {

--- a/desktop/src/renderer/deck.js
+++ b/desktop/src/renderer/deck.js
@@ -1,0 +1,1143 @@
+const { canonicalKeyFromCode } = require('../keymap');
+const {
+  MAX_DECK_COLS,
+  MAX_DECK_PAGES,
+  MAX_DECK_ROWS,
+  MAX_KEY_LABEL_LENGTH,
+  crc32,
+  encodeImageChunks,
+  encodeLayoutMessage,
+  encodePageMessage,
+  validateImageAck,
+  validateLayoutAck,
+  validatePageMessage,
+  validatePressMessage,
+} = require('./protocol');
+
+const ACK_TIMEOUT_MS = 5000;
+const SYNC_DEBOUNCE_MS = 600;
+const STORED_IMAGE_PIXELS = 192;
+const DEFAULT_KEY_COLOR = '#172630';
+const MEDIA_LABELS = {
+  mute: 'Mute',
+  next: 'Next track',
+  'play-pause': 'Play / Pause',
+  previous: 'Previous track',
+  'volume-down': 'Volume down',
+  'volume-up': 'Volume up',
+};
+
+function deviceLabel(deviceId, profile) {
+  return `${profile.name} · ${deviceId.slice(-4)}`;
+}
+
+function gridKey(page) {
+  return `${page.rows}x${page.cols}`;
+}
+
+async function loadImage(dataUrl) {
+  const image = new Image();
+  image.src = dataUrl;
+  await image.decode();
+  return image;
+}
+
+function toRgb565(imageData) {
+  const { data } = imageData;
+  const pixels = new Uint8Array((data.length / 4) * 2);
+
+  for (let source = 0, target = 0; source < data.length; source += 4, target += 2) {
+    const value =
+      ((data[source] >> 3) << 11) |
+      ((data[source + 1] >> 2) << 5) |
+      (data[source + 2] >> 3);
+    pixels[target] = value & 0xff;
+    pixels[target + 1] = value >> 8;
+  }
+
+  return pixels;
+}
+
+class DeckController {
+  constructor({ api, document }) {
+    this.api = api;
+    this.document = document;
+    this.devices = {};
+    this.boardLimits = new Map();
+    this.sessions = new Map();
+    this.pending = new Map();
+    this.syncTimers = new Map();
+    this.syncRunning = new Map();
+    this.selectedDeviceId = null;
+    this.selectedPage = 0;
+    this.selectedKey = null;
+    // Keeps the chosen action type's field visible while its value is
+    // still empty (an empty URL/hotkey is not a storable action yet).
+    this.pendingActionType = null;
+
+    this.card = document.querySelector('#deck-step');
+    this.deviceSelect = document.querySelector('#deck-device');
+    this.deviceStatus = document.querySelector('#deck-device-status');
+    this.deviceName = document.querySelector('#deck-device-name');
+    this.exportButton = document.querySelector('#deck-export');
+    this.importButton = document.querySelector('#deck-import');
+    this.syncStatus = document.querySelector('#deck-sync-status');
+    this.pageTabs = document.querySelector('#deck-page-tabs');
+    this.addPageButton = document.querySelector('#deck-add-page');
+    this.removePageButton = document.querySelector('#deck-remove-page');
+    this.pageName = document.querySelector('#deck-page-name');
+    this.rowsSelect = document.querySelector('#deck-rows');
+    this.colsSelect = document.querySelector('#deck-cols');
+    this.grid = document.querySelector('#deck-grid');
+    this.emptyState = document.querySelector('#deck-empty');
+    this.editorPanel = document.querySelector('#deck-editor');
+    this.keyEditor = document.querySelector('#deck-key-editor');
+    this.keyTitle = document.querySelector('#deck-key-title');
+    this.keyLabel = document.querySelector('#deck-key-label');
+    this.keyColor = document.querySelector('#deck-key-color');
+    this.keyImage = document.querySelector('#deck-key-image');
+    this.keyImageClear = document.querySelector('#deck-key-image-clear');
+    this.actionType = document.querySelector('#deck-action-type');
+    this.actionMedia = document.querySelector('#deck-action-media');
+    this.actionUrl = document.querySelector('#deck-action-url');
+    this.actionLaunch = document.querySelector('#deck-action-launch');
+    this.actionHotkey = document.querySelector('#deck-action-hotkey');
+    this.actionPage = document.querySelector('#deck-action-page');
+    this.keyTest = document.querySelector('#deck-key-test');
+    this.keyClear = document.querySelector('#deck-key-clear');
+
+    this.hotkeyValue = null;
+  }
+
+  async initialize() {
+    this.populateStaticControls();
+    this.bindEvents();
+
+    try {
+      const registry = await this.api.listDecks();
+      this.devices = registry.devices;
+    } catch (error) {
+      this.setSyncStatus(`Could not load deck profiles: ${error.message}`, 'error');
+    }
+
+    this.selectedDeviceId = Object.keys(this.devices)[0] || null;
+    this.renderAll();
+  }
+
+  setBoards(boards) {
+    this.boardLimits = new Map(
+      boards.map((board) => [board.id, board.deck]),
+    );
+    this.renderAll();
+  }
+
+  populateStaticControls() {
+    for (const [value, label] of Object.entries(MEDIA_LABELS)) {
+      const option = this.document.createElement('option');
+      option.value = value;
+      option.textContent = label;
+      this.actionMedia.append(option);
+    }
+
+    for (let size = 1; size <= MAX_DECK_ROWS; size++) {
+      const option = this.document.createElement('option');
+      option.value = String(size);
+      option.textContent = String(size);
+      this.rowsSelect.append(option);
+    }
+
+    for (let size = 1; size <= MAX_DECK_COLS; size++) {
+      const option = this.document.createElement('option');
+      option.value = String(size);
+      option.textContent = String(size);
+      this.colsSelect.append(option);
+    }
+  }
+
+  bindEvents() {
+    this.deviceSelect.addEventListener('change', () => {
+      this.selectedDeviceId = this.deviceSelect.value || null;
+      this.selectedPage = this.selectedProfile()?.activePage ?? 0;
+      this.selectedKey = null;
+      this.pendingActionType = null;
+      this.renderAll();
+    });
+    this.deviceName.addEventListener('change', () => {
+      this.updateProfile((profile) => {
+        profile.name = this.deviceName.value.trim() || 'Stream32 deck';
+      }, false);
+      this.renderDevicePicker();
+    });
+    this.exportButton.addEventListener('click', async () => {
+      try {
+        const result = await this.api.exportDeck(this.selectedDeviceId);
+        this.setSyncStatus(
+          result.saved ? 'Deck profile exported.' : 'Export cancelled.',
+          'ready',
+        );
+      } catch (error) {
+        this.setSyncStatus(`Export failed: ${error.message}`, 'error');
+      }
+    });
+    this.importButton.addEventListener('click', async () => {
+      await this.importProfile();
+    });
+    this.addPageButton.addEventListener('click', () => {
+      this.updateProfile((profile) => {
+        profile.pages.push({
+          name: `Page ${profile.pages.length + 1}`,
+          rows: 3,
+          cols: 3,
+          keys: [],
+        });
+        this.selectedPage = profile.pages.length - 1;
+        this.selectedKey = null;
+      });
+    });
+    this.removePageButton.addEventListener('click', () => {
+      this.updateProfile((profile) => {
+        if (profile.pages.length <= 1) {
+          return;
+        }
+
+        const removed = this.selectedPage;
+        profile.pages.splice(removed, 1);
+        this.selectedPage = Math.min(
+          this.selectedPage,
+          profile.pages.length - 1,
+        );
+        this.selectedKey = null;
+        profile.activePage = Math.min(
+          profile.activePage,
+          profile.pages.length - 1,
+        );
+
+        // Page actions and goPage targets pointing at or past the removed
+        // page are remapped so the profile stays valid.
+        for (const page of profile.pages) {
+          for (const key of page.keys) {
+            if (key.action?.type !== 'page') {
+              continue;
+            }
+
+            if (key.action.page === removed) {
+              delete key.action;
+            } else if (key.action?.page > removed) {
+              key.action.page -= 1;
+            }
+          }
+        }
+      });
+    });
+    this.pageName.addEventListener('change', () => {
+      this.updateProfile((page) => {
+        page.name = this.pageName.value.trim() || 'Page';
+      }, true, true);
+    });
+    this.rowsSelect.addEventListener('change', () => {
+      this.resizeSelectedPage();
+    });
+    this.colsSelect.addEventListener('change', () => {
+      this.resizeSelectedPage();
+    });
+    this.keyLabel.addEventListener('change', () => {
+      this.updateSelectedKey((key) => {
+        const label = this.keyLabel.value.trim().slice(0, MAX_KEY_LABEL_LENGTH);
+
+        if (label) {
+          key.label = label;
+        } else {
+          delete key.label;
+        }
+      });
+    });
+    this.keyColor.addEventListener('change', () => {
+      this.updateSelectedKey((key) => {
+        key.color = this.keyColor.value;
+      });
+    });
+    this.keyImage.addEventListener('change', async () => {
+      const file = this.keyImage.files?.[0];
+      this.keyImage.value = '';
+
+      if (!file) {
+        return;
+      }
+
+      try {
+        const dataUrl = await this.readImageFile(file);
+        this.updateSelectedKey((key) => {
+          key.image = dataUrl;
+        });
+      } catch (error) {
+        this.setSyncStatus(`Could not read image: ${error.message}`, 'error');
+      }
+    });
+    this.keyImageClear.addEventListener('click', () => {
+      this.updateSelectedKey((key) => {
+        delete key.image;
+      });
+    });
+    this.actionType.addEventListener('change', () => {
+      this.applyActionFromEditor();
+    });
+    this.actionMedia.addEventListener('change', () => {
+      this.applyActionFromEditor();
+    });
+    this.actionUrl.addEventListener('change', () => {
+      this.applyActionFromEditor();
+    });
+    this.actionLaunch.addEventListener('change', () => {
+      this.applyActionFromEditor();
+    });
+    this.actionPage.addEventListener('change', () => {
+      this.applyActionFromEditor();
+    });
+    this.actionHotkey.addEventListener('keydown', (event) => {
+      event.preventDefault();
+
+      const key = canonicalKeyFromCode(event.code);
+
+      if (!key) {
+        return;
+      }
+
+      this.hotkeyValue = {
+        key,
+        alt: event.altKey,
+        ctrl: event.ctrlKey,
+        meta: event.metaKey,
+        shift: event.shiftKey,
+      };
+      this.actionHotkey.value = this.describeHotkey(this.hotkeyValue);
+      this.applyActionFromEditor();
+    });
+    this.keyTest.addEventListener('click', () => {
+      const key = this.selectedKeyData();
+
+      if (key?.action) {
+        this.runKeyAction(this.selectedDeviceId, key.action);
+      }
+    });
+    this.keyClear.addEventListener('click', () => {
+      this.updateProfile((profile) => {
+        const page = profile.pages[this.selectedPage];
+        page.keys = page.keys.filter(
+          (key) => key.index !== this.selectedKey,
+        );
+      });
+    });
+  }
+
+  describeHotkey(hotkey) {
+    const parts = [];
+
+    if (hotkey.ctrl) parts.push('Ctrl');
+    if (hotkey.shift) parts.push('Shift');
+    if (hotkey.alt) parts.push('Alt');
+    if (hotkey.meta) parts.push('Win');
+
+    parts.push(hotkey.key);
+    return parts.join('+');
+  }
+
+  async readImageFile(file) {
+    const dataUrl = await new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(new Error('The file could not be read.'));
+      reader.onload = () => resolve(reader.result);
+      reader.readAsDataURL(file);
+    });
+    const image = await loadImage(dataUrl);
+    const scale = Math.min(
+      1,
+      STORED_IMAGE_PIXELS / Math.max(image.width, image.height),
+    );
+    const canvas = this.document.createElement('canvas');
+    canvas.width = Math.max(1, Math.round(image.width * scale));
+    canvas.height = Math.max(1, Math.round(image.height * scale));
+    canvas.getContext('2d').drawImage(image, 0, 0, canvas.width, canvas.height);
+    return canvas.toDataURL('image/webp', 0.92);
+  }
+
+  selectedProfile() {
+    return this.selectedDeviceId
+      ? this.devices[this.selectedDeviceId] || null
+      : null;
+  }
+
+  selectedKeyData() {
+    const profile = this.selectedProfile();
+
+    if (!profile || this.selectedKey === null) {
+      return null;
+    }
+
+    return (
+      profile.pages[this.selectedPage]?.keys.find(
+        (key) => key.index === this.selectedKey,
+      ) || null
+    );
+  }
+
+  limitsFor(profile) {
+    return (
+      this.boardLimits.get(profile?.boardId) || {
+        maxCols: MAX_DECK_COLS,
+        maxPages: MAX_DECK_PAGES,
+        maxRows: MAX_DECK_ROWS,
+      }
+    );
+  }
+
+  updateProfile(mutate, render = true, pageScope = false) {
+    const profile = this.selectedProfile();
+
+    if (!profile) {
+      return;
+    }
+
+    mutate(pageScope ? profile.pages[this.selectedPage] : profile);
+    this.persistProfile(this.selectedDeviceId);
+
+    if (render) {
+      this.renderAll();
+    }
+
+    this.scheduleSync(this.selectedDeviceId);
+  }
+
+  updateSelectedKey(mutate) {
+    const profile = this.selectedProfile();
+
+    if (!profile || this.selectedKey === null) {
+      return;
+    }
+
+    const page = profile.pages[this.selectedPage];
+    let key = page.keys.find((entry) => entry.index === this.selectedKey);
+
+    if (!key) {
+      key = { index: this.selectedKey };
+      page.keys.push(key);
+    }
+
+    mutate(key);
+
+    if (!key.label && !key.color && !key.image && !key.action) {
+      page.keys = page.keys.filter((entry) => entry !== key);
+    }
+
+    this.persistProfile(this.selectedDeviceId);
+    this.renderAll();
+    this.scheduleSync(this.selectedDeviceId);
+  }
+
+  resizeSelectedPage() {
+    this.updateProfile((page) => {
+      page.rows = Number(this.rowsSelect.value);
+      page.cols = Number(this.colsSelect.value);
+
+      const keyCount = page.rows * page.cols;
+      page.keys = page.keys.filter((key) => key.index < keyCount);
+
+      if (this.selectedKey !== null && this.selectedKey >= keyCount) {
+        this.selectedKey = null;
+      }
+    }, true, true);
+  }
+
+  applyActionFromEditor() {
+    const type = this.actionType.value;
+    this.pendingActionType = type === 'none' ? null : type;
+
+    this.updateSelectedKey((key) => {
+      switch (type) {
+        case 'media':
+          key.action = { type: 'media', command: this.actionMedia.value };
+          break;
+        case 'url': {
+          const url = this.actionUrl.value.trim();
+
+          if (url) {
+            key.action = { type: 'url', url };
+          } else {
+            delete key.action;
+          }
+
+          break;
+        }
+        case 'launch': {
+          const command = this.actionLaunch.value.trim();
+
+          if (command) {
+            key.action = { type: 'launch', command };
+          } else {
+            delete key.action;
+          }
+
+          break;
+        }
+        case 'hotkey':
+          if (this.hotkeyValue) {
+            key.action = { type: 'hotkey', ...this.hotkeyValue };
+          } else {
+            delete key.action;
+          }
+
+          break;
+        case 'page':
+          key.action = {
+            type: 'page',
+            page: Number(this.actionPage.value),
+          };
+          break;
+        default:
+          delete key.action;
+          break;
+      }
+    });
+  }
+
+  async persistProfile(deviceId) {
+    const profile = this.devices[deviceId];
+
+    if (!profile) {
+      return;
+    }
+
+    try {
+      this.devices[deviceId] = await this.api.saveDeck(deviceId, profile);
+    } catch (error) {
+      this.setSyncStatus(`Could not save the deck: ${error.message}`, 'error');
+    }
+  }
+
+  async importProfile() {
+    if (!this.selectedDeviceId) {
+      return;
+    }
+
+    try {
+      const { profile } = await this.api.importDeck();
+
+      if (!profile) {
+        return;
+      }
+
+      const confirmed = window.confirm(
+        'Importing replaces the entire deck for the selected device. Continue?',
+      );
+
+      if (!confirmed) {
+        return;
+      }
+
+      this.devices[this.selectedDeviceId] = profile;
+      this.selectedPage = profile.activePage;
+      this.selectedKey = null;
+      await this.persistProfile(this.selectedDeviceId);
+      this.renderAll();
+      this.scheduleSync(this.selectedDeviceId);
+      this.setSyncStatus('Deck profile imported.', 'ready');
+    } catch (error) {
+      this.setSyncStatus(`Import failed: ${error.message}`, 'error');
+    }
+  }
+
+  // ---- Device sessions -------------------------------------------------
+
+  async attachSession(session, board) {
+    const { deviceId, boardId } = session.hello;
+    this.sessions.set(deviceId, session);
+
+    if (!this.devices[deviceId]) {
+      try {
+        this.devices[deviceId] = await this.api.saveDeck(deviceId, {
+          name: `${board?.name || 'Stream32'} deck`,
+          boardId,
+          activePage: 0,
+          pages: [{ name: 'Main', rows: 3, cols: 3, keys: [] }],
+        });
+      } catch (error) {
+        this.setSyncStatus(
+          `Could not register the device: ${error.message}`,
+          'error',
+        );
+        return;
+      }
+
+      if (!this.selectedDeviceId) {
+        this.selectedDeviceId = deviceId;
+      }
+    }
+
+    this.renderAll();
+    this.scheduleSync(deviceId, 0);
+  }
+
+  detachSession(session) {
+    const deviceId = session.hello?.deviceId;
+
+    if (deviceId && this.sessions.get(deviceId) === session) {
+      this.sessions.delete(deviceId);
+      this.rejectPending(deviceId, new Error('The device disconnected.'));
+      this.renderAll();
+    }
+  }
+
+  handleDeviceMessage(session, message) {
+    const deviceId = session.hello?.deviceId;
+
+    if (!deviceId) {
+      return;
+    }
+
+    const pending = this.pending.get(deviceId);
+
+    if (pending && ['layout-ack', 'image-ack', 'error'].includes(message.type)) {
+      this.pending.delete(deviceId);
+
+      if (message.type === 'error') {
+        pending.reject(
+          new Error(
+            message.code === 'unknown-type'
+              ? 'The board firmware is too old for deck layouts. ' +
+                'Reflash it from the step below.'
+              : `Device error: ${message.code || 'unknown'}`,
+          ),
+        );
+      } else {
+        pending.resolve(message);
+      }
+
+      return;
+    }
+
+    if (message.type === 'press') {
+      this.handlePress(deviceId, message);
+    } else if (message.type === 'page') {
+      this.handleDevicePage(deviceId, message);
+    }
+  }
+
+  awaitReply(deviceId, timeoutMs = ACK_TIMEOUT_MS) {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(deviceId);
+        reject(new Error('The device did not acknowledge in time.'));
+      }, timeoutMs);
+
+      this.pending.set(deviceId, {
+        resolve: (message) => {
+          clearTimeout(timer);
+          resolve(message);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+    });
+  }
+
+  rejectPending(deviceId, error) {
+    const pending = this.pending.get(deviceId);
+
+    if (pending) {
+      this.pending.delete(deviceId);
+      pending.reject(error);
+    }
+  }
+
+  handlePress(deviceId, message) {
+    const press = validatePressMessage(message);
+
+    if (press.phase !== 'down') {
+      return;
+    }
+
+    const profile = this.devices[deviceId];
+    const key = profile?.pages[press.page]?.keys.find(
+      (entry) => entry.index === press.index,
+    );
+
+    if (key?.action) {
+      this.runKeyAction(deviceId, key.action);
+    }
+  }
+
+  handleDevicePage(deviceId, message) {
+    const { index } = validatePageMessage(message);
+    const profile = this.devices[deviceId];
+
+    if (!profile || index >= profile.pages.length) {
+      return;
+    }
+
+    profile.activePage = index;
+    this.persistProfile(deviceId);
+
+    if (deviceId === this.selectedDeviceId) {
+      this.selectedPage = index;
+      this.selectedKey = null;
+      this.renderAll();
+    }
+  }
+
+  async runKeyAction(deviceId, action) {
+    try {
+      if (action.type === 'page') {
+        const session = this.sessions.get(deviceId);
+        await session?.send(encodePageMessage(action.page));
+
+        const profile = this.devices[deviceId];
+
+        if (profile && action.page < profile.pages.length) {
+          profile.activePage = action.page;
+          this.persistProfile(deviceId);
+
+          if (deviceId === this.selectedDeviceId) {
+            this.selectedPage = action.page;
+            this.selectedKey = null;
+            this.renderAll();
+          }
+        }
+
+        return;
+      }
+
+      await this.api.runAction(action);
+    } catch (error) {
+      this.setSyncStatus(`Action failed: ${error.message}`, 'error');
+    }
+  }
+
+  // ---- Sync engine -----------------------------------------------------
+
+  scheduleSync(deviceId, delay = SYNC_DEBOUNCE_MS) {
+    if (!deviceId || !this.sessions.has(deviceId)) {
+      this.renderSyncStatus();
+      return;
+    }
+
+    clearTimeout(this.syncTimers.get(deviceId));
+    this.syncTimers.set(
+      deviceId,
+      setTimeout(() => {
+        this.syncTimers.delete(deviceId);
+        this.syncDevice(deviceId);
+      }, delay),
+    );
+  }
+
+  async syncDevice(deviceId) {
+    if (this.syncRunning.get(deviceId)) {
+      this.syncRunning.set(deviceId, 'again');
+      return;
+    }
+
+    const session = this.sessions.get(deviceId);
+    const profile = this.devices[deviceId];
+
+    if (!session || !profile) {
+      return;
+    }
+
+    this.syncRunning.set(deviceId, 'running');
+    this.setSyncStatus('Syncing the deck to the device…', 'working');
+
+    try {
+      for (const [pageIndex, page] of profile.pages.entries()) {
+        await this.syncPage(deviceId, session, profile, pageIndex, page);
+      }
+
+      await session.send(encodePageMessage(profile.activePage));
+      this.setSyncStatus('Deck synced to the device.', 'ready');
+    } catch (error) {
+      this.setSyncStatus(error.message, 'error');
+    } finally {
+      const runAgain = this.syncRunning.get(deviceId) === 'again';
+      this.syncRunning.delete(deviceId);
+
+      if (runAgain) {
+        this.scheduleSync(deviceId, 0);
+      }
+    }
+  }
+
+  async syncPage(deviceId, session, profile, pageIndex, page) {
+    let keyPx = profile.keyPx[gridKey(page)];
+
+    if (!keyPx) {
+      // First contact with this grid size: one extra round trip teaches us
+      // the key size so artwork CRCs can be computed.
+      const ack = await this.sendLayout(deviceId, session, profile, pageIndex, page, new Map());
+      keyPx = ack.keyPx;
+      profile.keyPx[gridKey(page)] = keyPx;
+      this.persistProfile(deviceId);
+    }
+
+    const renders = await this.renderPageImages(page, keyPx);
+    const ack = await this.sendLayout(
+      deviceId,
+      session,
+      profile,
+      pageIndex,
+      page,
+      renders,
+    );
+
+    if (ack.keyPx !== keyPx) {
+      profile.keyPx[gridKey(page)] = ack.keyPx;
+      this.persistProfile(deviceId);
+      return this.syncPage(deviceId, session, profile, pageIndex, page);
+    }
+
+    for (const index of ack.needImages) {
+      const render = renders.get(index);
+
+      if (render) {
+        await this.streamImage(deviceId, session, pageIndex, index, keyPx, render);
+      }
+    }
+  }
+
+  async sendLayout(deviceId, session, profile, pageIndex, page, renders) {
+    const keys = page.keys.map((key) => {
+      const entry = { index: key.index };
+
+      if (key.label) {
+        entry.label = key.label;
+      }
+
+      if (key.color) {
+        entry.color = key.color;
+      }
+
+      const render = renders.get(key.index);
+
+      if (render) {
+        entry.imageCrc = render.crc;
+      }
+
+      if (key.action?.type === 'page') {
+        entry.goPage = key.action.page;
+      }
+
+      return entry;
+    });
+
+    const reply = this.awaitReply(deviceId);
+    await session.send(
+      encodeLayoutMessage({
+        page: pageIndex,
+        of: profile.pages.length,
+        rows: page.rows,
+        cols: page.cols,
+        keys,
+      }),
+    );
+    return validateLayoutAck(await reply);
+  }
+
+  async streamImage(deviceId, session, pageIndex, index, keyPx, render) {
+    const chunks = encodeImageChunks({
+      page: pageIndex,
+      index,
+      width: keyPx,
+      height: keyPx,
+      pixels: render.pixels,
+    });
+
+    for (const [seq, chunk] of chunks.entries()) {
+      this.setSyncStatus(
+        `Sending key artwork… page ${pageIndex + 1}, key ${index + 1}, ` +
+          `${Math.round(((seq + 1) / chunks.length) * 100)}%`,
+        'working',
+      );
+
+      const reply = this.awaitReply(deviceId);
+      await session.send(chunk);
+      const ack = validateImageAck(await reply);
+
+      if (ack.page !== pageIndex || ack.index !== index || ack.seq !== seq) {
+        throw new Error('The device acknowledged the wrong image chunk.');
+      }
+    }
+  }
+
+  async renderPageImages(page, keyPx) {
+    const renders = new Map();
+
+    for (const key of page.keys) {
+      if (!key.image) {
+        continue;
+      }
+
+      const canvas = this.document.createElement('canvas');
+      canvas.width = keyPx;
+      canvas.height = keyPx;
+
+      const context = canvas.getContext('2d', { willReadFrequently: true });
+      context.fillStyle = key.color || DEFAULT_KEY_COLOR;
+      context.fillRect(0, 0, keyPx, keyPx);
+
+      try {
+        const image = await loadImage(key.image);
+        const scale = Math.min(keyPx / image.width, keyPx / image.height);
+        const width = image.width * scale;
+        const height = image.height * scale;
+        context.drawImage(
+          image,
+          (keyPx - width) / 2,
+          (keyPx - height) / 2,
+          width,
+          height,
+        );
+      } catch {
+        // A corrupt stored image falls back to the key color.
+      }
+
+      const pixels = toRgb565(context.getImageData(0, 0, keyPx, keyPx));
+      renders.set(key.index, { crc: crc32(pixels), pixels });
+    }
+
+    return renders;
+  }
+
+  // ---- Rendering ---------------------------------------------------------
+
+  setSyncStatus(message, state) {
+    this.syncStatus.textContent = message;
+    this.syncStatus.dataset.state = state;
+  }
+
+  renderSyncStatus() {
+    if (!this.selectedDeviceId) {
+      this.setSyncStatus('', 'idle');
+      return;
+    }
+
+    if (!this.sessions.has(this.selectedDeviceId)) {
+      this.setSyncStatus(
+        'Device offline — changes sync automatically on its next connection.',
+        'idle',
+      );
+    }
+  }
+
+  renderAll() {
+    this.renderDevicePicker();
+    this.renderPages();
+    this.renderGrid();
+    this.renderKeyEditor();
+    this.renderSyncStatus();
+  }
+
+  renderDevicePicker() {
+    const deviceIds = Object.keys(this.devices);
+    this.deviceSelect.replaceChildren();
+
+    for (const deviceId of deviceIds) {
+      const option = this.document.createElement('option');
+      option.value = deviceId;
+      option.textContent = deviceLabel(deviceId, this.devices[deviceId]);
+      this.deviceSelect.append(option);
+    }
+
+    const hasDevices = deviceIds.length > 0;
+    this.emptyState.hidden = hasDevices;
+    this.editorPanel.hidden = !hasDevices;
+
+    if (!hasDevices) {
+      this.selectedDeviceId = null;
+      return;
+    }
+
+    if (!deviceIds.includes(this.selectedDeviceId)) {
+      this.selectedDeviceId = deviceIds[0];
+    }
+
+    this.deviceSelect.value = this.selectedDeviceId;
+
+    const profile = this.selectedProfile();
+    this.deviceName.value = profile.name;
+    this.deviceStatus.textContent = this.sessions.has(this.selectedDeviceId)
+      ? 'Connected'
+      : 'Offline';
+    this.deviceStatus.dataset.state = this.sessions.has(this.selectedDeviceId)
+      ? 'ready'
+      : 'idle';
+  }
+
+  renderPages() {
+    const profile = this.selectedProfile();
+    this.pageTabs.replaceChildren();
+
+    if (!profile) {
+      return;
+    }
+
+    this.selectedPage = Math.min(this.selectedPage, profile.pages.length - 1);
+
+    for (const [index, page] of profile.pages.entries()) {
+      const tab = this.document.createElement('button');
+      tab.type = 'button';
+      tab.className = 'deck-page-tab';
+      tab.textContent = page.name;
+      tab.dataset.active = String(index === this.selectedPage);
+      tab.addEventListener('click', () => {
+        this.selectedPage = index;
+        this.selectedKey = null;
+        this.pendingActionType = null;
+        this.renderAll();
+      });
+      this.pageTabs.append(tab);
+    }
+
+    const limits = this.limitsFor(profile);
+    this.addPageButton.disabled = profile.pages.length >= limits.maxPages;
+    this.removePageButton.disabled = profile.pages.length <= 1;
+
+    const page = profile.pages[this.selectedPage];
+    this.pageName.value = page.name;
+
+    for (const option of this.rowsSelect.options) {
+      option.disabled = Number(option.value) > limits.maxRows;
+    }
+
+    for (const option of this.colsSelect.options) {
+      option.disabled = Number(option.value) > limits.maxCols;
+    }
+
+    this.rowsSelect.value = String(page.rows);
+    this.colsSelect.value = String(page.cols);
+  }
+
+  renderGrid() {
+    const profile = this.selectedProfile();
+    this.grid.replaceChildren();
+
+    if (!profile) {
+      return;
+    }
+
+    const page = profile.pages[this.selectedPage];
+    this.grid.style.setProperty('--deck-cols', String(page.cols));
+
+    for (let index = 0; index < page.rows * page.cols; index++) {
+      const key = page.keys.find((entry) => entry.index === index);
+      const cell = this.document.createElement('button');
+      cell.type = 'button';
+      cell.className = 'deck-key';
+      cell.dataset.selected = String(index === this.selectedKey);
+
+      if (key?.color) {
+        cell.style.background = key.color;
+      }
+
+      if (key?.image) {
+        const image = this.document.createElement('img');
+        image.src = key.image;
+        image.alt = '';
+        cell.append(image);
+      }
+
+      if (key?.label) {
+        const label = this.document.createElement('span');
+        label.textContent = key.label;
+        cell.append(label);
+      }
+
+      if (key?.action?.type === 'page') {
+        cell.dataset.badge = '⇒';
+      }
+
+      cell.addEventListener('click', () => {
+        if (this.selectedKey !== index) {
+          this.pendingActionType = null;
+        }
+
+        this.selectedKey = index;
+        this.renderAll();
+      });
+      this.grid.append(cell);
+    }
+  }
+
+  renderKeyEditor() {
+    const profile = this.selectedProfile();
+
+    if (!profile || this.selectedKey === null) {
+      this.keyEditor.hidden = true;
+      return;
+    }
+
+    this.keyEditor.hidden = false;
+
+    const page = profile.pages[this.selectedPage];
+    const key = this.selectedKeyData() || { index: this.selectedKey };
+    const row = Math.floor(this.selectedKey / page.cols) + 1;
+    const col = (this.selectedKey % page.cols) + 1;
+
+    this.keyTitle.textContent = `Key ${this.selectedKey + 1} (row ${row}, column ${col})`;
+    this.keyLabel.value = key.label || '';
+    this.keyColor.value = key.color || DEFAULT_KEY_COLOR;
+    this.keyImageClear.disabled = !key.image;
+
+    this.actionPage.replaceChildren();
+
+    for (const [index, target] of profile.pages.entries()) {
+      const option = this.document.createElement('option');
+      option.value = String(index);
+      option.textContent = target.name;
+      this.actionPage.append(option);
+    }
+
+    const action = key.action || null;
+    const displayType = action?.type || this.pendingActionType || 'none';
+
+    this.actionType.value = displayType;
+    this.actionMedia.hidden = displayType !== 'media';
+    this.actionUrl.hidden = displayType !== 'url';
+    this.actionLaunch.hidden = displayType !== 'launch';
+    this.actionHotkey.hidden = displayType !== 'hotkey';
+    this.actionPage.hidden = displayType !== 'page';
+
+    switch (action?.type) {
+      case 'media':
+        this.actionMedia.value = action.command;
+        break;
+      case 'url':
+        this.actionUrl.value = action.url;
+        break;
+      case 'launch':
+        this.actionLaunch.value = action.command;
+        break;
+      case 'hotkey':
+        this.hotkeyValue = {
+          key: action.key,
+          alt: action.alt,
+          ctrl: action.ctrl,
+          meta: action.meta,
+          shift: action.shift,
+        };
+        this.actionHotkey.value = this.describeHotkey(this.hotkeyValue);
+        break;
+      case 'page':
+        this.actionPage.value = String(action.page);
+        break;
+      default:
+        this.actionUrl.value = '';
+        this.actionLaunch.value = '';
+        this.actionHotkey.value = '';
+        this.hotkeyValue = null;
+        break;
+    }
+
+    this.keyTest.disabled = !action;
+  }
+}
+
+module.exports = { DeckController };

--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -34,8 +34,9 @@ function errorMessage(error) {
 }
 
 class DeviceController {
-  constructor({ api, document, serial }) {
+  constructor({ api, deck = null, document, serial }) {
     this.api = api;
+    this.deck = deck;
     this.document = document;
     this.serial = serial;
     this.boards = new Map();
@@ -44,7 +45,7 @@ class DeviceController {
     this.operation = null;
     this.selectedPort = null;
     this.selectedPortBoardId = null;
-    this.session = null;
+    this.sessions = new Map();
 
     this.boardSelect = document.querySelector('#board-select');
     this.boardDetails = document.querySelector('#board-details');
@@ -92,7 +93,7 @@ class DeviceController {
     this.reconnectButton.addEventListener('click', async () => {
       await this.reconnectAuthorizedDevice(true);
 
-      if (this.session) {
+      if (this.sessions.size > 0) {
         this.showTouchTest();
       }
     });
@@ -126,7 +127,7 @@ class DeviceController {
     }
 
     this.serial.addEventListener('connect', () => {
-      if (!this.session && !this.operation) {
+      if (!this.operation) {
         this.reconnectAuthorizedDevice();
       }
     });
@@ -135,9 +136,8 @@ class DeviceController {
         this.clearUsbSelection('The selected USB/COM port was disconnected.');
       }
 
-      if (this.session?.port === event.target) {
-        this.closeSession();
-        this.setDeviceStatus('Stream32 device disconnected.', 'idle');
+      if (this.sessions.has(event.target)) {
+        this.closeSessionForPort(event.target);
       }
     });
 
@@ -237,7 +237,7 @@ class DeviceController {
       // requestPort must run directly from this click before user activation
       // expires; downloading firmware first prevents Chromium's picker.
       const port = await this.serial.requestPort();
-      await this.closeSession();
+      await this.closeSessionForPort(port);
       await sleep(300);
       const info = port.getInfo();
       const vendorId = info.usbVendorId
@@ -301,6 +301,7 @@ class DeviceController {
       const previousSelection = this.boardSelect.value;
 
       this.boards = new Map(result.boards.map((board) => [board.id, board]));
+      this.deck?.setBoards(result.boards);
       this.boardSelect.replaceChildren();
 
       for (const board of result.boards) {
@@ -417,7 +418,7 @@ class DeviceController {
     let transport = null;
 
     try {
-      await this.closeSession();
+      await this.closeSessionForPort(port);
       await sleep(500);
       const firmware = await this.api.getBoardFirmware(board.id);
 
@@ -517,7 +518,7 @@ class DeviceController {
         );
       } catch (error) {
         lastError = error;
-        await this.closeSession();
+        await this.closeSessionForPort(port);
       }
     }
 
@@ -527,13 +528,37 @@ class DeviceController {
     );
   }
 
+  connectedSessions() {
+    return [...this.sessions.values()].filter(
+      (session) => session.handshakeComplete,
+    );
+  }
+
+  updateDeviceStatusSummary() {
+    const connected = this.connectedSessions();
+
+    if (connected.length === 0) {
+      this.setDeviceStatus('No Stream32 device is connected.', 'idle');
+    } else if (connected.length === 1) {
+      const { hello } = connected[0];
+      this.setDeviceStatus(
+        `Connected · ${hello.boardId} · firmware ${hello.firmwareVersion}`,
+        'connected',
+      );
+    } else {
+      this.setDeviceStatus(
+        `${connected.length} Stream32 devices connected.`,
+        'connected',
+      );
+    }
+  }
+
   async reconnectAuthorizedDevice(force = false) {
     if (
       this.busy ||
       this.operation ||
       !this.serial ||
-      this.boards.size === 0 ||
-      (this.session && !force)
+      this.boards.size === 0
     ) {
       return;
     }
@@ -542,25 +567,28 @@ class DeviceController {
       return;
     }
 
-    this.setDeviceStatus('Looking for an authorized Stream32 device…', 'working');
+    this.setDeviceStatus('Looking for authorized Stream32 devices…', 'working');
 
     try {
       if (force) {
-        await this.closeSession();
+        await this.closeAllSessions();
       }
 
       const ports = await this.serial.getPorts();
 
       for (const port of ports) {
+        if (this.sessions.has(port)) {
+          continue;
+        }
+
         try {
           await this.openSession(port, null);
-          return;
         } catch {
-          await this.closeSession();
+          await this.closeSessionForPort(port);
         }
       }
 
-      this.setDeviceStatus('No Stream32 device is connected.', 'idle');
+      this.updateDeviceStatusSummary();
     } catch (error) {
       this.setDeviceStatus(
         `Could not reconnect: ${errorMessage(error)}`,
@@ -576,7 +604,7 @@ class DeviceController {
     expectedBoardId,
     expectedFirmwareVersion = null,
   ) {
-    await this.closeSession();
+    await this.closeSessionForPort(port);
     await port.open({ baudRate: 115200, bufferSize: 4096 });
 
     let writer = null;
@@ -614,13 +642,34 @@ class DeviceController {
       rejectHandshake = reject;
     });
     const session = {
-      boardId: null,
+      hello: null,
       handshakeComplete: false,
       port,
       readTask: null,
       reader,
+      send: null,
+      sendChain: Promise.resolve(),
     };
-    this.session = session;
+    // Deck pushes serialize their writes so image chunks never interleave
+    // with layout or page messages on the same port.
+    session.send = (bytes) => {
+      const task = session.sendChain.then(async () => {
+        if (this.sessions.get(port) !== session) {
+          throw new Error('The device session is closed.');
+        }
+
+        const sendWriter = port.writable.getWriter();
+
+        try {
+          await sendWriter.write(bytes);
+        } finally {
+          sendWriter.releaseLock();
+        }
+      });
+      session.sendChain = task.catch(() => {});
+      return task;
+    };
+    this.sessions.set(port, session);
 
     const decoder = createLineDecoder({
       onError: (error) => {
@@ -646,20 +695,21 @@ class DeviceController {
               );
             }
 
-            session.boardId = hello.boardId;
+            session.hello = hello;
             session.handshakeComplete = true;
-            this.setDeviceStatus(
-              `Connected · ${hello.boardId} · firmware ` +
-                hello.firmwareVersion,
-              'connected',
-            );
+            this.updateDeviceStatusSummary();
             this.touchStatus.textContent = 'Touch the display to test input.';
+            this.deck?.attachSession(session, this.boards.get(hello.boardId));
             resolveHandshake(hello);
           } else if (message.type === 'touch' && session.handshakeComplete) {
             const touch = validateTouchMessage(message);
             this.touchStatus.textContent =
               `${touch.phase === 'down' ? 'Pressed' : 'Released'} at ` +
               `X ${touch.x}, Y ${touch.y}`;
+          } else if (session.handshakeComplete && this.deck) {
+            // layout-ack, image-ack, page, press, and error replies belong
+            // to the deck sync engine after the handshake.
+            this.deck.handleDeviceMessage(session, message);
           } else if (message.type === 'error') {
             this.appendLog(`Device error: ${message.code || 'unknown'}`);
           }
@@ -675,7 +725,7 @@ class DeviceController {
 
     session.readTask = (async () => {
       try {
-        while (this.session === session) {
+        while (this.sessions.get(port) === session) {
           const { done, value } = await reader.read();
 
           if (done) {
@@ -685,7 +735,7 @@ class DeviceController {
           decoder.push(value);
         }
       } catch (error) {
-        if (this.session === session) {
+        if (this.sessions.get(port) === session) {
           rejectHandshake(error);
           this.setDeviceStatus(
             `Device connection lost: ${errorMessage(error)}`,
@@ -693,11 +743,11 @@ class DeviceController {
           );
         }
       } finally {
-        const ownsSession = this.session === session;
+        const ownsSession = this.sessions.get(port) === session;
         reader.releaseLock();
 
         if (ownsSession) {
-          this.session = null;
+          this.sessions.delete(port);
 
           try {
             await port.close();
@@ -706,7 +756,8 @@ class DeviceController {
           }
 
           if (session.handshakeComplete) {
-            this.setDeviceStatus('Stream32 device disconnected.', 'idle');
+            this.deck?.detachSession(session);
+            this.updateDeviceStatusSummary();
           }
         }
       }
@@ -717,7 +768,7 @@ class DeviceController {
     // device answers or the handshake window closes.
     const helloTimer = setInterval(async () => {
       if (
-        this.session !== session ||
+        this.sessions.get(port) !== session ||
         session.handshakeComplete ||
         !port.writable ||
         port.writable.locked
@@ -746,21 +797,25 @@ class DeviceController {
     try {
       return await Promise.race([handshake, timeout]);
     } catch (error) {
-      await this.closeSession();
+      await this.closeSessionForPort(port);
       throw error;
     } finally {
       clearInterval(helloTimer);
     }
   }
 
-  async closeSession() {
-    const session = this.session;
+  async closeSessionForPort(port) {
+    const session = this.sessions.get(port);
 
     if (!session) {
       return;
     }
 
-    this.session = null;
+    this.sessions.delete(port);
+
+    if (session.handshakeComplete) {
+      this.deck?.detachSession(session);
+    }
 
     try {
       await session.reader.cancel();
@@ -778,6 +833,12 @@ class DeviceController {
       await session.port.close();
     } catch {
       // The operating system may have already removed the port.
+    }
+  }
+
+  async closeAllSessions() {
+    for (const port of [...this.sessions.keys()]) {
+      await this.closeSessionForPort(port);
     }
   }
 }

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -41,6 +41,148 @@
           </p>
         </header>
 
+        <details id="deck-step" class="card deck-card" open>
+          <summary class="card-summary">
+            <h2 id="deck-title">Deck</h2>
+          </summary>
+
+          <div class="card-body">
+            <p id="deck-empty">
+              No Stream32 deck yet. Flash a board below and connect it to
+              start configuring keys.
+            </p>
+
+            <div id="deck-editor" hidden>
+              <div class="deck-toolbar">
+                <div class="deck-device-picker">
+                  <label for="deck-device">Device</label>
+                  <select id="deck-device"></select>
+                  <span
+                    id="deck-device-status"
+                    class="helper"
+                    data-state="idle"
+                  >Offline</span>
+                </div>
+                <input
+                  id="deck-device-name"
+                  type="text"
+                  maxlength="60"
+                  aria-label="Device nickname"
+                >
+                <div class="deck-file-actions">
+                  <button id="deck-import" class="button button-quiet" type="button">
+                    Import
+                  </button>
+                  <button id="deck-export" class="button button-quiet" type="button">
+                    Export
+                  </button>
+                </div>
+              </div>
+
+              <p
+                id="deck-sync-status"
+                class="helper"
+                data-state="idle"
+                aria-live="polite"
+              ></p>
+
+              <div class="deck-pages">
+                <div id="deck-page-tabs" role="tablist" aria-label="Deck pages"></div>
+                <button id="deck-add-page" class="button button-quiet" type="button">
+                  + Page
+                </button>
+                <button id="deck-remove-page" class="button button-quiet" type="button">
+                  Remove page
+                </button>
+              </div>
+
+              <div class="deck-page-settings">
+                <input
+                  id="deck-page-name"
+                  type="text"
+                  maxlength="40"
+                  aria-label="Page name"
+                >
+                <label for="deck-rows">Rows</label>
+                <select id="deck-rows"></select>
+                <label for="deck-cols">Columns</label>
+                <select id="deck-cols"></select>
+              </div>
+
+              <div id="deck-grid" class="deck-grid" aria-label="Deck keys"></div>
+
+              <div id="deck-key-editor" class="deck-key-editor" hidden>
+                <p id="deck-key-title" class="field-label"></p>
+                <div class="deck-key-fields">
+                  <label>
+                    Label
+                    <input id="deck-key-label" type="text" maxlength="32">
+                  </label>
+                  <label>
+                    Color
+                    <input id="deck-key-color" type="color" value="#172630">
+                  </label>
+                  <label>
+                    Image
+                    <input id="deck-key-image" type="file" accept="image/*">
+                  </label>
+                  <button
+                    id="deck-key-image-clear"
+                    class="button button-quiet"
+                    type="button"
+                  >
+                    Remove image
+                  </button>
+                  <label>
+                    Action
+                    <select id="deck-action-type">
+                      <option value="none">Do nothing</option>
+                      <option value="media">Media control</option>
+                      <option value="url">Open website</option>
+                      <option value="launch">Launch app / command</option>
+                      <option value="hotkey">Keyboard shortcut</option>
+                      <option value="page">Go to page</option>
+                    </select>
+                  </label>
+                  <select id="deck-action-media" aria-label="Media command" hidden></select>
+                  <input
+                    id="deck-action-url"
+                    type="url"
+                    placeholder="https://example.com"
+                    aria-label="Website address"
+                    hidden
+                  >
+                  <input
+                    id="deck-action-launch"
+                    type="text"
+                    maxlength="1024"
+                    placeholder="notepad.exe or any command line"
+                    aria-label="Launch command"
+                    hidden
+                  >
+                  <input
+                    id="deck-action-hotkey"
+                    type="text"
+                    readonly
+                    placeholder="Click, then press keys"
+                    aria-label="Keyboard shortcut"
+                    hidden
+                  >
+                  <select id="deck-action-page" aria-label="Target page" hidden></select>
+                </div>
+                <div class="deck-key-actions">
+                  <button id="deck-key-test" class="button button-secondary" type="button">
+                    Test action
+                  </button>
+                  <button id="deck-key-clear" class="button button-quiet" type="button">
+                    Clear key
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </details>
+
         <details id="flash-step" class="card setup-step" open>
           <summary class="card-summary">
             <span class="step">Step 1</span>

--- a/desktop/src/renderer/protocol.js
+++ b/desktop/src/renderer/protocol.js
@@ -3,6 +3,17 @@ const BOARD_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const DEVICE_ID_PATTERN = /^[a-f0-9]{12}$/;
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/;
 
+const MAX_DECK_PAGES = 8;
+const MAX_DECK_ROWS = 5;
+const MAX_DECK_COLS = 5;
+const MAX_KEY_LABEL_LENGTH = 32;
+const MAX_KEY_PIXELS = 512;
+const KEY_COLOR_PATTERN = /^#[0-9a-f]{6}$/;
+const IMAGE_CRC_PATTERN = /^[0-9a-f]{8}$/;
+// 2688 raw bytes → 3584 base64 characters, keeping every image line (JSON
+// envelope included) under MAX_PROTOCOL_LINE_LENGTH.
+const IMAGE_CHUNK_RAW_BYTES = 2688;
+
 function normalizeChipName(value) {
   return String(value)
     .trim()
@@ -115,6 +126,268 @@ function validateTouchMessage(message) {
   };
 }
 
+let crc32Table = null;
+
+// Matches the standard reflected CRC-32 (zlib) used by esp_rom_crc32_le(0, …)
+// on the device; returned as 8 lowercase hex characters.
+function crc32(bytes) {
+  if (!crc32Table) {
+    crc32Table = new Uint32Array(256);
+
+    for (let index = 0; index < 256; index++) {
+      let value = index;
+
+      for (let bit = 0; bit < 8; bit++) {
+        value = value & 1 ? 0xedb88320 ^ (value >>> 1) : value >>> 1;
+      }
+
+      crc32Table[index] = value >>> 0;
+    }
+  }
+
+  let crc = 0xffffffff;
+
+  for (const byte of bytes) {
+    crc = crc32Table[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+
+  return ((crc ^ 0xffffffff) >>> 0).toString(16).padStart(8, '0');
+}
+
+function requireProtocolInteger(value, field, minimum, maximum) {
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new TypeError(`${field} is outside the supported range.`);
+  }
+
+  return value;
+}
+
+function encodeLine(message) {
+  const line = `${JSON.stringify(message)}\n`;
+
+  if (line.length > MAX_PROTOCOL_LINE_LENGTH) {
+    throw new RangeError('Encoded protocol line exceeds the limit.');
+  }
+
+  return new TextEncoder().encode(line);
+}
+
+function encodeLayoutMessage({ page, of, rows, cols, keys }) {
+  requireProtocolInteger(page, 'layout page', 0, MAX_DECK_PAGES - 1);
+  requireProtocolInteger(of, 'layout page count', 1, MAX_DECK_PAGES);
+  requireProtocolInteger(rows, 'layout rows', 1, MAX_DECK_ROWS);
+  requireProtocolInteger(cols, 'layout cols', 1, MAX_DECK_COLS);
+
+  if (page >= of || !Array.isArray(keys)) {
+    throw new TypeError('Layout pages are inconsistent.');
+  }
+
+  const keyCount = rows * cols;
+  const seen = new Set();
+  const encodedKeys = keys.map((key) => {
+    const index = requireProtocolInteger(
+      key.index,
+      'layout key index',
+      0,
+      keyCount - 1,
+    );
+
+    if (seen.has(index)) {
+      throw new TypeError('Layout keys must have unique indexes.');
+    }
+
+    seen.add(index);
+
+    const encoded = { index };
+
+    if (key.label !== undefined) {
+      if (
+        typeof key.label !== 'string' ||
+        key.label.length > MAX_KEY_LABEL_LENGTH
+      ) {
+        throw new TypeError('Layout key label is invalid.');
+      }
+
+      encoded.label = key.label;
+    }
+
+    if (key.color !== undefined) {
+      if (
+        typeof key.color !== 'string' ||
+        !KEY_COLOR_PATTERN.test(key.color)
+      ) {
+        throw new TypeError('Layout key color is invalid.');
+      }
+
+      encoded.color = key.color;
+    }
+
+    if (key.imageCrc !== undefined) {
+      if (
+        typeof key.imageCrc !== 'string' ||
+        !IMAGE_CRC_PATTERN.test(key.imageCrc)
+      ) {
+        throw new TypeError('Layout key image CRC is invalid.');
+      }
+
+      encoded.imageCrc = key.imageCrc;
+    }
+
+    if (key.goPage !== undefined) {
+      encoded.goPage = requireProtocolInteger(
+        key.goPage,
+        'layout key goPage',
+        0,
+        of - 1,
+      );
+    }
+
+    return encoded;
+  });
+
+  return encodeLine({
+    type: 'layout',
+    page,
+    of,
+    rows,
+    cols,
+    keys: encodedKeys,
+  });
+}
+
+function toBase64(bytes) {
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary);
+}
+
+function encodeImageChunks({ page, index, width, height, pixels }) {
+  requireProtocolInteger(page, 'image page', 0, MAX_DECK_PAGES - 1);
+  requireProtocolInteger(index, 'image key index', 0, MAX_DECK_ROWS * MAX_DECK_COLS - 1);
+  requireProtocolInteger(width, 'image width', 1, MAX_KEY_PIXELS);
+  requireProtocolInteger(height, 'image height', 1, MAX_KEY_PIXELS);
+
+  if (!(pixels instanceof Uint8Array) || pixels.length !== width * height * 2) {
+    throw new TypeError('Image pixels must be RGB565 bytes.');
+  }
+
+  const total = Math.ceil(pixels.length / IMAGE_CHUNK_RAW_BYTES);
+  const chunks = [];
+
+  for (let seq = 0; seq < total; seq++) {
+    const slice = pixels.subarray(
+      seq * IMAGE_CHUNK_RAW_BYTES,
+      (seq + 1) * IMAGE_CHUNK_RAW_BYTES,
+    );
+    chunks.push(
+      encodeLine({
+        type: 'image',
+        page,
+        index,
+        seq,
+        of: total,
+        w: width,
+        h: height,
+        data: toBase64(slice),
+      }),
+    );
+  }
+
+  return chunks;
+}
+
+function encodePageMessage(index) {
+  requireProtocolInteger(index, 'page index', 0, MAX_DECK_PAGES - 1);
+  return encodeLine({ type: 'page', index });
+}
+
+function validateLayoutAck(message) {
+  const page = requireProtocolInteger(
+    message.page,
+    'layout-ack page',
+    0,
+    MAX_DECK_PAGES - 1,
+  );
+  const rows = requireProtocolInteger(
+    message.rows,
+    'layout-ack rows',
+    1,
+    MAX_DECK_ROWS,
+  );
+  const cols = requireProtocolInteger(
+    message.cols,
+    'layout-ack cols',
+    1,
+    MAX_DECK_COLS,
+  );
+  const keyPx = requireProtocolInteger(
+    message.keyPx,
+    'layout-ack keyPx',
+    16,
+    MAX_KEY_PIXELS,
+  );
+
+  if (!Array.isArray(message.needImages)) {
+    throw new TypeError('layout-ack needImages must be an array.');
+  }
+
+  const needImages = message.needImages.map((index) =>
+    requireProtocolInteger(index, 'layout-ack needImages', 0, rows * cols - 1),
+  );
+
+  return { page, rows, cols, keyPx, needImages };
+}
+
+function validateImageAck(message) {
+  return {
+    page: requireProtocolInteger(
+      message.page,
+      'image-ack page',
+      0,
+      MAX_DECK_PAGES - 1,
+    ),
+    index: requireProtocolInteger(
+      message.index,
+      'image-ack index',
+      0,
+      MAX_DECK_ROWS * MAX_DECK_COLS - 1,
+    ),
+    seq: requireProtocolInteger(message.seq, 'image-ack seq', 0, 65535),
+  };
+}
+
+function validatePageMessage(message) {
+  return {
+    index: requireProtocolInteger(
+      message.index,
+      'page index',
+      0,
+      MAX_DECK_PAGES - 1,
+    ),
+  };
+}
+
+function validatePressMessage(message) {
+  if (!['down', 'up'].includes(message.phase)) {
+    throw new TypeError('Device press message is invalid.');
+  }
+
+  return {
+    page: requireProtocolInteger(message.page, 'press page', 0, MAX_DECK_PAGES - 1),
+    index: requireProtocolInteger(
+      message.index,
+      'press index',
+      0,
+      MAX_DECK_ROWS * MAX_DECK_COLS - 1,
+    ),
+    phase: message.phase,
+  };
+}
+
 function createLineDecoder({ onError, onMessage }) {
   const decoder = new TextDecoder();
   let buffer = '';
@@ -165,11 +438,23 @@ function createLineDecoder({ onError, onMessage }) {
 }
 
 module.exports = {
+  MAX_DECK_COLS,
+  MAX_DECK_PAGES,
+  MAX_DECK_ROWS,
+  MAX_KEY_LABEL_LENGTH,
   MAX_PROTOCOL_LINE_LENGTH,
+  crc32,
   createLineDecoder,
   encodeHostHello,
+  encodeImageChunks,
+  encodeLayoutMessage,
+  encodePageMessage,
   isExpectedChip,
   normalizeChipName,
   validateDeviceHello,
+  validateImageAck,
+  validateLayoutAck,
+  validatePageMessage,
+  validatePressMessage,
   validateTouchMessage,
 };

--- a/desktop/src/renderer/renderer.js
+++ b/desktop/src/renderer/renderer.js
@@ -5,9 +5,17 @@ const checkUpdatesButton = document.querySelector('#check-updates');
 const updateRow = document.querySelector('.update-row');
 const updateStatus = document.querySelector('#update-status');
 
+const UPDATE_BUSY_STATES = new Set(['available', 'checking', 'downloading']);
+let updateReady = false;
+
 function showUpdateStatus({ message, state }) {
   updateRow.dataset.state = state;
   updateStatus.textContent = message;
+  updateReady ||= state === 'downloaded';
+  checkUpdatesButton.textContent = updateReady
+    ? 'Restart to update'
+    : 'Check now';
+  checkUpdatesButton.disabled = UPDATE_BUSY_STATES.has(state);
 }
 
 async function loadAutoStartState() {
@@ -42,17 +50,26 @@ autoStartControl.addEventListener('change', async () => {
 });
 
 checkUpdatesButton.addEventListener('click', async () => {
+  const installing = updateReady;
+  let installStarted = false;
   checkUpdatesButton.disabled = true;
 
   try {
-    await window.stream32.checkForUpdates();
+    if (installing) {
+      checkUpdatesButton.textContent = 'Restarting…';
+      await window.stream32.installUpdate();
+      installStarted = true;
+    } else {
+      await window.stream32.checkForUpdates();
+    }
   } catch (error) {
     showUpdateStatus({
-      message: `Update check failed: ${error.message}`,
+      message: `Update ${installing ? 'install' : 'check'} failed: ${error.message}`,
       state: 'error',
     });
   } finally {
-    checkUpdatesButton.disabled = false;
+    checkUpdatesButton.disabled =
+      UPDATE_BUSY_STATES.has(updateRow.dataset.state) || installStarted;
   }
 });
 

--- a/desktop/src/renderer/renderer.js
+++ b/desktop/src/renderer/renderer.js
@@ -1,3 +1,4 @@
+const { DeckController } = require('./deck');
 const { DeviceController } = require('./device');
 
 const autoStartControl = document.querySelector('#autostart');
@@ -76,12 +77,23 @@ checkUpdatesButton.addEventListener('click', async () => {
 window.stream32.onUpdateStatus(showUpdateStatus);
 loadAutoStartState();
 
+const deckController = new DeckController({
+  api: window.stream32,
+  document,
+});
 const deviceController = new DeviceController({
   api: window.stream32,
+  deck: deckController,
   document,
   serial: navigator.serial,
 });
 
+deckController.initialize().catch((error) => {
+  const syncStatus = document.querySelector('#deck-sync-status');
+  syncStatus.dataset.state = 'error';
+  syncStatus.textContent =
+    `Deck setup failed: ${error instanceof Error ? error.message : error}`;
+});
 deviceController.initialize().catch((error) => {
   const deviceStatus = document.querySelector('#device-status');
   deviceStatus.dataset.state = 'error';

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -444,6 +444,205 @@ input:disabled {
   opacity: 0.45;
 }
 
+#deck-empty {
+  margin: 0.6rem 0 0;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.deck-toolbar {
+  display: flex;
+  align-items: end;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-top: 0.8rem;
+}
+
+.deck-device-picker {
+  display: grid;
+  flex: 1 1 240px;
+  gap: 0.35rem;
+}
+
+.deck-device-picker label {
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.deck-device-picker .helper[data-state="ready"] {
+  color: var(--success);
+}
+
+.deck-toolbar input[type="text"],
+.deck-page-settings input[type="text"],
+.deck-key-fields input,
+.deck-key-fields select {
+  min-height: 2.55rem;
+  padding: 0 0.85rem;
+  color: var(--ink);
+  border: 1px solid #46606e;
+  border-radius: 9px;
+  background: var(--surface-strong);
+}
+
+.deck-file-actions {
+  display: flex;
+  gap: 0.9rem;
+  padding-bottom: 0.55rem;
+}
+
+#deck-sync-status {
+  min-height: 1.1rem;
+  margin: 0.65rem 0 0;
+}
+
+#deck-sync-status[data-state="ready"] {
+  color: var(--success);
+}
+
+#deck-sync-status[data-state="working"] {
+  color: var(--accent-strong);
+}
+
+.deck-pages {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
+#deck-page-tabs {
+  display: flex;
+  gap: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.deck-page-tab {
+  padding: 0.4rem 0.9rem;
+  cursor: pointer;
+  color: var(--muted);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.deck-page-tab[data-active="true"] {
+  color: #151b1f;
+  border-color: var(--accent);
+  background: var(--accent);
+}
+
+.deck-page-settings {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  margin-top: 0.9rem;
+  font-size: 0.8rem;
+}
+
+.deck-page-settings select {
+  width: 4.2rem;
+  min-height: 2.35rem;
+}
+
+.deck-grid {
+  display: grid;
+  grid-template-columns: repeat(var(--deck-cols, 3), minmax(0, 96px));
+  gap: 0.55rem;
+  justify-content: start;
+  margin-top: 1.1rem;
+}
+
+.deck-key {
+  position: relative;
+  display: grid;
+  overflow: hidden;
+  aspect-ratio: 1;
+  padding: 0.3rem;
+  cursor: pointer;
+  place-items: center;
+  color: var(--ink);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--surface-strong);
+}
+
+.deck-key img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.deck-key span {
+  z-index: 1;
+  max-width: 100%;
+  overflow: hidden;
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.65);
+  white-space: nowrap;
+}
+
+.deck-key[data-badge]::after {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.4rem;
+  content: attr(data-badge);
+  color: var(--accent-strong);
+  font-size: 0.7rem;
+}
+
+.deck-key[data-selected="true"] {
+  border-color: var(--accent);
+  outline: 2px solid rgba(255, 173, 34, 0.4);
+  outline-offset: 2px;
+}
+
+.deck-key-editor {
+  margin-top: 1.2rem;
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background: rgba(11, 17, 22, 0.48);
+}
+
+.deck-key-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 0.8rem;
+  margin-top: 0.7rem;
+}
+
+.deck-key-fields label {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.deck-key-fields input[type="color"] {
+  min-height: 2.55rem;
+  padding: 0.2rem;
+}
+
+.deck-key-fields input[type="file"] {
+  padding: 0.5rem 0.85rem;
+  font-size: 0.75rem;
+}
+
+.deck-key-actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
 .progress-group {
   margin-top: 1rem;
 }

--- a/desktop/src/updater.js
+++ b/desktop/src/updater.js
@@ -50,7 +50,7 @@ function createUpdater({ onDownloaded, sendStatus }) {
 
     return autoUpdater.checkForUpdatesAndNotify({
       title: 'Stream32 update ready',
-      body: 'Restart Stream32 from the tray menu to install it.',
+      body: 'Choose Restart to update in Stream32 or from the tray menu.',
     });
   }
 

--- a/desktop/test/actions.test.js
+++ b/desktop/test/actions.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  linuxInvocation,
+  macInvocation,
+  windowsKeyLine,
+} = require('../src/actions');
+const { canonicalKeyFromCode } = require('../src/keymap');
+
+test('maps media commands to extended Windows virtual keys', () => {
+  assert.equal(
+    windowsKeyLine({ type: 'media', command: 'play-pause' }),
+    '179e',
+  );
+  assert.equal(windowsKeyLine({ type: 'media', command: 'mute' }), '173e');
+});
+
+test('maps hotkeys to ordered Windows key sequences', () => {
+  assert.equal(
+    windowsKeyLine({
+      type: 'hotkey',
+      key: 'F5',
+      ctrl: true,
+      shift: true,
+      alt: false,
+      meta: false,
+    }),
+    '17 16 116',
+  );
+  assert.equal(
+    windowsKeyLine({ type: 'hotkey', key: 'Up', meta: true }),
+    '91 38e',
+  );
+});
+
+test('maps actions to Linux and macOS invocations', () => {
+  assert.deepEqual(linuxInvocation({ type: 'media', command: 'volume-up' }), {
+    command: 'pactl',
+    args: ['set-sink-volume', '@DEFAULT_SINK@', '+5%'],
+  });
+  assert.deepEqual(linuxInvocation({ type: 'media', command: 'next' }), {
+    command: 'playerctl',
+    args: ['next'],
+  });
+  assert.deepEqual(
+    linuxInvocation({ type: 'hotkey', key: 'A', ctrl: true, shift: true }),
+    { command: 'xdotool', args: ['key', '--clearmodifiers', 'ctrl+shift+a'] },
+  );
+
+  assert.deepEqual(macInvocation({ type: 'hotkey', key: 'A', meta: true }), {
+    command: 'osascript',
+    args: [
+      '-e',
+      'tell application "System Events" to keystroke "a" using {command down}',
+    ],
+  });
+  assert.deepEqual(macInvocation({ type: 'hotkey', key: 'F5', ctrl: true }), {
+    command: 'osascript',
+    args: [
+      '-e',
+      'tell application "System Events" to key code 96 using {control down}',
+    ],
+  });
+  assert.throws(
+    () => macInvocation({ type: 'media', command: 'play-pause' }),
+    /not supported on macOS/,
+  );
+});
+
+test('canonicalizes KeyboardEvent codes for hotkey capture', () => {
+  assert.equal(canonicalKeyFromCode('KeyA'), 'A');
+  assert.equal(canonicalKeyFromCode('Digit7'), '7');
+  assert.equal(canonicalKeyFromCode('F11'), 'F11');
+  assert.equal(canonicalKeyFromCode('ArrowLeft'), 'Left');
+  assert.equal(canonicalKeyFromCode('Comma'), 'Comma');
+  assert.equal(canonicalKeyFromCode('ControlLeft'), null);
+  assert.equal(canonicalKeyFromCode('MetaRight'), null);
+});

--- a/desktop/test/boards.test.js
+++ b/desktop/test/boards.test.js
@@ -68,6 +68,27 @@ test('validates catalog compatibility and rejects hostile asset names', () => {
   assert.throws(() => validateCatalog(hostile, '0.1.0'), /unsafe/);
 });
 
+test('applies and validates optional per-board deck limits', () => {
+  const image = Buffer.from([0xe9, 1, 2, 3]);
+
+  assert.deepEqual(
+    validateCatalog(catalogFor(image), '0.1.0').boards[0].deck,
+    { maxCols: 5, maxPages: 8, maxRows: 5 },
+  );
+  assert.deepEqual(
+    validateCatalog(
+      catalogFor(image, { deck: { maxRows: 4, maxCols: 3, maxPages: 2 } }),
+      '0.1.0',
+    ).boards[0].deck,
+    { maxCols: 3, maxPages: 2, maxRows: 4 },
+  );
+  assert.throws(
+    () =>
+      validateCatalog(catalogFor(image, { deck: { maxRows: 99 } }), '0.1.0'),
+    /deck maxRows/,
+  );
+});
+
 test('downloads from the fixed release base, verifies, and caches firmware', async () => {
   const directory = mkdtempSync(path.join(os.tmpdir(), 'stream32-boards-'));
   const image = Buffer.from([0xe9, 0xaa, 0xbb, 0xcc, 0xdd]);

--- a/desktop/test/deck-store.test.js
+++ b/desktop/test/deck-store.test.js
@@ -1,0 +1,176 @@
+const assert = require('node:assert/strict');
+const { mkdtempSync, rmSync } = require('node:fs');
+const { tmpdir } = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  MAX_DEVICES,
+  createDefaultProfile,
+  exportProfile,
+  importProfile,
+  readDecks,
+  saveDeviceProfile,
+  validateProfile,
+} = require('../src/deck-store');
+
+const BOARD_ID = 'waveshare-esp32-s3-touch-lcd-4-v3';
+const DEVICE_ID = 'aabbccddeeff';
+const TINY_PNG =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+function sampleProfile() {
+  return {
+    name: 'Desk deck',
+    boardId: BOARD_ID,
+    activePage: 1,
+    keyPx: { '3x3': 150 },
+    pages: [
+      {
+        name: 'Main',
+        rows: 3,
+        cols: 3,
+        keys: [
+          {
+            index: 0,
+            label: 'OBS',
+            color: '#ff5533',
+            image: TINY_PNG,
+            action: { type: 'launch', command: 'obs' },
+          },
+          { index: 8, action: { type: 'page', page: 1 } },
+        ],
+      },
+      {
+        name: 'Media',
+        rows: 2,
+        cols: 2,
+        keys: [
+          { index: 0, action: { type: 'media', command: 'play-pause' } },
+          {
+            index: 1,
+            action: { type: 'hotkey', key: 'F5', ctrl: true, shift: true },
+          },
+          { index: 2, action: { type: 'url', url: 'https://stream32.dev' } },
+          { index: 3, action: { type: 'page', page: 0 } },
+        ],
+      },
+    ],
+  };
+}
+
+test('validates a full multi-page profile', () => {
+  const validated = validateProfile(sampleProfile());
+
+  assert.equal(validated.pages.length, 2);
+  assert.equal(validated.activePage, 1);
+  assert.equal(validated.keyPx['3x3'], 150);
+  assert.deepEqual(validated.pages[1].keys[1].action, {
+    type: 'hotkey',
+    key: 'F5',
+    alt: false,
+    ctrl: true,
+    meta: false,
+    shift: true,
+  });
+});
+
+test('rejects invalid profiles', () => {
+  assert.throws(
+    () => validateProfile({ boardId: BOARD_ID, pages: [] }),
+    /1-8 pages/,
+  );
+
+  const badAction = sampleProfile();
+  badAction.pages[0].keys[0].action = { type: 'sql-injection' };
+  assert.throws(() => validateProfile(badAction), /Unknown action type/);
+
+  const badPageTarget = sampleProfile();
+  badPageTarget.pages[0].keys[1].action = { type: 'page', page: 7 };
+  assert.throws(() => validateProfile(badPageTarget), /Action page/);
+
+  const badUrl = sampleProfile();
+  badUrl.pages[1].keys[2].action = { type: 'url', url: 'file:///etc/passwd' };
+  assert.throws(() => validateProfile(badUrl), /http or https/);
+
+  const badImage = sampleProfile();
+  badImage.pages[0].keys[0].image = 'data:text/html;base64,PGh0bWw+';
+  assert.throws(() => validateProfile(badImage), /Key image/);
+
+  const duplicateKeys = sampleProfile();
+  duplicateKeys.pages[0].keys = [{ index: 0 }, { index: 0 }];
+  assert.throws(() => validateProfile(duplicateKeys), /unique indexes/);
+});
+
+test('persists, reloads, and caps the registry', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'stream32-decks-'));
+  const decksPath = path.join(directory, 'decks.json');
+
+  try {
+    saveDeviceProfile(DEVICE_ID, sampleProfile(), decksPath);
+    const registry = readDecks(decksPath);
+
+    assert.deepEqual(Object.keys(registry.devices), [DEVICE_ID]);
+    assert.equal(registry.devices[DEVICE_ID].name, 'Desk deck');
+
+    assert.throws(
+      () => saveDeviceProfile('nope', sampleProfile(), decksPath),
+      /Device id/,
+    );
+
+    for (let index = 1; index < MAX_DEVICES; index++) {
+      saveDeviceProfile(
+        `aabbccddee${index.toString(16).padStart(2, '0')}`,
+        createDefaultProfile(BOARD_ID),
+        decksPath,
+      );
+    }
+
+    assert.throws(
+      () =>
+        saveDeviceProfile(
+          'ffffffffffff',
+          createDefaultProfile(BOARD_ID),
+          decksPath,
+        ),
+      /devices are supported/,
+    );
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test('drops corrupt registry entries instead of failing', () => {
+  const directory = mkdtempSync(path.join(tmpdir(), 'stream32-decks-'));
+  const decksPath = path.join(directory, 'decks.json');
+
+  try {
+    saveDeviceProfile(DEVICE_ID, sampleProfile(), decksPath);
+
+    const { writeSettings, readSettings } = require('../src/settings');
+    const raw = readSettings(decksPath);
+    raw.devices['000000000001'] = { boardId: BOARD_ID, pages: 'garbage' };
+    raw.devices['not a device id'] = createDefaultProfile(BOARD_ID);
+    writeSettings(raw, decksPath);
+
+    assert.deepEqual(Object.keys(readDecks(decksPath).devices), [DEVICE_ID]);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test('round-trips export and import and rejects malformed files', () => {
+  const exported = exportProfile(sampleProfile());
+  const imported = importProfile(exported);
+
+  assert.deepEqual(imported, validateProfile(sampleProfile()));
+  assert.throws(() => importProfile('not json'), /not valid JSON/);
+  assert.throws(
+    () => importProfile('{"stream32Deck":99,"profile":{}}'),
+    /unsupported format/,
+  );
+  assert.throws(
+    () => importProfile(JSON.stringify({ stream32Deck: 1, profile: {} })),
+    /board id/,
+  );
+});

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -3,10 +3,18 @@ const test = require('node:test');
 
 const {
   MAX_PROTOCOL_LINE_LENGTH,
+  crc32,
   createLineDecoder,
   encodeHostHello,
+  encodeImageChunks,
+  encodeLayoutMessage,
+  encodePageMessage,
   isExpectedChip,
   validateDeviceHello,
+  validateImageAck,
+  validateLayoutAck,
+  validatePageMessage,
+  validatePressMessage,
   validateTouchMessage,
 } = require('../src/renderer/protocol');
 
@@ -78,6 +86,162 @@ test('validates device identity and rejects the wrong board', () => {
         '0.2.0',
       ),
     /expected 0.2.0/,
+  );
+});
+
+test('computes standard zlib CRC-32 hex digests', () => {
+  // Reference vectors for CRC-32/ISO-HDLC, the polynomial used by
+  // esp_rom_crc32_le(0, …) on the device.
+  assert.equal(crc32(new TextEncoder().encode('123456789')), 'cbf43926');
+  assert.equal(crc32(new Uint8Array(0)), '00000000');
+  assert.equal(crc32(new Uint8Array([0xff, 0x00, 0xff])), '6cdb0272');
+});
+
+test('encodes layout pages and rejects invalid keys', () => {
+  const line = new TextDecoder().decode(
+    encodeLayoutMessage({
+      page: 0,
+      of: 2,
+      rows: 2,
+      cols: 3,
+      keys: [
+        { index: 0, label: 'OBS', color: '#ff5533', imageCrc: 'deadbeef' },
+        { index: 5, goPage: 1 },
+      ],
+    }),
+  );
+
+  assert.deepEqual(JSON.parse(line), {
+    type: 'layout',
+    page: 0,
+    of: 2,
+    rows: 2,
+    cols: 3,
+    keys: [
+      { index: 0, label: 'OBS', color: '#ff5533', imageCrc: 'deadbeef' },
+      { index: 5, goPage: 1 },
+    ],
+  });
+  assert.throws(
+    () =>
+      encodeLayoutMessage({
+        page: 0,
+        of: 1,
+        rows: 2,
+        cols: 2,
+        keys: [{ index: 4 }],
+      }),
+    /outside the supported range/,
+  );
+  assert.throws(
+    () =>
+      encodeLayoutMessage({
+        page: 0,
+        of: 1,
+        rows: 2,
+        cols: 2,
+        keys: [{ index: 0, color: 'red' }],
+      }),
+    /color/,
+  );
+  assert.throws(
+    () =>
+      encodeLayoutMessage({
+        page: 1,
+        of: 1,
+        rows: 2,
+        cols: 2,
+        keys: [],
+      }),
+    /inconsistent/,
+  );
+});
+
+test('chunks images under the protocol line limit', () => {
+  const pixels = new Uint8Array(96 * 96 * 2).fill(0xa5);
+  const chunks = encodeImageChunks({
+    page: 1,
+    index: 3,
+    width: 96,
+    height: 96,
+    pixels,
+  });
+
+  assert.equal(chunks.length, Math.ceil(pixels.length / 2688));
+
+  let reassembled = new Uint8Array(0);
+
+  for (const [seq, chunk] of chunks.entries()) {
+    assert.ok(chunk.length <= MAX_PROTOCOL_LINE_LENGTH);
+
+    const message = JSON.parse(new TextDecoder().decode(chunk));
+    assert.equal(message.type, 'image');
+    assert.equal(message.page, 1);
+    assert.equal(message.index, 3);
+    assert.equal(message.seq, seq);
+    assert.equal(message.of, chunks.length);
+
+    const raw = Uint8Array.from(atob(message.data), (c) => c.charCodeAt(0));
+    const merged = new Uint8Array(reassembled.length + raw.length);
+    merged.set(reassembled);
+    merged.set(raw, reassembled.length);
+    reassembled = merged;
+  }
+
+  assert.deepEqual(reassembled, pixels);
+  assert.throws(
+    () =>
+      encodeImageChunks({
+        page: 0,
+        index: 0,
+        width: 8,
+        height: 8,
+        pixels: new Uint8Array(3),
+      }),
+    /RGB565/,
+  );
+});
+
+test('validates deck acknowledgements and events', () => {
+  assert.deepEqual(
+    validateLayoutAck({
+      type: 'layout-ack',
+      page: 0,
+      rows: 3,
+      cols: 3,
+      keyPx: 150,
+      needImages: [0, 8],
+    }),
+    { page: 0, rows: 3, cols: 3, keyPx: 150, needImages: [0, 8] },
+  );
+  assert.throws(
+    () =>
+      validateLayoutAck({
+        page: 0,
+        rows: 3,
+        cols: 3,
+        keyPx: 150,
+        needImages: [9],
+      }),
+    /needImages/,
+  );
+  assert.deepEqual(validateImageAck({ page: 0, index: 4, seq: 2 }), {
+    page: 0,
+    index: 4,
+    seq: 2,
+  });
+  assert.deepEqual(
+    new TextDecoder().decode(encodePageMessage(2)),
+    '{"type":"page","index":2}\n',
+  );
+  assert.deepEqual(validatePageMessage({ index: 1 }), { index: 1 });
+  assert.deepEqual(
+    validatePressMessage({ page: 1, index: 7, phase: 'down' }),
+    { page: 1, index: 7, phase: 'down' },
+  );
+  assert.throws(
+    () => validatePressMessage({ page: 0, index: 0, phase: 'held' }),
+    /invalid/,
   );
 });
 


### PR DESCRIPTION
## What

Adds the initial Stream32 deck experience end to end:

**Desktop**
- Deck editor with a device picker (per-unit profiles keyed by the MAC-derived `deviceId`), page tabs (up to 8 pages, each 1-5 x 1-5 keys), and a key editor for label, color, artwork, and actions: media control, open URL, launch app/command, keyboard hotkey (capture field), and go-to-page.
- Multi-session serial support: every authorized Stream32 connects concurrently; presses route per device.
- Sync engine: layouts push after each handshake; artwork renders at the device-reported `keyPx`, converts to RGB565, and streams base64-chunked with per-chunk acks. CRC-32 reconciliation means a steady-state reconnect streams nothing.
- Profile export/import as validated JSON files; deck profiles persist in `userData/decks.json`.
- In-app "Restart to update" flow for downloaded updates (separate commit).

**Firmware (Waveshare Rev3, 0.2.0)**
- Protocol-1 additive deck messages: `layout` / `layout-ack` (`keyPx` + `needImages`), `image` / `image-ack`, `page`, `press`.
- LVGL key grid with streamed artwork; `goPage` keys switch pages locally, so navigation works standalone.
- New `deck` flash partition: page layout sectors plus a CRC-keyed 64 KB image slot pool (dedup across pages, GC after full sync, header-written-last crash safety). Decks survive power loss and render without a host.
- Board profiles can declare deck grid/page limits (`deck` block in `board.json`, catalog schema unchanged).

## Testing

- `npm run check` and `npm test` (36 tests) pass in `desktop/`: protocol codecs + CRC vectors, deck store validation and export/import round-trip, action key-sequence mappings, board deck-limit validation.
- `node boards/tools/build-catalog.js --validate-only` passes.
- Firmware compiles via Board CI on this PR (no local ESP-IDF).

## Notes for review

- `boards/README.md` documents the new protocol messages.
- `minimumDesktopVersion` stays 0.1.0: firmware 0.2.0 remains compatible with older desktops (hello/ping/touch unchanged); older firmware answers `unknown-type` and the desktop shows a reflash hint.
