### PR TITLE
fix(desktop): read a booting board as progress, not an error

### DIFF
--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -1172,7 +1172,16 @@ class DeviceController {
             // to the deck sync engine after the handshake.
             this.deckRuntime.handleDeviceMessage(session, message);
           } else if (message.type === 'error') {
-            this.appendLog(`Device error: ${message.code || 'unknown'}`);
+            // A board that is still booting refuses the hello with the
+            // startup stage it has reached, and bsp_display_status is the
+            // only pre-handshake source of a display-* code. The retry timer
+            // is already going to try again, so this is progress, not failure.
+            this.appendLog(
+              /^display-/.test(message.code)
+                ? `Protocol: board is still starting up (${message.code}); ` +
+                  'retrying'
+                : `Device error: ${message.code || 'unknown'}`,
+            );
           }
         } catch (error) {
           if (!session.handshakeComplete) {

--- a/desktop/test/device.test.js
+++ b/desktop/test/device.test.js
@@ -315,6 +315,51 @@ test('one open session accepts a delayed hello after retrying', async () => {
   assert.equal(port.state.closes, 1);
 });
 
+test('a booting board reads as progress while real refusals stay errors', async () => {
+  const controller = protocolController();
+  const logs = [];
+  const line = (json) => new TextEncoder().encode(`${json}\n`);
+  // The CrowPanel answers hellos before app_main sets system_ready, so an
+  // early one comes back carrying the display stage it has reached so far.
+  const port = fakeProtocolPort(({ readableController, writeCount }) => {
+    if (writeCount === 1) {
+      readableController.enqueue(
+        line('{"type":"error","code":"display-panel-init"}'),
+      );
+      return;
+    }
+
+    readableController.enqueue(line('{"type":"error","code":"invalid-json"}'));
+    readableController.enqueue(
+      line(JSON.stringify({
+        boardId: TEST_BOARD_ID,
+        deviceId: '0123456789ab',
+        features: [],
+        firmwareVersion: TEST_FIRMWARE_VERSION,
+        protocol: 1,
+        type: 'hello',
+      })),
+    );
+  });
+
+  controller.appendLog = (message) => logs.push(message);
+
+  const result = await controller.openSession(
+    port,
+    TEST_BOARD_ID,
+    TEST_FIRMWARE_VERSION,
+    2000,
+  );
+
+  assert.equal(result.boardId, TEST_BOARD_ID);
+  assert.deepEqual(logs, [
+    'Protocol: board is still starting up (display-panel-init); retrying',
+    'Device error: invalid-json',
+  ]);
+
+  await controller.closeSessionForPort(port);
+});
+
 // A CrowPanel on firmware 0.2.0 answers on both its CH340 bridge and its
 // native USB 2.0 port, and reconnect opens every authorized port.
 function boardAnsweringOn(transport) {


### PR DESCRIPTION
A board that answers a hello before `app_main` finishes refuses it with the display startup stage it has reached, and the hello retry timer tries again a second later. The desktop logged that as `Device error: display-ready`, which reads like a contradiction and like a failed flash — and it shows up during the post-flash reconnect, which is exactly when a failed flash would.

The CrowPanel starts its protocol tasks before display bring-up on purpose, then sets `system_ready` on the last line of `app_main`, after `deck_ui_init` has restored saved decks from flash. Any hello landing in that window gets refused with `bsp_display_status()`.

`bsp_display_status` is the only pre-handshake source of a `display-*` code, so those now log as `Protocol: board is still starting up (display-panel-init); retrying`. Every other refusal, including `unsupported-protocol` and `invalid-json`, is untouched.

Desktop only — no firmware change, no reflash.

Covered by a new test in `desktop/test/device.test.js` that refuses the first hello with a startup stage and a genuine error, then asserts the two log lines read differently and the session still completes.