### PR TITLE
feat: enable the CrowPanel's USB 2.0 port as a fast deck link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ including the USB and power requirements for each board.
 | Display | Screen | Deck size | Notes |
 | --- | --- | --- | --- |
 | Waveshare `ESP32-S3-Touch-LCD-4` | 480x480, 4" | up to 5x5, 8 pages | **Rev 3.0 only** (not Rev 4 or the 4.3" board) |
-| Elecrow `CrowPanel Advanced 10.1"` ESP32-P4 | 1024x600, 10.1" | up to 40 keys/page, 8 pages | UART0 carries power and data; USB 2.0 is optional supplemental power |
+| Elecrow `CrowPanel Advanced 10.1"` ESP32-P4 | 1024x600, 10.1" | up to 40 keys/page, 8 pages | UART0 carries power, data, and flashing; USB 2.0 adds power and a much faster sync link |
 
 Purchase links and buying tips are in [Buying a display](./boards/BUYING.md).
 Firmware, flashing, and the USB protocol are documented in

--- a/boards/BUYING.md
+++ b/boards/BUYING.md
@@ -47,16 +47,20 @@ sizes and chip variants, so choose carefully.
     "10.1" ESP32-P4 Display"). The 5", 7", 9", and ESP32-S3 variants are
     different devices.
   - Hardware revisions **1.0 to 1.2** are supported.
-- **Use the UART0 port.** One USB data cable connected to **UART0** normally
-  provides both power and data. The separate **USB 2.0** port can provide
-  supplemental power if the display is unstable on a power-limited USB port.
+- **Flash over the UART0 port.** One USB data cable connected to **UART0**
+  normally provides both power and data, and it is the only port that can
+  flash the board.
+- **Two cables are better.** The separate **USB 2.0** port steadies a panel on
+  a power-limited USB port, and Stream32 firmware also uses it as a native
+  USB link that syncs artwork far faster than the UART0 bridge.
 
 The on-board ESP32-C6 wireless module is not used by Stream32.
 
 ## What else you need
 
 - A **USB data cable** (not a charge-only cable). The Waveshare uses its USB-C
-  port; the CrowPanel uses the port labeled **UART0**.
+  port; the CrowPanel uses the port labeled **UART0**. A second data cable for
+  the CrowPanel's **USB 2.0** port is optional but recommended.
 - Nothing else is required to get started. Enclosures and stands are optional and
   up to you.
 

--- a/boards/README.md
+++ b/boards/README.md
@@ -37,13 +37,18 @@ Elecrow `CrowPanel Advanced 10.1"` (profile
   this firmware never touches)
 - ESP32-P4NRW32 (16 MB flash, 32 MB PSRAM), EK79007 1024×600 MIPI-DSI IPS
   panel, GT911 touch
-- Flashing and the Stream32 protocol both run through the on-board CH340K
-  USB-UART bridge on the port labeled `UART0`. Shipping hardware has been
-  observed as `USB-SERIAL CH340K` (`1a86:7522`, for example COM6); the profile
-  also retains `1a86:7523` for earlier documented CH340 variants. One UART0
-  connection normally supplies both power and data. The USB 2.0 port can
-  provide supplemental power when needed. The pre-installed ESP32-C6 radio
-  module is not used.
+- Flashing always runs through the on-board CH340K USB-UART bridge on the port
+  labeled `UART0`. Shipping hardware has been observed as `USB-SERIAL CH340K`
+  (`1a86:7522`, for example COM6); the profile also retains `1a86:7523` for
+  earlier documented CH340 variants. One UART0 connection normally supplies
+  both power and data. The pre-installed ESP32-C6 radio module is not used.
+- The port labeled `USB 2.0` is wired straight to the ESP32-P4's high-speed USB
+  PHY, and Elecrow's stock firmware leaves it unused. From firmware `0.2.0`
+  Stream32 enables it as a CDC-ACM link, so the same JSON protocol can run at
+  USB 2.0 speed instead of 115200 baud. It enumerates as
+  `Stream32 CrowPanel 10.1`, and its serial number is the board's device ID.
+  Connect both cables and pick that port for the deck; artwork sync is roughly
+  two orders of magnitude faster than over the bridge.
 
 The Espressif ROM reports the chip family, which the desktop verifies
 before erasing. The ROM cannot identify the attached display or PCB
@@ -78,12 +83,20 @@ saved layouts and artwork.
 For the CrowPanel, connect UART0 with a known-good USB data cable. Close serial
 monitors, install the current WCH CH340 driver if Windows does not expose the
 COM port reliably, and try a shorter cable or different direct USB port if the
-automatic 460800 fallback also fails. USB 2.0 can be connected as supplemental
-power if the display is unstable.
+automatic 460800 fallback also fails. Flashing never uses the USB 2.0 port: the
+P4's USB Serial/JTAG pins are taken by other functions on this board, so the
+bootloader is only reachable over UART0. Leaving USB 2.0 connected during a
+flash is fine and steadies a power-limited panel.
 
 ### Deck sync performance
 
