### PR TITLE
ci(boards): build affected firmware only

### DIFF
--- a/.github/workflows/ci-boards.yml
+++ b/.github/workflows/ci-boards.yml
@@ -23,9 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.boards.outputs.matrix }}
+      has_boards: ${{ steps.boards.outputs.has_boards }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -35,13 +38,33 @@ jobs:
       - name: Validate board profiles
         run: node boards/tools/build-catalog.js --validate-only
 
+      - name: Test board tooling
+        run: node --test boards/tools/*.test.js
+
       - name: Discover firmware projects
         id: boards
-        run: echo "matrix=$(node boards/tools/build-catalog.js --matrix)" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ -z "$BASE_SHA" ] || [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            matrix="$(node boards/tools/build-catalog.js --matrix)"
+          else
+            matrix="$(
+              git diff --name-only "$BASE_SHA" "$GITHUB_SHA" |
+                node boards/tools/build-catalog.js --matrix --changed-stdin
+            )"
+          fi
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          if jq -e '.include | length > 0' <<< "$matrix" >/dev/null; then
+            echo "has_boards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_boards=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build ${{ matrix.id }}
     needs: validate
+    if: needs.validate.outputs.has_boards == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -67,7 +90,13 @@ jobs:
 
   catalog:
     name: Assemble release catalog
-    needs: build
+    needs:
+      - validate
+      - build
+    if: >-
+      always() &&
+      needs.validate.outputs.has_boards == 'true' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -85,8 +114,23 @@ jobs:
           path: boards/dist
           merge-multiple: true
 
+      - name: Download current board catalog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release download boards-current
+          --pattern catalog-v1.json
+          --output "${RUNNER_TEMP}/previous-catalog-v1.json"
+          || true
+
       - name: Generate release catalog
-        run: node boards/tools/build-catalog.js
+        run: |
+          if [ -f "${RUNNER_TEMP}/previous-catalog-v1.json" ]; then
+            node boards/tools/build-catalog.js \
+              --previous-catalog "${RUNNER_TEMP}/previous-catalog-v1.json"
+          else
+            node boards/tools/build-catalog.js
+          fi
 
       - name: Upload board bundle
         uses: actions/upload-artifact@v7

--- a/.github/workflows/release-boards.yml
+++ b/.github/workflows/release-boards.yml
@@ -22,9 +22,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.boards.outputs.matrix }}
+      has_boards: ${{ steps.boards.outputs.has_boards }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: Set up Node.js
         uses: actions/setup-node@v7
@@ -34,13 +37,35 @@ jobs:
       - name: Validate board profiles
         run: node boards/tools/build-catalog.js --validate-only
 
+      - name: Test board tooling
+        run: node --test boards/tools/*.test.js
+
       - name: Discover firmware projects
         id: boards
-        run: echo "matrix=$(node boards/tools/build-catalog.js --matrix)" >> "$GITHUB_OUTPUT"
+        env:
+          BASE_SHA: ${{ github.event.before }}
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ] ||
+             [ -z "$BASE_SHA" ] ||
+             [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            matrix="$(node boards/tools/build-catalog.js --matrix)"
+          else
+            matrix="$(
+              git diff --name-only "$BASE_SHA" "$GITHUB_SHA" |
+                node boards/tools/build-catalog.js --matrix --changed-stdin
+            )"
+          fi
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+          if jq -e '.include | length > 0' <<< "$matrix" >/dev/null; then
+            echo "has_boards=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_boards=false" >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build ${{ matrix.id }}
     needs: validate
+    if: needs.validate.outputs.has_boards == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -66,7 +91,13 @@ jobs:
 
   publish:
     name: Publish board catalog
-    needs: build
+    needs:
+      - validate
+      - build
+    if: >-
+      always() &&
+      needs.validate.outputs.has_boards == 'true' &&
+      needs.build.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -84,8 +115,23 @@ jobs:
           path: boards/dist
           merge-multiple: true
 
+      - name: Download current board catalog
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release download boards-current
+          --pattern catalog-v1.json
+          --output "${RUNNER_TEMP}/previous-catalog-v1.json"
+          || true
+
       - name: Generate catalog and checksums
-        run: node boards/tools/build-catalog.js
+        run: |
+          if [ -f "${RUNNER_TEMP}/previous-catalog-v1.json" ]; then
+            node boards/tools/build-catalog.js \
+              --previous-catalog "${RUNNER_TEMP}/previous-catalog-v1.json"
+          else
+            node boards/tools/build-catalog.js
+          fi
 
       - name: Enforce immutable firmware versions
         env:

--- a/boards/tools/build-catalog.js
+++ b/boards/tools/build-catalog.js
@@ -8,11 +8,17 @@ const {
 } = require('node:fs');
 const path = require('node:path');
 
+const {
+  reusePublishedImage,
+  selectAffectedProfiles,
+} = require('./catalog-helpers');
+
 const boardsDirectory = path.resolve(__dirname, '..');
 const sourceCatalogPath = path.join(boardsDirectory, 'catalog.json');
 const outputDirectory = path.join(boardsDirectory, 'dist');
 const validateOnly = process.argv.includes('--validate-only');
 const matrixOnly = process.argv.includes('--matrix');
+const changedStdin = process.argv.includes('--changed-stdin');
 const BOARD_ID_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const PROFILE_PATH_PATTERN = /^[a-z0-9][a-z0-9./-]+\.json$/;
 const IMAGE_NAME_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}\.bin$/;
@@ -35,6 +41,22 @@ function readJson(filePath) {
   } catch (error) {
     fail(`Could not read ${filePath}: ${error.message}`);
   }
+}
+
+function argumentValue(flag) {
+  const index = process.argv.indexOf(flag);
+
+  if (index < 0) {
+    return null;
+  }
+
+  const value = process.argv[index + 1];
+
+  if (!value || value.startsWith('--')) {
+    fail(`${flag} requires a file path.`);
+  }
+
+  return value;
 }
 
 function requireString(value, field) {
@@ -291,9 +313,16 @@ const profiles = sourceCatalog.boards.map((relativeProfilePath) => {
 });
 
 if (matrixOnly) {
+  const matrixProfiles = changedStdin
+    ? selectAffectedProfiles(
+        profiles,
+        readFileSync(0, 'utf8').split(/\r?\n/),
+      )
+    : profiles;
+
   console.log(
     JSON.stringify({
-      include: profiles.map((profile) => ({
+      include: matrixProfiles.map((profile) => ({
         id: profile.id,
         path: path.posix.join(
           'boards',
@@ -312,20 +341,37 @@ if (validateOnly) {
   process.exit(0);
 }
 
+const previousCatalogPath = argumentValue('--previous-catalog');
+const previousCatalog = previousCatalogPath
+  ? readJson(path.resolve(previousCatalogPath))
+  : null;
+
 const boards = profiles.map((profile) => {
   const imagePath = path.join(outputDirectory, profile.firmware.imageName);
+  let imageMetadata;
 
-  if (!existsSync(imagePath)) {
-    fail(`Built firmware image is missing: ${imagePath}`);
-  }
+  if (existsSync(imagePath)) {
+    const image = readFileSync(imagePath);
+    const size = statSync(imagePath).size;
+    const hash = createHash('sha256').update(image).digest('hex');
+    const { bootOffset } = SUPPORTED_CHIPS.get(profile.chip);
 
-  const image = readFileSync(imagePath);
-  const size = statSync(imagePath).size;
-  const hash = createHash('sha256').update(image).digest('hex');
-  const { bootOffset } = SUPPORTED_CHIPS.get(profile.chip);
+    if (image[bootOffset] !== 0xe9) {
+      fail(`${imagePath} is not an Espressif boot image.`);
+    }
 
-  if (image[bootOffset] !== 0xe9) {
-    fail(`${imagePath} is not an Espressif boot image.`);
+    imageMetadata = {
+      assetName: profile.firmware.imageName,
+      offset: profile.firmware.offset,
+      size,
+      sha256: hash,
+    };
+  } else {
+    try {
+      imageMetadata = reusePublishedImage(profile, previousCatalog);
+    } catch (error) {
+      fail(`Built firmware image is missing: ${imagePath}. ${error.message}`);
+    }
   }
 
   return {
@@ -342,14 +388,7 @@ const boards = profiles.map((profile) => {
     recoveryInstructions: profile.recoveryInstructions,
     firmware: {
       version: profile.firmware.version,
-      images: [
-        {
-          assetName: profile.firmware.imageName,
-          offset: profile.firmware.offset,
-          size,
-          sha256: hash,
-        },
-      ],
+      images: [imageMetadata],
     },
   };
 });

--- a/boards/tools/catalog-helpers.js
+++ b/boards/tools/catalog-helpers.js
@@ -1,0 +1,110 @@
+const path = require('node:path');
+
+const HASH_PATTERN = /^[a-f0-9]{64}$/;
+const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
+const BUILD_ALL_PATHS = new Set([
+  '.github/workflows/ci-boards.yml',
+  '.github/workflows/release-boards.yml',
+  'boards/catalog.json',
+]);
+
+function normalizeChangedPath(filePath) {
+  return String(filePath).trim().replaceAll('\\', '/').replace(/^\.\//, '');
+}
+
+function selectAffectedProfiles(profiles, changedFiles) {
+  const files = changedFiles.map(normalizeChangedPath).filter(Boolean);
+
+  if (
+    files.some(
+      (filePath) =>
+        BUILD_ALL_PATHS.has(filePath) ||
+        filePath.startsWith('boards/common/') ||
+        filePath.startsWith('boards/tools/'),
+    )
+  ) {
+    return profiles;
+  }
+
+  const knownBoardDirectories = new Map(
+    profiles.map((profile) => [
+      path.posix.dirname(profile.sourcePath),
+      profile,
+    ]),
+  );
+  const affected = new Set();
+
+  for (const filePath of files) {
+    if (!filePath.startsWith('boards/') || filePath === 'boards/README.md') {
+      continue;
+    }
+
+    const relativePath = filePath.slice('boards/'.length);
+    const boardDirectory = relativePath.split('/')[0];
+    const profile = knownBoardDirectories.get(boardDirectory);
+
+    if (!profile) {
+      // Unknown board/tooling paths may affect catalog behavior. Build all
+      // known boards rather than silently under-testing the change.
+      return profiles;
+    }
+
+    affected.add(profile);
+  }
+
+  return profiles.filter((profile) => affected.has(profile));
+}
+
+function reusePublishedImage(profile, previousCatalog) {
+  if (
+    !previousCatalog ||
+    previousCatalog.schemaVersion !== 1 ||
+    !Array.isArray(previousCatalog.boards)
+  ) {
+    throw new Error('A valid previous catalog is required for unchanged firmware.');
+  }
+
+  const board = previousCatalog.boards.find((entry) => entry.id === profile.id);
+
+  if (
+    !board ||
+    board.firmware?.version !== profile.firmware.version ||
+    !Array.isArray(board.firmware.images)
+  ) {
+    throw new Error(
+      `Previous catalog has no matching firmware for ${profile.id} ` +
+        `${profile.firmware.version}.`,
+    );
+  }
+
+  const image = board.firmware.images.find(
+    (entry) =>
+      entry.assetName === profile.firmware.imageName &&
+      entry.offset === profile.firmware.offset,
+  );
+
+  if (
+    !image ||
+    !Number.isSafeInteger(image.size) ||
+    image.size < 1 ||
+    image.size > MAX_IMAGE_BYTES ||
+    typeof image.sha256 !== 'string' ||
+    !HASH_PATTERN.test(image.sha256)
+  ) {
+    throw new Error(
+      `Previous catalog image metadata does not match ${profile.id}.`,
+    );
+  }
+
+  return {
+    assetName: image.assetName,
+    offset: image.offset,
+    sha256: image.sha256,
+    size: image.size,
+  };
+}
+
+module.exports = {
+  reusePublishedImage,
+  selectAffectedProfiles,
+};

--- a/boards/tools/catalog-helpers.test.js
+++ b/boards/tools/catalog-helpers.test.js
@@ -1,0 +1,147 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  reusePublishedImage,
+  selectAffectedProfiles,
+} = require('./catalog-helpers');
+
+const waveshare = {
+  id: 'waveshare',
+  sourcePath: 'waveshare/board.json',
+  firmware: {
+    imageName: 'waveshare-1.0.0.bin',
+    offset: 0,
+    version: '1.0.0',
+  },
+};
+const elecrow = {
+  id: 'elecrow',
+  sourcePath: 'elecrow/board.json',
+  firmware: {
+    imageName: 'elecrow-2.0.0.bin',
+    offset: 0,
+    version: '2.0.0',
+  },
+};
+const profiles = [waveshare, elecrow];
+
+test('selects only the board whose profile or firmware changed', () => {
+  assert.deepEqual(
+    selectAffectedProfiles(profiles, [
+      'boards/elecrow/firmware/main/main.c',
+    ]),
+    [elecrow],
+  );
+  assert.deepEqual(
+    selectAffectedProfiles(profiles, ['boards/waveshare/board.json']),
+    [waveshare],
+  );
+});
+
+test('selects every board for shared code, tooling, catalog, or workflows', () => {
+  for (const changedPath of [
+    'boards/common/components/deck/deck_ui.c',
+    'boards/tools/build-catalog.js',
+    'boards/catalog.json',
+    '.github/workflows/ci-boards.yml',
+  ]) {
+    assert.deepEqual(selectAffectedProfiles(profiles, [changedPath]), profiles);
+  }
+});
+
+test('selects no firmware for documentation-only changes', () => {
+  assert.deepEqual(
+    selectAffectedProfiles(profiles, ['boards/README.md', 'README.md']),
+    [],
+  );
+});
+
+test('fails safe when an unknown board path changes', () => {
+  assert.deepEqual(
+    selectAffectedProfiles(profiles, ['boards/new-board/firmware/main.c']),
+    profiles,
+  );
+});
+
+test('reuses only exact, validated previous image metadata', () => {
+  const previousCatalog = {
+    schemaVersion: 1,
+    boards: [
+      {
+        id: 'elecrow',
+        firmware: {
+          version: '2.0.0',
+          images: [
+            {
+              assetName: 'elecrow-2.0.0.bin',
+              offset: 0,
+              sha256: 'a'.repeat(64),
+              size: 123456,
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  assert.deepEqual(reusePublishedImage(elecrow, previousCatalog), {
+    assetName: 'elecrow-2.0.0.bin',
+    offset: 0,
+    sha256: 'a'.repeat(64),
+    size: 123456,
+  });
+  assert.throws(
+    () =>
+      reusePublishedImage(
+        {
+          ...elecrow,
+          firmware: { ...elecrow.firmware, version: '2.0.1' },
+        },
+        previousCatalog,
+      ),
+    /no matching firmware/,
+  );
+  assert.throws(
+    () =>
+      reusePublishedImage(elecrow, {
+        ...previousCatalog,
+        boards: [
+          {
+            ...previousCatalog.boards[0],
+            firmware: {
+              ...previousCatalog.boards[0].firmware,
+              images: [
+                {
+                  ...previousCatalog.boards[0].firmware.images[0],
+                  sha256: 'unsafe',
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    /does not match/,
+  );
+  assert.throws(
+    () =>
+      reusePublishedImage(elecrow, {
+        ...previousCatalog,
+        boards: [
+          {
+            ...previousCatalog.boards[0],
+            firmware: {
+              ...previousCatalog.boards[0].firmware,
+              images: [
+                {
+                  ...previousCatalog.boards[0].firmware.images[0],
+                  size: 33 * 1024 * 1024,
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    /does not match/,
+  );
+});


### PR DESCRIPTION
## Summary
- select board build matrices from changed paths
- skip firmware jobs for documentation-only changes
- build every board for shared code, catalog, tooling, or workflow changes
- reuse exact validated metadata from the current catalog for unchanged firmware
- run board tooling tests in CI and publishing workflows

## Verification
- node --test boards/tools/*.test.js
- node boards/tools/build-catalog.js --validate-only
- verified single-board, shared-code, and docs-only matrices
- parsed both workflow files as YAML
- git diff --check

Made with [Cursor](https://cursor.com)