### PR TITLE
Fix icon rendering on device and desktop

### DIFF
--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -19,9 +19,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.2.2",
+    "version": "0.2.3",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.2.2.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.2.3.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.2.2")
+set(PROJECT_VER "0.2.3")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v3)

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/deck_ui.c
@@ -244,6 +244,7 @@ static void build_page(uint8_t page_index)
             origin_y + row * (key_px + DECK_KEY_GAP)
         );
         lv_obj_set_style_radius(cell, 14, LV_PART_MAIN);
+        lv_obj_set_style_clip_corner(cell, true, LV_PART_MAIN);
         lv_obj_set_style_border_width(cell, 2, LV_PART_MAIN);
         lv_obj_set_style_border_color(
             cell,

--- a/desktop/src/renderer/deck.js
+++ b/desktop/src/renderer/deck.js
@@ -1155,6 +1155,7 @@ class DeckController {
         image.src = key.image;
         image.alt = '';
         cell.append(image);
+        cell.dataset.hasImage = 'true';
       }
 
       if (key?.label) {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -715,6 +715,10 @@ input:disabled {
   white-space: nowrap;
 }
 
+.deck-key[data-has-image="true"] span {
+  align-self: end;
+}
+
 .deck-key[data-badge]::after {
   position: absolute;
   top: 0.25rem;


### PR DESCRIPTION
## Summary
- clip full-size icon artwork to rounded Waveshare key cells
- publish Waveshare firmware metadata as 0.2.3
- bottom-align Electron key labels when icon artwork is present

## Validation
- `node boards/tools/build-catalog.js --validate-only`
- `npm ci`
- `npm test` (38 passed)
- `npm run check`
- live Electron smoke: icon label moved to bottom, label-only stayed centered, removing icon re-centered label

## Notes
- local ESP-IDF is unavailable on this Windows host; Board CI uses the required ESP-IDF 5.4.4 build
- no Waveshare device was connected for a hardware smoke test