-The runtime protocol stays at 115200 baud for compatibility. The previous slow
+Over a UART bridge the runtime protocol stays at 115200 baud for
+compatibility, which is the dominant cost of a cold sync: one 2688-byte image
+chunk needs about 320 ms of wire time, so a single 150 px key runs into
+seconds. A CrowPanel synced over its USB 2.0 port instead spends microseconds
+per chunk, and the remaining cost is the round trip for each `image-ack`.
+
+The previous slow
 path sent every rendered key as raw RGB565, base64-expanded and
 stop-and-wait, so a fully decorated 40-key CrowPanel page was dominated by
 image wire bytes. Firmware now advertises the additive `image-rle` feature.
@@ -125,10 +138,15 @@ New protocols, chips, or transports require corresponding desktop support.
 ## USB protocol v1
 
 Firmware and desktop exchange bounded newline-delimited JSON over the
-board's serial link (the ESP32-S3's native USB Serial/JTAG port, or the
-CrowPanel's CH340 UART0 bridge at a fixed 115200 baud). Image lines remain
-below 4096 bytes; the 40-key CrowPanel accepts up to 8192 bytes for its larger
-single-line layouts.
+board's serial link: the ESP32-S3's native USB Serial/JTAG port, or on the
+CrowPanel either its CH340 UART0 bridge at a fixed 115200 baud or its native
+USB 2.0 CDC link. Image lines remain below 4096 bytes; the 40-key CrowPanel
+accepts up to 8192 bytes for its larger single-line layouts.
+
+The framing is identical on every link, so a board that answers on two ports
+reports the same `deviceId` on both. Such firmware names its link in the hello
+`features` as `transport-usb` or `transport-uart`, and the desktop keeps one
+session per device on the highest-ranked link.
 
 Desktop messages:
 
@@ -243,8 +261,8 @@ storage decisions, and live-overlay pixel ownership in `deck_ui.c`.
 ## Flash recovery
 
 Use a USB data cable and close other serial monitors before flashing. Connect
-the CrowPanel through UART0; USB 2.0 is only needed as supplemental power if
-the display is unstable. If automatic bootloader entry fails:
+the CrowPanel through UART0; the USB 2.0 port cannot reach the bootloader.
+If automatic bootloader entry fails:
 
 1. Disconnect power.
 2. Hold **BOOT** while reconnecting USB, then release **BOOT**.

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -26,20 +26,21 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.9",
+    "version": "0.2.0",
     "projectPath": "firmware",
