### PR TITLE
Add pure touch polling and manual deck connection

### DIFF
--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.3",
+    "version": "0.1.4",
     "projectPath": "firmware",
-    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.1.3.bin",
+    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.1.4.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.1.3")
+set(PROJECT_VER "0.1.4")
 project(stream32_elecrow_crowpanel_advanced_10_1_esp32_p4)

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/components/elecrow_bsp/elecrow_bsp.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/components/elecrow_bsp/elecrow_bsp.c
@@ -15,6 +15,7 @@
 #include "esp_lcd_mipi_dsi.h"
 #include "esp_lcd_panel_io.h"
 #include "esp_lcd_panel_ops.h"
+#include "esp_lcd_touch.h"
 #include "esp_lcd_touch_gt911.h"
 #include "esp_ldo_regulator.h"
 #include "esp_log.h"
@@ -333,12 +334,16 @@ lv_display_t *bsp_display_start(void)
         return display;
     }
 
-    /* The GT911 edge can be lost after display/flash traffic. Keep the
-       interrupt wake-up, but poll often enough that one missed edge cannot
-       leave the panel unresponsive. */
-    lvgl_port_lock(0);
-    lv_indev_set_mode(touch, LV_INDEV_MODE_TIMER);
-    lvgl_port_unlock();
+    /* ponytail: use one 15 ms polling path instead of mixing the GT911's
+       100 Hz interrupt wake-up with LVGL's timer reads. Revisit event mode
+       only with a driver that cannot lose or duplicate readiness edges. */
+    if (esp_lcd_touch_register_interrupt_callback(s_touch, NULL) == ESP_OK) {
+        lvgl_port_lock(0);
+        lv_indev_set_mode(touch, LV_INDEV_MODE_TIMER);
+        lvgl_port_unlock();
+    } else {
+        ESP_LOGW(TAG, "Could not disable touch interrupt; using event mode");
+    }
 
     s_status = "display-ready";
     return display;

