### PR TITLE
fix(board): poll CrowPanel touch input

### DIFF
--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.2",
+    "version": "0.1.3",
     "projectPath": "firmware",
-    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.1.2.bin",
+    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.1.3.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.1.2")
+set(PROJECT_VER "0.1.3")
 project(stream32_elecrow_crowpanel_advanced_10_1_esp32_p4)

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/components/elecrow_bsp/elecrow_bsp.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/components/elecrow_bsp/elecrow_bsp.c
@@ -253,7 +253,7 @@ lv_display_t *bsp_display_start(void)
         .task_priority = 4,
         .task_stack = 16384,
         .task_affinity = -1,
-        .task_max_sleep_ms = 500,
+        .task_max_sleep_ms = 20,
         .timer_period_ms = 5,
     };
 
@@ -325,11 +325,20 @@ lv_display_t *bsp_display_start(void)
         .handle = s_touch,
     };
 
-    if (lvgl_port_add_touch(&touch_config) == NULL) {
+    lv_indev_t *touch = lvgl_port_add_touch(&touch_config);
+
+    if (touch == NULL) {
         ESP_LOGW(TAG, "Could not register touch with LVGL");
         s_status = "display-ready-no-touch";
         return display;
     }
+
+    /* The GT911 edge can be lost after display/flash traffic. Keep the
+       interrupt wake-up, but poll often enough that one missed edge cannot
+       leave the panel unresponsive. */
+    lvgl_port_lock(0);
+    lv_indev_set_mode(touch, LV_INDEV_MODE_TIMER);
+    lvgl_port_unlock();
 
     s_status = "display-ready";
     return display;


### PR DESCRIPTION
## Summary
- keep the CrowPanel GT911 interrupt wake-up
- switch LVGL input to timer polling with a 20 ms sleep bound
- publish CrowPanel firmware 0.1.3

## Verification
- ESP-IDF 5.4.4 firmware build passed
- flashed merged 0.1.3 image successfully on COM6
- firmware 0.1.3 handshake confirmed
- board catalog validation passed
- board tooling tests passed

## Known result
The board remained protocol-responsive, but the live touch retest still emitted zero touch events. This version is not claimed to fully resolve the reported click issue.

Made with [Cursor](https://cursor.com)