-    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.1.9.bin",
+    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.2.0.bin",
     "offset": 0
   },
   "capabilities": [
     "display",
     "brightness",
     "touch",
-    "usb-uart-bridge"
+    "usb-uart-bridge",
+    "usb-cdc"
   ],
   "recoveryInstructions": [
-    "Use the USB port labeled UART0, slide POWER to ON, and close other serial monitors.",
-    "UART0 normally supplies both power and data; connect USB 2.0 only as supplemental power if the display is unstable.",
+    "Flashing always runs over the USB port labeled UART0: slide POWER to ON and close other serial monitors.",
+    "Firmware 0.2.0 and later also serve the deck over the USB 2.0 port. Connect both cables, then pick the 'Stream32 CrowPanel 10.1' port to sync far faster than the UART0 bridge.",
     "Hold BOOT, press and release RST, then release BOOT to enter download mode.",
     "If 921600 baud is unstable, the desktop automatically restarts the complete write once at 460800 baud.",
     "Leave Full erase off to preserve saved decks; enable it only for slow, destructive troubleshooting.",

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.1.9")
+set(PROJECT_VER "0.2.0")
 project(stream32_elecrow_crowpanel_advanced_10_1_esp32_p4)

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/CMakeLists.txt
@@ -6,6 +6,7 @@ idf_component_register(
         esp_app_format
         esp_driver_uart
         esp_hw_support
+        esp_tinyusb
         json
         stream32_deck
 )

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/idf_component.yml
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/idf_component.yml
@@ -7,6 +7,8 @@ dependencies:
     version: "1.1.2"
   espressif/esp_lvgl_port:
     version: "2.5.0"
+  espressif/esp_tinyusb:
+    version: "2.2.1"
   lvgl/lvgl:
     public: true
     version: "9.2.0"

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
@@ -15,8 +15,12 @@
 #include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "lvgl.h"
+#include "tinyusb.h"
+#include "tinyusb_cdc_acm.h"
+#include "tinyusb_default_config.h"
 
 #define STREAM32_BOARD_ID "elecrow-crowpanel-advanced-10-1-esp32-p4"
 #define STREAM32_PROTOCOL_VERSION 1
@@ -26,6 +30,16 @@
 #define STREAM32_UART_BAUD 115200
 #define STREAM32_UART_TX GPIO_NUM_37
 #define STREAM32_UART_RX GPIO_NUM_38
+/* The CrowPanel's second USB-C port wires D+/D- straight to the ESP32-P4's
+   USB 2.0 high-speed PHY (module pads 50/49), so CDC-ACM turns the port
+   Elecrow ships as power-only into a 480 Mbit/s protocol link. UART0 stays
+   live beside it: it is the only way to flash this board, and the desktop
+   holds it open across the manual post-flash reset. */
+#define STREAM32_USB_CDC TINYUSB_CDC_ACM_0
+#define STREAM32_USB_READ_CHUNK 512
+#define STREAM32_USB_WRITE_TIMEOUT_MS 100
+/* Safety net only: the CDC receive callback wakes the reader immediately. */
+#define STREAM32_USB_IDLE_POLL_MS 50
 /* This board advertises a 40-key page budget, so it accepts the extended
    8 KB layout line (the desktop's baseline for other messages is 4 KB). */
 #define STREAM32_LINE_CAPACITY 8192
@@ -33,17 +47,94 @@
 #define STREAM32_EVENT_LINE_CAPACITY 128
 #define STREAM32_REPLY_CAPACITY 384
 
+typedef enum {
+    STREAM32_LINK_UART = 0,
+    STREAM32_LINK_USB,
+} stream32_link_t;
+
+/* Per-transport assembler for newline-delimited JSON. */
+typedef struct {
+    stream32_link_t link;
+    char *buffer;
+    size_t capacity;
+    size_t length;
+    bool dropping_oversized_line;
+} line_reader_t;
+
 static const char *TAG = "stream32";
 static QueueHandle_t event_queue;
+/* Serializes dispatch and every physical write. deck_protocol keeps static
+   decode state and both transports share this file's reply buffer, so only
+   one link may be mid-message at a time. */
+static SemaphoreHandle_t protocol_mutex;
+/* The transport that delivered the last complete host line. Replies and
+   queued events follow it, so the desktop always hears back on the link it
+   is actually talking on. */
+static stream32_link_t active_link = STREAM32_LINK_UART;
 static lv_obj_t *connection_label;
 static lv_obj_t *touch_label;
 static lv_obj_t *touch_surface;
 static volatile bool system_ready;
+static TaskHandle_t usb_task;
+/* Filled from the efuse MAC before TinyUSB starts. */
+static char usb_serial_string[13];
+/* Index order is TinyUSB's default: language, manufacturer, product, serial,
+   CDC interface. Naming the device keeps the fast link tellable from the
+   CH340 bridge in the desktop's port list, and the per-board serial keeps two
+   panels on one host distinct. File scope: the language compound literal
+   needs static storage duration. */
+static const char *usb_strings[] = {
+    (const char[]){0x09, 0x04},
+    "Stream32",
+    "Stream32 CrowPanel 10.1",
+    usb_serial_string,
+    "Stream32 deck link",
+};
+
+static bool usb_flush(void)
+{
+    return tinyusb_cdcacm_write_flush(
+               STREAM32_USB_CDC,
+               pdMS_TO_TICKS(STREAM32_USB_WRITE_TIMEOUT_MS)
+           ) == ESP_OK;
+}
+
+/* Queues one span, flushing only when the TX FIFO fills so a whole line
+   normally costs a single USB transfer. Returns false once the host stops
+   draining, which abandons the line instead of stalling the protocol task. */
+static bool usb_queue_all(const char *data, size_t length)
+{
+    size_t written = 0;
+
+    while (written < length) {
+        written += tinyusb_cdcacm_write_queue(
+            STREAM32_USB_CDC,
+            (const uint8_t *)data + written,
+            length - written
+        );
+
+        if (written < length && !usb_flush()) {
+            return false;
+        }
+    }
+
+    return true;
+}
 
 static void serial_write_line(const char *json)
 {
+    const size_t length = strlen(json);
+
+    if (active_link == STREAM32_LINK_USB) {
+        if (usb_queue_all(json, length) && usb_queue_all("\n", 1)) {
+            (void)usb_flush();
+        }
+
+        return;
+    }
+
     /* uart_write_bytes blocks until the line fits the TX ring buffer. */
-    uart_write_bytes(STREAM32_UART, json, strlen(json));
+    uart_write_bytes(STREAM32_UART, json, length);
     uart_write_bytes(STREAM32_UART, "\n", 1);
 }
 
@@ -69,7 +160,7 @@ static void update_connection_label(const char *text)
 static void send_hello(void)
 {
     uint8_t mac[6];
-    char message[256];
+    char message[288];
     const esp_app_desc_t *app = esp_app_get_description();
 
     /* The ESP32-P4 has no radio; the efuse base MAC is its identity. */
@@ -80,7 +171,7 @@ static void send_hello(void)
         "{\"type\":\"hello\",\"protocol\":%d,\"boardId\":\"%s\","
         "\"firmwareVersion\":\"%s\",\"deviceId\":\"%02x%02x%02x%02x%02x%02x\","
         "\"features\":[\"display-control\",\"display-brightness\",\"display-blank\","
-        "\"key-update\",\"image-rle\"]}",
+        "\"key-update\",\"image-rle\",\"%s\"]}",
         STREAM32_PROTOCOL_VERSION,
         STREAM32_BOARD_ID,
         app->version,
@@ -89,7 +180,10 @@ static void send_hello(void)
         mac[2],
         mac[3],
         mac[4],
-        mac[5]
+        mac[5],
+        /* Both ports reach the same board, so the desktop needs to know
+           which link a session landed on to keep the faster one. */
+        active_link == STREAM32_LINK_USB ? "transport-usb" : "transport-uart"
     );
     serial_write_line(message);
 }