--- a/desktop/src/renderer/deck.js
+++ b/desktop/src/renderer/deck.js
@@ -69,6 +69,7 @@ class DeckController {
     this.selectedPage = 0;
     this.selectedKey = null;
 
+    this.connectPanel = document.querySelector('#deck-connect');
     this.deviceSelect = document.querySelector('#deck-device');
     this.deviceStatus = document.querySelector('#deck-device-status');
     this.deviceName = document.querySelector('#deck-device-name');
@@ -1014,6 +1015,12 @@ class DeckController {
     this.renderSyncStatus();
   }
 
+  setManualConnectionHidden(hidden) {
+    this.connectPanel.dataset.hidden = String(hidden);
+    this.connectPanel.inert = hidden;
+    this.connectPanel.setAttribute('aria-hidden', String(hidden));
+  }
+
   renderDevicePicker() {
     const deviceIds = Object.keys(this.devices);
     this.deviceSelect.replaceChildren();
@@ -1031,6 +1038,7 @@ class DeckController {
 
     if (!hasDevices) {
       this.selectedDeviceId = null;
+      this.setManualConnectionHidden(false);
       return;
     }
 
@@ -1042,12 +1050,12 @@ class DeckController {
 
     const profile = this.selectedProfile();
     this.deviceName.value = profile.name;
-    this.deviceStatus.textContent = this.sessions.has(this.selectedDeviceId)
+    const connected = this.sessions.has(this.selectedDeviceId);
+    this.deviceStatus.textContent = connected
       ? 'Connected'
       : 'Offline';
-    this.deviceStatus.dataset.state = this.sessions.has(this.selectedDeviceId)
-      ? 'ready'
-      : 'idle';
+    this.deviceStatus.dataset.state = connected ? 'ready' : 'idle';
+    this.setManualConnectionHidden(connected);
   }
 
   renderPages() {

--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -13,6 +13,8 @@ const HELLO_RETRY_MS = 1000;
 const RECONNECT_ATTEMPTS = 8;
 const RECONNECT_DELAY_MS = 750;
 const MAX_LOG_LINES = 80;
+const MANUAL_CONNECTION_HELP =
+  'If auto-connect misses your deck, choose its USB / COM port.';
 
 function sleep(milliseconds) {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
@@ -46,7 +48,7 @@ class DeviceController {
     this.selectedPort = null;
     this.selectedPortBoardId = null;
     this.serialPortRequestId = null;
-    this.usbPortListEmpty = false;
+    this.serialPortListEmpty = false;
     this.sessions = new Map();
 
     this.boardSelect = document.querySelector('#board-select');
@@ -54,6 +56,9 @@ class DeviceController {
     this.catalogStatus = document.querySelector('#catalog-status');
     this.confirmRevision = document.querySelector('#confirm-revision');
     this.confirmationBoard = document.querySelector('#confirmation-board');
+    this.deckConnectButton = document.querySelector('#deck-connect-device');
+    this.deckPortSelect = document.querySelector('#deck-port-select');
+    this.deckPortStatus = document.querySelector('#deck-port-status');
     this.deviceStatus = document.querySelector('#device-status');
     this.firmwareVersion = document.querySelector('#firmware-version');
     this.flashButton = document.querySelector('#flash-device');
@@ -72,6 +77,19 @@ class DeviceController {
   }
 
   async initialize() {
+    this.deckConnectButton.addEventListener('click', () => {
+      if (this.operation === 'deck-select') {
+        this.cancelSerialPortSelection();
+      } else {
+        this.connectSelectedDevice();
+      }
+    });
+    this.deckPortSelect.addEventListener('change', () =>
+      this.confirmSerialPortSelection(),
+    );
+    this.deck?.deviceSelect.addEventListener('change', () =>
+      this.resetDeckPortStatus(),
+    );
     this.boardSelect.addEventListener('change', () => {
       this.confirmRevision.checked = false;
       this.clearUsbSelection();
@@ -79,13 +97,13 @@ class DeviceController {
     });
     this.refreshUsbButton.addEventListener('click', () => {
       if (this.operation === 'usb-select') {
-        this.cancelUsbPortSelection();
+        this.cancelSerialPortSelection();
       } else {
         this.selectUsbPort();
       }
     });
     this.usbPortSelect.addEventListener('change', () =>
-      this.confirmUsbPortSelection(),
+      this.confirmSerialPortSelection(),
     );
     this.confirmRevision.addEventListener('change', () =>
       this.updateFlashButton(),
@@ -120,7 +138,7 @@ class DeviceController {
         : `Downloading firmware… ${percent}%`;
     });
     this.api.onSerialPortList((request) => {
-      this.showUsbPorts(request);
+      this.showSerialPorts(request);
     });
 
     if (!this.serial) {
@@ -129,6 +147,8 @@ class DeviceController {
         'error',
       );
       this.flashButton.disabled = true;
+      this.deckConnectButton.disabled = true;
+      this.deckPortSelect.disabled = true;
       this.refreshUsbButton.disabled = true;
       this.usbPortSelect.disabled = true;
       this.reconnectButton.disabled = true;
@@ -193,6 +213,8 @@ class DeviceController {
     this.operation = operation;
     this.busy = operation === 'flash';
     this.boardSelect.disabled = true;
+    this.deckConnectButton.disabled = true;
+    this.deckPortSelect.disabled = true;
     this.refreshUsbButton.disabled = true;
     this.usbPortSelect.disabled = true;
     this.refreshButton.disabled = true;
@@ -210,6 +232,10 @@ class DeviceController {
     this.operation = null;
     this.busy = false;
     this.boardSelect.disabled = false;
+    this.deckConnectButton.disabled = !this.serial;
+    this.deckConnectButton.textContent = 'Connect COM port';
+    this.deckPortSelect.disabled = true;
+    this.deckPortSelect.hidden = true;
     this.refreshUsbButton.disabled =
       !this.serial || !this.selectedBoard();
     this.refreshUsbButton.textContent = 'Refresh ports';
@@ -225,11 +251,20 @@ class DeviceController {
   }
 
   setUsbPortDisplay(message) {
+    this.setPortDisplay(this.usbPortSelect, message);
+  }
+
+  setPortDisplay(select, message) {
     const option = this.document.createElement('option');
     option.value = '';
     option.textContent = message;
-    this.usbPortSelect.replaceChildren(option);
-    this.usbPortSelect.disabled = true;
+    select.replaceChildren(option);
+    select.disabled = true;
+  }
+
+  resetDeckPortStatus() {
+    this.deckPortStatus.textContent = MANUAL_CONNECTION_HELP;
+    this.deckPortStatus.dataset.state = 'idle';
   }
 
   clearUsbSelection(message = 'No USB or COM port selected.') {
@@ -241,7 +276,27 @@ class DeviceController {
     this.updateFlashButton();
   }
 
-  showUsbPorts(request) {
+  serialPortControls() {
+    if (this.operation === 'deck-select') {
+      return {
+        button: this.deckConnectButton,
+        select: this.deckPortSelect,
+        status: this.deckPortStatus,
+      };
+    }
+
+    if (this.operation === 'usb-select') {
+      return {
+        button: this.refreshUsbButton,
+        select: this.usbPortSelect,
+        status: this.usbPortStatus,
+      };
+    }
+
+    return null;
+  }
+
+  showSerialPorts(request) {
     if (
       !Number.isSafeInteger(request?.requestId) ||
       !Array.isArray(request.ports)
@@ -249,26 +304,31 @@ class DeviceController {
       return;
     }
 
-    if (this.operation !== 'usb-select') {
+    const controls = this.serialPortControls();
+
+    if (!controls) {
       this.api.selectSerialPort(request.requestId, '').catch(console.error);
       return;
     }
 
+    const { button, select, status } = controls;
     this.serialPortRequestId = request.requestId;
-    this.usbPortListEmpty = request.ports.length === 0;
-    this.usbPortSelect.replaceChildren();
+    this.serialPortListEmpty = request.ports.length === 0;
+    status.dataset.state = 'idle';
+    select.replaceChildren();
+    select.hidden = false;
 
     const placeholder = this.document.createElement('option');
     placeholder.value = '';
-    placeholder.textContent = this.usbPortListEmpty
+    placeholder.textContent = this.serialPortListEmpty
       ? 'No USB / COM ports found'
       : 'Select a USB / COM port';
-    placeholder.disabled = !this.usbPortListEmpty;
+    placeholder.disabled = !this.serialPortListEmpty;
     placeholder.selected = true;
-    this.usbPortSelect.append(placeholder);
+    select.append(placeholder);
 
-    if (this.usbPortListEmpty) {
-      this.usbPortStatus.textContent = 'No USB / COM ports found.';
+    if (this.serialPortListEmpty) {
+      status.textContent = 'No USB / COM ports found.';
       this.api.selectSerialPort(request.requestId, '').catch(console.error);
       return;
     }
@@ -277,29 +337,31 @@ class DeviceController {
       const option = this.document.createElement('option');
       option.value = port.id;
       option.textContent = port.label;
-      this.usbPortSelect.append(option);
+      select.append(option);
     }
 
-    this.usbPortSelect.disabled = false;
-    this.usbPortStatus.textContent =
+    select.disabled = false;
+    status.textContent =
       `${request.ports.length} USB / COM ` +
       `${request.ports.length === 1 ? 'port' : 'ports'} found.`;
-    this.refreshUsbButton.textContent = 'Cancel';
-    this.refreshUsbButton.disabled = false;
-    this.usbPortSelect.focus();
+    button.textContent = 'Cancel';
+    button.disabled = false;
+    select.focus();
   }
 
-  async confirmUsbPortSelection() {
-    const portId = this.usbPortSelect.value;
+  async confirmSerialPortSelection() {
+    const operation = this.operation;
+    const controls = this.serialPortControls();
+    const portId = controls?.select.value;
 
-    if (!this.serialPortRequestId || !portId) {
+    if (!controls || !this.serialPortRequestId || !portId) {
       return;
     }
 
-    this.usbPortSelect.disabled = true;
-    this.refreshUsbButton.disabled = true;
-    this.usbPortStatus.textContent =
-      `Selecting ${this.usbPortSelect.selectedOptions[0].textContent}…`;
+    controls.select.disabled = true;
+    controls.button.disabled = true;
+    controls.status.textContent =
+      `Selecting ${controls.select.selectedOptions[0].textContent}…`;
 
     try {
       const accepted = await this.api.selectSerialPort(
@@ -311,24 +373,31 @@ class DeviceController {
         throw new Error('The serial port list expired. Refresh and try again.');
       }
     } catch (error) {
-      this.clearUsbSelection(`Could not select USB/COM: ${errorMessage(error)}`);
-      this.endOperation('usb-select');
+      controls.status.textContent =
+        `Could not select USB/COM: ${errorMessage(error)}`;
+      controls.status.dataset.state = 'error';
+      this.endOperation(operation);
     }
   }
 
-  async cancelUsbPortSelection() {
-    if (!this.serialPortRequestId) {
+  async cancelSerialPortSelection() {
+    const operation = this.operation;
+    const controls = this.serialPortControls();
+
+    if (!controls || !this.serialPortRequestId) {
       return;
     }
 
-    this.usbPortSelect.disabled = true;
-    this.refreshUsbButton.disabled = true;
+    controls.select.disabled = true;
+    controls.button.disabled = true;
 
     try {
       await this.api.selectSerialPort(this.serialPortRequestId, '');
     } catch (error) {
-      this.clearUsbSelection(`Could not cancel USB/COM: ${errorMessage(error)}`);
-      this.endOperation('usb-select');
+      controls.status.textContent =
+        `Could not cancel USB/COM: ${errorMessage(error)}`;
+      controls.status.dataset.state = 'error';
+      this.endOperation(operation);
     }
   }
 
@@ -344,7 +413,7 @@ class DeviceController {
     }
 
     this.serialPortRequestId = null;
-    this.usbPortListEmpty = false;
+    this.serialPortListEmpty = false;
     this.setUsbPortDisplay('Scanning for USB / COM ports…');
     this.usbPortStatus.textContent = 'Scanning for USB / COM ports…';
     this.refreshUsbButton.textContent = 'Scanning…';
@@ -374,7 +443,7 @@ class DeviceController {
     } catch (error) {
       this.clearUsbSelection(
         error?.name === 'NotFoundError'
-          ? this.usbPortListEmpty
+          ? this.serialPortListEmpty
             ? 'No USB / COM ports found.'
             : 'USB/COM selection cancelled.'
           : `Could not select USB/COM: ${errorMessage(error)}`,
@@ -382,6 +451,47 @@ class DeviceController {
     } finally {
       this.serialPortRequestId = null;
       this.endOperation('usb-select');
+    }
+  }
+
+  async connectSelectedDevice() {
+    if (!this.serial || !this.beginOperation('deck-select')) {
+      return;
+    }
+
+    this.serialPortRequestId = null;
+    this.serialPortListEmpty = false;
+    this.setPortDisplay(
+      this.deckPortSelect,
+      'Scanning for USB / COM ports…',
+    );
+    this.deckPortSelect.hidden = false;
+    this.deckPortStatus.textContent = 'Scanning for USB / COM ports…';
+    this.deckPortStatus.dataset.state = 'idle';
+    this.deckConnectButton.textContent = 'Scanning…';
+
+    try {
+      // requestPort must stay in this click handler's call chain so Chromium
+      // preserves user activation while Electron renders the inline list.
+      const port = await this.serial.requestPort();
+      const selectedLabel =
+        this.deckPortSelect.selectedOptions[0]?.textContent || 'Serial port';
+      this.deckPortSelect.disabled = true;
+      this.deckConnectButton.disabled = true;
+      this.deckPortStatus.textContent = `Connecting to ${selectedLabel}…`;
+      await this.openSession(port, null);
+      this.resetDeckPortStatus();
+    } catch (error) {
+      const cancelled = error?.name === 'NotFoundError';
+      this.deckPortStatus.textContent = cancelled
+        ? this.serialPortListEmpty
+          ? 'No USB / COM ports found.'
+          : 'USB/COM selection cancelled.'
+        : `Could not connect: ${errorMessage(error)}`;
+      this.deckPortStatus.dataset.state = cancelled ? 'idle' : 'error';
+    } finally {
+      this.serialPortRequestId = null;
+      this.endOperation('deck-select');
     }
   }
 

--- a/desktop/src/renderer/index.html
+++ b/desktop/src/renderer/index.html
@@ -48,6 +48,34 @@
 
       <div class="content">
         <section id="view-deck" class="view view-deck" aria-label="Deck">
+          <div id="deck-connect" class="usb-picker deck-connect">
+            <div class="usb-port-field">
+              <label class="field-label" for="deck-port-select">
+                Manual connection
+              </label>
+              <select id="deck-port-select" disabled hidden>
+                <option value="">Choose a USB / COM port</option>
+              </select>
+              <p
+                id="deck-port-status"
+                class="helper"
+                data-state="idle"
+                aria-live="polite"
+              >
+                If auto-connect misses your deck, choose its USB / COM port.
+              </p>
+            </div>
+            <div class="usb-actions">
+              <button
+                id="deck-connect-device"
+                class="button button-secondary"
+                type="button"
+              >
+                Connect COM port
+              </button>
+            </div>
+          </div>
+
           <div id="deck-empty" class="deck-empty">
             <p class="kicker">Deck</p>
             <h2>No Stream32 deck yet</h2>

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -488,6 +488,33 @@ input:disabled {
   text-align: center;
 }
 
+.deck-connect {
+  max-height: 10rem;
+  margin: 0 0 1rem;
+  overflow: hidden;
+  opacity: 1;
+  transform: translateY(0);
+  transition:
+    max-height 240ms ease,
+    margin 240ms ease,
+    padding-top 240ms ease,
+    padding-bottom 240ms ease,
+    border-width 240ms ease,
+    opacity 160ms ease,
+    transform 220ms ease;
+}
+
+.deck-connect[data-hidden="true"] {
+  max-height: 0;
+  margin: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  pointer-events: none;
+  border-width: 0;
+  opacity: 0;
+  transform: translateY(-0.5rem);
+}
+
 .deck-empty h2 {
   font-size: 1.6rem;
 }

--- a/desktop/test/deck.test.js
+++ b/desktop/test/deck.test.js
@@ -1,0 +1,49 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { DeckController } = require('../src/renderer/deck');
+
+test('manual connection visibility follows the selected deck only', () => {
+  const controller = Object.create(DeckController.prototype);
+  const attributes = {};
+
+  controller.connectPanel = {
+    dataset: {},
+    inert: false,
+    setAttribute(name, value) {
+      attributes[name] = value;
+    },
+  };
+  controller.deviceSelect = {
+    append() {},
+    replaceChildren() {},
+  };
+  controller.deviceStatus = { dataset: {} };
+  controller.deviceName = {};
+  controller.emptyState = {};
+  controller.editorPanel = {};
+  controller.document = {
+    createElement: () => ({}),
+  };
+  controller.devices = {
+    aaaa11112222: { name: 'Connected deck' },
+    bbbb33334444: { name: 'Offline deck' },
+  };
+  controller.sessions = new Map([['aaaa11112222', {}]]);
+  controller.selectedDeviceId = 'aaaa11112222';
+
+  controller.renderDevicePicker();
+
+  assert.equal(controller.deviceStatus.textContent, 'Connected');
+  assert.equal(controller.connectPanel.dataset.hidden, 'true');
+  assert.equal(controller.connectPanel.inert, true);
+  assert.equal(attributes['aria-hidden'], 'true');
+
+  controller.selectedDeviceId = 'bbbb33334444';
+  controller.renderDevicePicker();
+
+  assert.equal(controller.deviceStatus.textContent, 'Offline');
+  assert.equal(controller.connectPanel.dataset.hidden, 'false');
+  assert.equal(controller.connectPanel.inert, false);
+  assert.equal(attributes['aria-hidden'], 'false');
+});

--- a/desktop/test/device.test.js
+++ b/desktop/test/device.test.js
@@ -1,0 +1,54 @@
+const assert = require('node:assert/strict');
+const Module = require('node:module');
+const test = require('node:test');
+
+const loadModule = Module._load;
+Module._load = function loadWithoutEsptool(request, ...arguments_) {
+  return request === 'esptool-js'
+    ? { ESPLoader: class {}, Transport: class {} }
+    : loadModule.call(this, request, ...arguments_);
+};
+const { DeviceController } = require('../src/renderer/device');
+Module._load = loadModule;
+
+test('connects a manually selected COM port to the deck session', async () => {
+  const port = {};
+  const controller = Object.create(DeviceController.prototype);
+  const operations = [];
+  let opened;
+
+  controller.document = {
+    createElement: () => ({}),
+  };
+  controller.deckConnectButton = {};
+  controller.deckPortSelect = {
+    replaceChildren() {},
+    selectedOptions: [{ textContent: 'USB Serial Device (COM7)' }],
+  };
+  controller.deckPortStatus = { dataset: {} };
+  controller.serial = {
+    requestPort: async () => port,
+  };
+  controller.beginOperation = (operation) => {
+    controller.operation = operation;
+    operations.push(`begin:${operation}`);
+    return true;
+  };
+  controller.endOperation = (operation) => {
+    operations.push(`end:${operation}`);
+    controller.operation = null;
+  };
+  controller.openSession = async (...arguments_) => {
+    opened = arguments_;
+  };
+
+  await controller.connectSelectedDevice();
+
+  assert.deepEqual(opened, [port, null]);
+  assert.equal(
+    controller.deckPortStatus.textContent,
+    'If auto-connect misses your deck, choose its USB / COM port.',
+  );
+  assert.equal(controller.deckPortStatus.dataset.state, 'idle');
+  assert.deepEqual(operations, ['begin:deck-select', 'end:deck-select']);
+});


### PR DESCRIPTION
## Summary
- switch the CrowPanel GT911 integration to a single polling path
- publish CrowPanel firmware metadata for v0.1.4
- add manual USB / COM deck connection controls and tests

## Validation
- npm test
- npm run check
- node boards/tools/build-catalog.js --validate-only

Firmware was not built locally because ESP-IDF is unavailable in this environment; Board CI will build it.

Made with [Cursor](https://cursor.com)