### PR TITLE
fix(boards): guard the overlay table on every page

### DIFF
--- a/boards/common/components/stream32_deck/deck_ui.c
+++ b/boards/common/components/stream32_deck/deck_ui.c
@@ -75,6 +75,8 @@ typedef struct {
 static const char *TAG = "deck_ui";
 static deck_notify_fn s_notify;
 static deck_page_t s_pages[DECK_MAX_PAGES];
+/* bsp_display_lock owns this table, from its first read to its last write:
+   two transports mean two tasks race to free overlay->image. */
 static deck_overlay_t s_overlays[DECK_MAX_PAGES][DECK_MAX_KEYS];
 static uint8_t s_page_count;
 static uint8_t s_visible_page;
@@ -223,11 +225,11 @@ static void reload_artwork(const deck_page_t *page, int key_px)
 
 bool deck_ui_clear_overlays(void)
 {
-    const bool rebuild = s_active && s_visible_page < s_page_count;
-
-    if (rebuild && !bsp_display_lock(1000)) {
+    if (!bsp_display_lock(1000)) {
         return false;
     }
+
+    const bool rebuild = s_active && s_visible_page < s_page_count;
 
     if (rebuild && s_deck_screen != NULL) {
         /* Detach every LVGL image descriptor before freeing its pixels. */
@@ -248,9 +250,9 @@ bool deck_ui_clear_overlays(void)
 
     if (rebuild) {
         build_page_locked(s_visible_page);
-        bsp_display_unlock();
     }
 
+    bsp_display_unlock();
     return true;
 }
 
@@ -670,6 +672,12 @@ const char *deck_ui_apply_key_update(
         memcpy(parsed.label, update->label, sizeof(parsed.label));
     }
 
+    /* Before the read: the reuse below borrows a pointer the sweep may free,
+       so locking the free alone would still install a dangling one. */
+    if (!bsp_display_lock(1000)) {
+        return "display-busy";
+    }
+
     deck_overlay_t *overlay = &s_overlays[page_index][key_index];
     const deck_overlay_t previous = *overlay;
     *need_image = parsed.image_crc != 0;
@@ -684,10 +692,6 @@ const char *deck_ui_apply_key_update(
     const bool changed = memcmp(&previous, &parsed, sizeof(parsed)) != 0;
     const bool rebuild =
         changed && s_active && page_index == s_visible_page;
-
-    if (rebuild && !bsp_display_lock(1000)) {
-        return "display-busy";
-    }
 
     if (rebuild && s_deck_screen != NULL) {
         /* The current descriptor may point at overlay->image. */
@@ -704,9 +708,9 @@ const char *deck_ui_apply_key_update(
 
     if (rebuild) {
         build_page_locked((uint8_t)page_index);
-        bsp_display_unlock();
     }
 
+    bsp_display_unlock();
     return NULL;
 }
 
@@ -768,13 +772,13 @@ const char *deck_ui_commit_image(
 
     memcpy(owned_pixels, pixels, size);
 
-    deck_overlay_t *overlay = &s_overlays[page][index];
-    const bool rebuild = s_active && page == s_visible_page;
-
-    if (rebuild && !bsp_display_lock(1000)) {
+    if (!bsp_display_lock(1000)) {
         heap_caps_free(owned_pixels);
         return "display-busy";
     }
+
+    deck_overlay_t *overlay = &s_overlays[page][index];
+    const bool rebuild = s_active && page == s_visible_page;
 
     if (rebuild && s_deck_screen != NULL) {
         /* Stop LVGL from reading the old image before replacing it. */
@@ -790,9 +794,9 @@ const char *deck_ui_commit_image(
 
     if (rebuild) {
         build_page_locked(page);
-        bsp_display_unlock();
     }
 
+    bsp_display_unlock();
     return NULL;
 }
 

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -26,9 +26,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.3.10",
+    "version": "0.3.11",
     "projectPath": "firmware",
-    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.3.10.bin",
+    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.3.11.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.3.10")
+set(PROJECT_VER "0.3.11")
 project(stream32_elecrow_crowpanel_advanced_10_1_esp32_p4)

--- a/boards/esp32-2432s028r-ili9341/board.json
+++ b/boards/esp32-2432s028r-ili9341/board.json
@@ -26,9 +26,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.13",
+    "version": "0.1.14",
     "projectPath": "firmware",
-    "imageName": "esp32-2432s028r-ili9341-0.1.13.bin",
+    "imageName": "esp32-2432s028r-ili9341-0.1.14.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
+++ b/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set(PROJECT_VER "0.1.13")
+set(PROJECT_VER "0.1.14")
 project(stream32_esp32_2432s028r_ili9341)

--- a/boards/tools/deck-protocol-source.test.js
+++ b/boards/tools/deck-protocol-source.test.js
@@ -382,6 +382,35 @@ test('UI owns overlays and detaches LVGL images before freeing pixels', () => {
   );
 });
 
+test('every overlay mutation holds the display lock, not just visible ones', () => {
+  // The lease sweep in deck_ui_poll frees these pixels from the task that
+  // reads one transport while a key update frees them from the task reading
+  // the other. Gating the lock on a rebuild left every page but the visible
+  // one racing, which is a double free rather than a torn repaint.
+  const signatures = [
+    'bool deck_ui_clear_overlays(void)',
+    'const char *deck_ui_apply_key_update(',
+    'const char *deck_ui_commit_image(',
+  ];
+
+  for (const signature of signatures) {
+    // None of the three is forward declared, so this lands on the definition.
+    const start = ui.indexOf(signature);
+    assert.ok(start > 0, `${signature} not found`);
+
+    const body = ui.slice(start, ui.indexOf('\n}', start));
+
+    assert.doesNotMatch(body, /rebuild && !bsp_display_lock/, signature);
+    assert.match(body, /if \(!bsp_display_lock\(1000\)\) \{/, signature);
+    // The lock has to be taken before the overlay is read, not just before
+    // the free, or the reuse path installs a pointer the sweep has released.
+    assert.ok(
+      body.indexOf('bsp_display_lock') < body.indexOf('s_overlays['),
+      `${signature} reads the overlay table before locking it`,
+    );
+  }
+});
+
 const BOARDS = [
   'waveshare-esp32-s3-touch-lcd-4-v3',
   'elecrow-crowpanel-advanced-10-1-esp32-p4',

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.3.10",
+    "version": "0.3.11",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.10.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.11.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.3.10")
+set(PROJECT_VER "0.3.11")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v3)

--- a/desktop/test/firmware-live-state.test.js
+++ b/desktop/test/firmware-live-state.test.js
@@ -132,9 +132,11 @@ test('firmware detaches visible LVGL images before freeing pixels', () => {
   );
   assert.match(
     commitBody,
-    /const bool rebuild = s_active && page == s_visible_page;[\s\S]*bsp_display_lock[\s\S]*lv_obj_clean[\s\S]*heap_caps_free\(overlay->image\)[\s\S]*overlay->image = owned_pixels;[\s\S]*build_page_locked/,
+    /bsp_display_lock[\s\S]*const bool rebuild = s_active && page == s_visible_page;[\s\S]*lv_obj_clean[\s\S]*heap_caps_free\(overlay->image\)[\s\S]*overlay->image = owned_pixels;[\s\S]*build_page_locked/,
   );
-  assert.match(clearBody, /if \(rebuild && !bsp_display_lock\(1000\)\) \{\s*return false;/);
+  // Unconditional: the lock owns the overlay table, so a page that is not on
+  // screen still has to hold it before touching s_overlays.
+  assert.match(clearBody, /if \(!bsp_display_lock\(1000\)\) \{\s*return false;/);
   assert.doesNotMatch(clearBody, /\bbuild_page\(/);
 });
 


### PR DESCRIPTION
## Summary

- `bsp_display_lock` now owns the whole overlay table instead of only the visible page, closing a double free between the lease sweep and key updates.
- The lock is taken before the first read of the overlay rather than around the free alone, so the image-reuse path cannot install a pointer the sweep has already released.
- All three board profiles take a firmware patch version, since the shared component changed bytes.

## Why

`deck_ui_poll` expires the overlay lease and calls `deck_ui_clear_overlays`, which frees `overlay->image` for every page. On the ESP32-P4 that poll runs on the UART task while the USB task can be inside `deck_ui_apply_key_update`, and `deck_ui_poll` is called outside `protocol_mutex`.

`bsp_display_lock` happened to cover the common case because both sides take it while rebuilding. The hole was that `apply_key_update` computes `rebuild = changed && s_active && page_index == s_visible_page`, so a key update for an **off-screen** page took no lock at all while `clear_overlays` swept every page. That is a double free of the pixel buffer, not a torn repaint.

`deck_ui_commit_image` had the same conditional-lock shape and is fixed alongside it.

This supersedes #14, which narrowed the same window without closing it: reading the pointer, writing NULL, then freeing is not atomic, so the sweep can still free between the read and the NULL write.

## Notes for reviewers

- **Recursion**: `bsp_display_lock` resolves to `lvgl_port_lock`, which uses `xSemaphoreTakeRecursive`, so the wider hold nests safely.
- **Lock ordering**: this adds protocol-then-display on paths that previously took no display lock. There is no inverse path — the notify callback registered with `deck_ui_init` is `queue_event_line`, a non-blocking `xQueueSend` that never takes `protocol_mutex`.
- **New refusals**: an off-screen key update or image commit can now answer `display-busy`. The desktop already lists that code as expected for `key-update-ack`, `image-ack`, and `layout-ack`, so it degrades to a retry.
- `deck_ui.c` is at 999 lines against the 1000-line assertion in `deck-protocol-source.test.js`. The locking rationale sits on the `s_overlays` declaration rather than being repeated at three sites. The file is due for a split before the next change to it.

## Test plan

- [x] `node --test boards/tools/*.test.js` — 27 pass
- [x] `node boards/tools/build-catalog.js --validate-only` — 3 profiles
- [x] `npm test` in `desktop/` — 258 pass (`firmware-live-state.test.js` asserts the new ordering)
- [x] New guard fails when any of the three sites reverts to the conditional lock
- [ ] `Board CI` builds all three profiles
- [ ] Exercise a P4 with Companion driving key updates while an overlay lease expires