@@ -134,7 +228,11 @@ static void handle_host_message(const char *line, size_t length)
             send_error(bsp_display_status());
         } else {
             deck_protocol_clear_overlays();
-            update_connection_label("USB connected to Stream32");
+            update_connection_label(
+                active_link == STREAM32_LINK_USB
+                    ? "USB 2.0 connected to Stream32"
+                    : "UART0 connected to Stream32"
+            );
             send_hello();
         }
     } else if (strcmp(type->valuestring, "ping") == 0) {
@@ -175,6 +273,125 @@ static void handle_host_message(const char *line, size_t length)
     cJSON_Delete(message);
 }
 
+/* Feeds one transport's bytes into its assembler and dispatches whole lines
+   under the shared lock, so replies leave on the link they arrived from. */
+static void consume_bytes(
+    line_reader_t *reader,
+    const uint8_t *data,
+    size_t count
+)
+{
+    for (size_t index = 0; index < count; index++) {
+        const char byte = (char)data[index];
+
+        if (byte != '\n') {
+            if (byte != '\r' && !reader->dropping_oversized_line) {
+                if (reader->length < reader->capacity - 1) {
+                    reader->buffer[reader->length++] = byte;
+                } else {
+                    reader->dropping_oversized_line = true;
+                }
+            }
+
+            continue;
+        }
+
+        xSemaphoreTake(protocol_mutex, portMAX_DELAY);
+        active_link = reader->link;
+
+        if (reader->dropping_oversized_line) {
+            send_error("message-too-large");
+        } else if (reader->length > 0) {
+            handle_host_message(reader->buffer, reader->length);
+        }
+
+        xSemaphoreGive(protocol_mutex);
+        reader->length = 0;
+        reader->dropping_oversized_line = false;
+    }
+}
+
+static void usb_rx_event(int itf, cdcacm_event_t *event)
+{
+    (void)itf;
+    (void)event;
+
+    xTaskNotifyGive(usb_task);
+}
+
+static void usb_protocol_task(void *argument)
+{
+    /* TINYUSB_DEFAULT_CONFIG selects the high-speed port on the ESP32-P4,
+       which is the one the CrowPanel's USB 2.0 connector is wired to. */
+    tinyusb_config_t usb_config = TINYUSB_DEFAULT_CONFIG();
+    const tinyusb_config_cdcacm_t cdc_config = {
+        .cdc_port = STREAM32_USB_CDC,
+        .callback_rx = usb_rx_event,
+    };
+    uint8_t incoming[STREAM32_USB_READ_CHUNK];
+    uint8_t mac[6];
+    /* Static: an 8 KB line does not belong on the task stack. */
+    static char line[STREAM32_LINE_CAPACITY];
+    line_reader_t reader = {
+        .link = STREAM32_LINK_USB,
+        .buffer = line,
+        .capacity = sizeof(line),
+    };
+
+    (void)argument;
+    /* Published before the callback can fire so no notification is lost. */
+    usb_task = xTaskGetCurrentTaskHandle();
+    /* Same efuse base MAC the hello reports as deviceId. */
+    ESP_ERROR_CHECK(esp_read_mac(mac, ESP_MAC_BASE));
+    snprintf(
+        usb_serial_string,
+        sizeof(usb_serial_string),
+        "%02x%02x%02x%02x%02x%02x",
+        mac[0],
+        mac[1],
+        mac[2],
+        mac[3],
+        mac[4],
+        mac[5]
+    );
+    usb_config.descriptor.string = usb_strings;
+    usb_config.descriptor.string_count =
+        sizeof(usb_strings) / sizeof(usb_strings[0]);
+
+    esp_err_t status = tinyusb_driver_install(&usb_config);
+
+    if (status == ESP_OK) {
+        status = tinyusb_cdcacm_init(&cdc_config);
+    }
+
+    if (status != ESP_OK) {
+        /* UART0 still carries the protocol, so lose the fast link, not the
+           board. Nothing here may abort a panel that flashes over UART0.
+           A failed init registered no callback, so the handle stays set and
+           unused rather than becoming a NULL target for a stray notify. */
+        ESP_LOGW(TAG, "USB 2.0 link unavailable: %s", esp_err_to_name(status));
+        vTaskDelete(NULL);
+        return;
+    }
+
+    while (true) {
+        size_t received = 0;
+
+        if (tinyusb_cdcacm_read(
+                STREAM32_USB_CDC,
+                incoming,
+                sizeof(incoming),
+                &received
+            ) == ESP_OK &&
+            received > 0) {
+            consume_bytes(&reader, incoming, received);
+            continue;
+        }
+
+        (void)ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(STREAM32_USB_IDLE_POLL_MS));
+    }
+}
+
 static void serial_protocol_task(void *argument)
 {
     const uart_config_t config = {
@@ -186,10 +403,13 @@ static void serial_protocol_task(void *argument)
         .source_clk = UART_SCLK_DEFAULT,
     };
     uint8_t incoming[256];
-    /* Static: a 4 KB line does not belong on the task stack. */
+    /* Static: an 8 KB line does not belong on the task stack. */
     static char line[STREAM32_LINE_CAPACITY];
-    size_t line_length = 0;
-    bool dropping_oversized_line = false;
+    line_reader_t reader = {
+        .link = STREAM32_LINK_UART,
+        .buffer = line,
+        .capacity = sizeof(line),
+    };
 
     (void)argument;
     ESP_ERROR_CHECK(uart_driver_install(
@@ -219,25 +439,8 @@ static void serial_protocol_task(void *argument)
             pdMS_TO_TICKS(20)
         );
 
-        for (int index = 0; index < received; index++) {
-            const char byte = (char)incoming[index];
-
-            if (byte == '\n') {
-                if (dropping_oversized_line) {
-                    send_error("message-too-large");
-                } else if (line_length > 0) {
-                    handle_host_message(line, line_length);
-                }
-
-                line_length = 0;
-                dropping_oversized_line = false;
-            } else if (byte != '\r' && !dropping_oversized_line) {
-                if (line_length < sizeof(line) - 1) {
-                    line[line_length++] = byte;
-                } else {
-                    dropping_oversized_line = true;
-                }
-            }
+        if (received > 0) {
+            consume_bytes(&reader, incoming, (size_t)received);
         }
 
         deck_ui_poll();
@@ -245,7 +448,11 @@ static void serial_protocol_task(void *argument)
         char event_line[STREAM32_EVENT_LINE_CAPACITY];
 
         while (xQueueReceive(event_queue, event_line, 0) == pdTRUE) {
+            /* Touch and press events are the one writer outside dispatch, so
+               they take the same lock to stay off a half-written reply. */
+            xSemaphoreTake(protocol_mutex, portMAX_DELAY);
             serial_write_line(event_line);
+            xSemaphoreGive(protocol_mutex);
         }
     }
 }
@@ -365,9 +572,10 @@ static void create_self_test_ui(void)
 void app_main(void)
 {
     event_queue = xQueueCreate(24, STREAM32_EVENT_LINE_CAPACITY);
+    protocol_mutex = xSemaphoreCreateMutex();
 
-    if (event_queue == NULL) {
-        ESP_LOGE(TAG, "Could not allocate the event queue");
+    if (event_queue == NULL || protocol_mutex == NULL) {
+        ESP_LOGE(TAG, "Could not allocate the protocol primitives");
         return;
     }
 
@@ -386,6 +594,13 @@ void app_main(void)
     if (task_created != pdPASS) {
         ESP_LOGE(TAG, "Could not create the serial protocol task");
         return;
+    }
+
+    /* The fast link is optional: a board with nothing in its USB 2.0 port
+       keeps working over UART0, so a failure here is only logged. */
+    if (xTaskCreate(usb_protocol_task, "stream32_usb", 8192, NULL, 5, NULL) !=
+        pdPASS) {
+        ESP_LOGW(TAG, "Could not create the USB 2.0 protocol task");
     }
 
     lv_display_t *display = bsp_display_start();

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/sdkconfig.defaults
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/sdkconfig.defaults
@@ -17,6 +17,15 @@ CONFIG_APP_REPRODUCIBLE_BUILD=y
 # desktop tolerates that pre-handshake noise.
 CONFIG_ESP_CONSOLE_NONE=y
 
+# The USB 2.0 connector reaches the P4's high-speed PHY, so the same JSON
+# protocol also runs as CDC-ACM at 480 Mbit/s. esp_tinyusb 2.x picks that
+# port at run time (TINYUSB_DEFAULT_CONFIG), so only the class is set here.
+# EP_BUFSIZE dominates CDC throughput; RX must be at least that large.
+CONFIG_TINYUSB_CDC_ENABLED=y
+CONFIG_TINYUSB_CDC_EP_BUFSIZE=2048
+CONFIG_TINYUSB_CDC_RX_BUFSIZE=4096
+CONFIG_TINYUSB_CDC_TX_BUFSIZE=1024
+
 CONFIG_SPIRAM=y
 CONFIG_SPIRAM_MODE_HEX=y
 CONFIG_SPIRAM_SPEED_200M=y

--- a/boards/tools/deck-protocol-source.test.js
+++ b/boards/tools/deck-protocol-source.test.js
@@ -105,6 +105,48 @@ test('both board transports dispatch through the shared protocol module', () => 
   );
 });
 
+test('the CrowPanel serves both links without risking the flashing one', () => {
+  const main = read(
+    path.join(
+      ROOT,
+      'boards',
+      'elecrow-crowpanel-advanced-10-1-esp32-p4',
+      'firmware',
+      'main',
+      'main.c',
+    ),
+  );
+  const usbTask = main.slice(
+    main.indexOf('static void usb_protocol_task('),
+    main.indexOf('static void serial_protocol_task('),
+  );
+  const uartTask = main.slice(
+    main.indexOf('static void serial_protocol_task('),
+    main.indexOf('static void touch_event_handler('),
+  );
+
+  // One assembler for both links: line limits and the oversized-line reply
+  // cannot drift apart per transport.
+  assert.match(usbTask, /consume_bytes\(&reader/);
+  assert.match(uartTask, /consume_bytes\(&reader/);
+  assert.doesNotMatch(usbTask, /handle_host_message\(/);
+  assert.doesNotMatch(uartTask, /handle_host_message\(/);
+  assert.match(
+    main,
+    /xSemaphoreTake\(protocol_mutex[\s\S]*handle_host_message\([\s\S]*xSemaphoreGive\(protocol_mutex\)/,
+  );
+
+  // UART0 is the only way to flash this board and the link the desktop holds
+  // across a manual post-flash reset, so USB bring-up may never abort.
+  assert.doesNotMatch(usbTask, /ESP_ERROR_CHECK\(\s*tinyusb/);
+  assert.match(usbTask, /vTaskDelete\(NULL\)/);
+  assert.match(uartTask, /ESP_ERROR_CHECK\(uart_driver_install\(/);
+
+  // The desktop keeps one session per board by ranking the reported link.
+  assert.match(main, /"transport-usb" : "transport-uart"/);
+  assert.ok(main.split(/\r?\n/).length < 1000);
+});
+
 test('Sleep blanks through the idle wake path without changing lock state', () => {
   const blankDisplay = ui.slice(
     ui.indexOf('const char *deck_ui_blank_display('),

--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -5,6 +5,7 @@ const {
   encodeDisplayMessage,
   encodeHostHello,
   isExpectedChip,
+  transportRank,
   validateDeviceHello,
   validateTouchMessage,
 } = require('./protocol');
@@ -759,7 +760,9 @@ class DeviceController {
     let firmwareWritten = false;
 
     try {
-      await this.closeSessionForPort(port);
+      // A board can answer on more than one port, and the reset into the
+      // bootloader invalidates every session it holds.
+      await this.closeSessionsForBoard(board.id, port);
       await sleep(500);
       const firmware = await this.api.getBoardFirmware(board.id);
       const fullErase = this.fullErase.checked;
@@ -1130,6 +1133,23 @@ class DeviceController {
               );
             }
 
+            // A board with both a UART bridge and a native USB link answers
+            // on two ports. Keep one session per device, on the faster link,
+            // so sync never lands on the slow bridge by enumeration order.
+            const rival = this.sessionForDeviceId(hello.deviceId, session);
+
+            if (rival && transportRank(rival.hello) >= transportRank(hello)) {
+              throw new Error(
+                'This device is already connected on a faster port.',
+              );
+            }
+
+            if (rival) {
+              this.closeSessionForPort(rival.port).catch((error) => {
+                this.appendLog(`Protocol: ${errorMessage(error)}`);
+              });
+            }
+
             session.hello = hello;
             session.handshakeComplete = true;
             this.updateDeviceStatusSummary();
@@ -1244,6 +1264,18 @@ class DeviceController {
     }
   }
 
+  // Finds an established session for the same physical board, ignoring the
+  // caller's own session so a handshake never matches itself.
+  sessionForDeviceId(deviceId, exclude = null) {
+    for (const session of this.sessions.values()) {
+      if (session !== exclude && session.hello?.deviceId === deviceId) {
+        return session;
+      }
+    }
+
+    return null;
+  }
+
   async closeSessionForPort(port) {
     const session = this.sessions.get(port);
 
@@ -1281,6 +1313,16 @@ class DeviceController {
   async closeAllSessions() {
     for (const port of [...this.sessions.keys()]) {
       await this.closeSessionForPort(port);
+    }
+  }
+
+  async closeSessionsForBoard(boardId, flashPort) {
+    await this.closeSessionForPort(flashPort);
+
+    for (const [port, session] of [...this.sessions]) {
+      if (session.hello?.boardId === boardId) {
+        await this.closeSessionForPort(port);
+      }
     }
   }
 

--- a/desktop/src/renderer/protocol.js
+++ b/desktop/src/renderer/protocol.js
@@ -141,6 +141,24 @@ function validateDeviceHello(
   };
 }
 
+// A board can expose more than one port to the same host: the CrowPanel
+// answers on its CH340 UART0 bridge and, from firmware 0.2.0, on its native
+// USB 2.0 link. Both report the same deviceId, so sessions are ranked and
+// only the fastest is kept. Firmware that names no transport ranks lowest,
+// which leaves single-port boards on their existing link.
+const TRANSPORT_RANKS = new Map([
+  ['transport-usb', 2],
+  ['transport-uart', 1],
+]);
+
+function transportRank(hello) {
+  const ranks = (hello?.features || []).map(
+    (feature) => TRANSPORT_RANKS.get(feature) || 0,
+  );
+
+  return Math.max(0, ...ranks);
+}
+
 function validateTouchMessage(message) {
   if (
     !message ||
@@ -716,6 +734,7 @@ module.exports = {
   isExpectedChip,
   normalizeChipName,
   toRgb565,
+  transportRank,
   validateDeviceHello,
   validateImageAck,
   validateKeyUpdateAck,

--- a/desktop/test/device.test.js
+++ b/desktop/test/device.test.js
@@ -240,6 +240,7 @@ test('manual post-flash reset skips RTS and uses one 90-second session', async (
   controller.setDeviceStatus = (...arguments_) => statuses.push(arguments_);
   controller.appendLog = (message) => logs.push(message);
   controller.closeSessionForPort = async () => {};
+  controller.sessions = new Map();
   controller.api = {
     getBoardFirmware: async () => ({
       board: { ...board, preferredFlashBaud: 921600 },
@@ -312,6 +313,74 @@ test('one open session accepts a delayed hello after retrying', async () => {
 
   await controller.closeSessionForPort(port);
   assert.equal(port.state.closes, 1);
+});
+
+// A CrowPanel on firmware 0.2.0 answers on both its CH340 bridge and its
+// native USB 2.0 port, and reconnect opens every authorized port.
+function boardAnsweringOn(transport) {
+  const hello = new TextEncoder().encode(
+    `${JSON.stringify({
+      boardId: TEST_BOARD_ID,
+      deviceId: '0123456789ab',
+      features: ['image-rle', transport],
+      firmwareVersion: TEST_FIRMWARE_VERSION,
+      protocol: 1,
+      type: 'hello',
+    })}\n`,
+  );
+
+  return fakeProtocolPort(({ readableController }) => {
+    readableController.enqueue(hello);
+  });
+}
+
+async function settle(predicate) {
+  for (let attempt = 0; attempt < 200 && !predicate(); attempt++) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+
+  assert.ok(predicate(), 'the losing session never closed');
+}
+
+test('a second port on the same board hands over to the USB link', async () => {
+  const controller = protocolController();
+  const bridge = boardAnsweringOn('transport-uart');
+  const usb = boardAnsweringOn('transport-usb');
+
+  await controller.openSession(bridge, TEST_BOARD_ID, TEST_FIRMWARE_VERSION, 2000);
+  await controller.openSession(usb, TEST_BOARD_ID, TEST_FIRMWARE_VERSION, 2000);
+  await settle(() => bridge.state.closes === 1);
+
+  assert.deepEqual([...controller.sessions.keys()], [usb]);
+});
+
+test('a slower bridge port cannot displace the open USB session', async () => {
+  const controller = protocolController();
+  const usb = boardAnsweringOn('transport-usb');
+  const bridge = boardAnsweringOn('transport-uart');
+
+  await controller.openSession(usb, TEST_BOARD_ID, TEST_FIRMWARE_VERSION, 2000);
+  await assert.rejects(
+    controller.openSession(bridge, TEST_BOARD_ID, TEST_FIRMWARE_VERSION, 2000),
+    /already connected on a faster port/,
+  );
+
+  assert.deepEqual([...controller.sessions.keys()], [usb]);
+  assert.equal(bridge.state.closes, 1);
+});
+
+test('flashing releases every port the board answers on', async () => {
+  const controller = protocolController();
+  const usb = boardAnsweringOn('transport-usb');
+  const flashPort = {};
+
+  await controller.openSession(usb, TEST_BOARD_ID, TEST_FIRMWARE_VERSION, 2000);
+  // The reset into the bootloader kills the USB link too, so a session left
+  // open there would outrank the post-flash handshake on UART0.
+  await controller.closeSessionsForBoard(TEST_BOARD_ID, flashPort);
+
+  assert.equal(controller.sessions.size, 0);
+  assert.equal(usb.state.closes, 1);
 });
 
 test('handshake timeout closes the port and releases stream locks', async () => {

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -15,6 +15,7 @@ const {
   encodeRle565,
   isExpectedChip,
   layoutLineLimitFor,
+  transportRank,
   validateDeviceHello,
   validateImageAck,
   validateKeyUpdateAck,
@@ -658,4 +659,16 @@ test('validates touch bounds and chip names', () => {
   );
   assert.equal(isExpectedChip('ESP32-P4', 'ESP32-P4'), true);
   assert.equal(isExpectedChip('ESP32-C3', 'ESP32-S3'), false);
+});
+
+test('ranks a native USB link above a UART bridge', () => {
+  const rank = (features) => transportRank({ features });
+
+  assert.ok(rank(['image-rle', 'transport-usb']) > rank(['transport-uart']));
+  // Boards that name no transport must not outrank one that does, so a
+  // single-port board never displaces an established session.
+  assert.ok(rank(['transport-uart']) > rank(['image-rle']));
+  assert.equal(rank([]), 0);
+  assert.equal(transportRank(undefined), 0);
+  assert.equal(transportRank({}), 0);
 });

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -17,7 +17,7 @@ before flashing, because look-alike products are not interchangeable.
 | Display | Confirm before you flash | Power and data |
 | --- | --- | --- |
 | Waveshare `ESP32-S3-Touch-LCD-4` | Silkscreen reads **Rev 3.0** (not Rev 4, and not the 4.3" board) | Single USB-C carries data and power |
-| Elecrow `CrowPanel Advanced 10.1"` ESP32-P4 | It is the **10.1" ESP32-P4** model, not a 5"/7"/9" or ESP32-S3 variant | **UART0** normally carries both power and data; **USB 2.0** is optional supplemental power |
+| Elecrow `CrowPanel Advanced 10.1"` ESP32-P4 | It is the **10.1" ESP32-P4** model, not a 5"/7"/9" or ESP32-S3 variant | **UART0** carries power and data and is the only port that can flash it; connecting **USB 2.0** as well adds power and a much faster sync link |
 
 See [Buying a display](../boards/BUYING.md) for exactly what to look for on each
 product page.
@@ -100,6 +100,10 @@ live key state, and multi-step actions, see
 - **The CrowPanel screen is dim or resets during flashing.** Try a shorter
   cable or a USB port that can provide more power. If needed, connect the
   USB 2.0 port as supplemental power while keeping data on UART0.
+- **CrowPanel deck syncs are slow.** Artwork over the UART0 bridge is limited
+  to 115200 baud. Connect the **USB 2.0** port to your computer as well, then
+  use **Connect COM port** and pick `Stream32 CrowPanel 10.1`. Flashing still
+  goes through UART0. This needs CrowPanel firmware `0.2.0` or later.
 - **Flashing fails repeatedly.** Enter BOOT mode manually: disconnect power,
   hold **BOOT** while reconnecting USB, release **BOOT**, then flash again. See
   [flash recovery](../boards/README.md#flash-recovery).


### PR DESCRIPTION
## Why

The Elecrow CrowPanel's second USB-C port is wired straight to the ESP32-P4's
USB 2.0 high-speed PHY, but Elecrow ships it disabled — their wiki says *"the
shipped firmware does not include USB functionality"* — so it only ever supplied
power. Every deck sync therefore ran through the CH340K bridge on `UART0` at
115200 baud, where a single 2688-byte image chunk needs about 320 ms of wire
time. A 150 px key is ~17 chunks, so cold syncs took seconds per key.

## Hardware verification

From Elecrow's own Eagle schematic (`ESP32-P4 Display 10.1 inch V1.2.sch`):

| Net | Connector | Destination |
| --- | --- | --- |
| `USB1_D+/D-` | `J1` (UART0) | series resistors into `U1` = CH340K |
| `USB2_D+/D-` | `J16` (USB 2.0) | `U7` = ESP32-P4NRW32 pads **50 / 49** |

Pads 49/50 are the P4's dedicated **HS_PHY**. Both FS PHYs are unavailable on
this board: GPIO24/25 (USB Serial/JTAG) carry `I2S_MCLK` and `P4_IO25`, and
GPIO26/27 (OTG-FS) carry `I2S_SDIN2` and `P4_TXD2`. Elecrow's own USB example
confirms the port with `CONFIG_TINYUSB_RHPORT_HS=y`.

Two consequences: the bootloader is only reachable over `UART0`, so **flashing
is unchanged**; and enabling the port is purely a firmware change.

## What changed

**Firmware `0.1.9` → `0.2.0`** (`espressif/esp_tinyusb` 2.2.1, CDC-ACM). Both
transports stay live and share one line assembler and one dispatch lock, since
`deck_protocol` keeps static decode state. Replies and queued touch/press events
follow whichever link delivered the last host line. USB bring-up failure is
logged, never fatal — a panel must not lose the port it is flashed through.

The device enumerates as `Stream32 CrowPanel 10.1` with the board's device ID as
its USB serial number, so the two ports are tellable apart in the port list.

**Desktop.** The board now answers on two ports with the same `deviceId`, and
reconnect opens every authorized port. The hello names its link
(`transport-usb` / `transport-uart`); the app ranks it and keeps one session per
device on the fastest one. Flashing had the same one-port-per-board assumption
and now releases every session for the board it resets.

No protocol version bump: `features` already exists, is validated, and is
optional, so older firmware and the Waveshare board are unaffected.

## Testing

- `node boards/tools/build-catalog.js --validate-only` — 2 profiles
- `node --test boards/tools/*.test.js` — 15 pass (+1 firmware source contract)
- `desktop`: `npm test` 228 pass (+4), `npm run check` clean

**Not yet verified on hardware.** I have no CrowPanel or ESP-IDF locally, so
this PR relies on Board CI for the compile, and the USB link still needs a
real-panel check: enumeration, a cold sync over USB 2.0, a flash over UART0
with the USB cable attached, and the panel working with only UART0 connected.
