### PR TITLE
harden: a race condition exists between the overlay lea... in deck_ui.c

### DIFF
--- a/boards/common/components/stream32_deck/deck_ui.c
+++ b/boards/common/components/stream32_deck/deck_ui.c
@@ -695,7 +695,9 @@ const char *deck_ui_apply_key_update(
     }
 
     if (overlay->image != NULL && overlay->image != parsed.image) {
-        heap_caps_free(overlay->image);
+        void *old_image = overlay->image;
+        overlay->image = NULL;  /* Clear before free to prevent double-free if lease expires concurrently. */
+        heap_caps_free(old_image);
     }
 
     *overlay = parsed;


### PR DESCRIPTION
## Summary
Harden input handling in `boards/common/components/stream32_deck/deck_ui.c` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `boards/common/components/stream32_deck/deck_ui.c:685` |
| **Assessment** | Defensive hardening |

**Description**: A race condition exists between the overlay lease timeout mechanism and key-update processing. If an overlay lease expires between lock acquisition and memory free operations, the same memory pointer could be freed twice, corrupting heap metadata.

## Changes
- `boards/common/components/stream32_deck/deck_ui.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
