### PR TITLE
feat(desktop): re-sync a deck after its grid re-flows

### DIFF
--- a/desktop/src/renderer/deck-runtime.js
+++ b/desktop/src/renderer/deck-runtime.js
@@ -96,6 +96,9 @@ class DeckRuntime {
     this.pending = new Map();
     this.syncTimers = new Map();
     this.syncRunning = new Map();
+    // What a sync is up to, for the cards to show. Kept apart from
+    // syncRunning so the re-entrancy sentinel stays a plain flag.
+    this.syncProgress = new Map();
     this.multiRuns = new Set();
     this.cleaning = new Set();
     this.calibrating = new Set();
@@ -168,12 +171,21 @@ class DeckRuntime {
   async setCompanionSurface(deviceId, companion) {
     const device = await this.api.setDeckCompanion(deviceId, companion);
     this.setDevice(deviceId, device);
+    await this.relayoutDevice(deviceId);
+    this.onRenderAll();
+    return device;
+  }
+
+  // Lays a board out again from nothing, through whichever owner drives it.
+  // Needed when ownership changes hands, and when the board has thrown away
+  // what it was showing. Companion caches keyPx and registers a bitmap size,
+  // so its surface has to be rebuilt rather than merely redrawn.
+  async relayoutDevice(deviceId) {
     await this.companion.detach(deviceId);
     const session = this.sessions.get(deviceId);
 
     if (!session) {
-      this.onRenderAll();
-      return device;
+      return;
     }
 
     if (this.companionEnabled(deviceId)) {
@@ -182,9 +194,6 @@ class DeckRuntime {
     } else {
       this.scheduleSync(deviceId, 0);
     }
-
-    this.onRenderAll();
-    return device;
   }
 
   sessionFor(deviceId) {
@@ -1030,6 +1039,22 @@ class DeckRuntime {
     );
   }
 
+  // Streaming a deck takes long enough to look like nothing is happening,
+  // which is most of why a re-flow felt broken. Fields merge, so a caller can
+  // move the image count without restating which page it is on.
+  setSyncProgress(deviceId, progress) {
+    if (progress === null) {
+      this.syncProgress.delete(deviceId);
+    } else {
+      this.syncProgress.set(deviceId, {
+        ...this.syncProgress.get(deviceId),
+        ...progress,
+      });
+    }
+
+    this.onRenderSyncStatus();
+  }
+
   async syncDevice(deviceId) {
     if (this.syncRunning.get(deviceId)) {
       this.syncRunning.set(deviceId, 'again');
@@ -1056,9 +1081,18 @@ class DeckRuntime {
 
     const leadPage = profile.activePage;
     let streamedArtwork = false;
+    let pagesDone = 0;
 
     try {
       for (const pageIndex of syncOrder(profile.pages.length, leadPage)) {
+        // Counted in the order they are sent rather than by page number,
+        // because syncOrder leads with whichever page is on screen.
+        this.setSyncProgress(deviceId, {
+          page: ++pagesDone,
+          pages: profile.pages.length,
+          sent: 0,
+          images: 0,
+        });
         streamedArtwork = await this.syncPage(
           deviceId,
           session,
@@ -1131,6 +1165,7 @@ class DeckRuntime {
       session.profileSyncInProgress = false;
       const runAgain = this.syncRunning.get(deviceId) === 'again';
       this.syncRunning.delete(deviceId);
+      this.setSyncProgress(deviceId, null);
 
       if (runAgain) {
         this.scheduleSync(deviceId, 0);
@@ -1179,6 +1214,10 @@ class DeckRuntime {
     }
 
     let streamed = false;
+    let sent = 0;
+
+    // Artwork is the slow part of a sync, so it is what the cards count.
+    this.setSyncProgress(deviceId, { sent, images: ack.needImages.length });
 
     for (const index of ack.needImages) {
       const render = renders.get(index);
@@ -1194,6 +1233,8 @@ class DeckRuntime {
         );
         streamed = true;
       }
+
+      this.setSyncProgress(deviceId, { sent: ++sent });
     }
 
     return streamed;

--- a/desktop/src/renderer/deck.js
+++ b/desktop/src/renderer/deck.js
@@ -260,7 +260,10 @@ class DeckController {
       onStatus: (message, state) => this.setSyncStatus(message, state),
       onProfileStatus: (message, state) =>
         this.setProfileMatchStatus(message, state),
-      onRenderSyncStatus: () => this.renderSyncStatus(),
+      onRenderSyncStatus: () => {
+        this.renderSyncStatus();
+        this.onSyncProgress?.();
+      },
     });
   }
 

--- a/desktop/src/renderer/device-manager.js
+++ b/desktop/src/renderer/device-manager.js
@@ -147,6 +147,24 @@ function firmwareStatus(row) {
   return { state: 'current', label: `Up to date · ${row.firmwareVersion}` };
 }
 
+// A settling count rather than a spinner, so a long re-flow visibly gets
+// somewhere. Artwork is the slow part, which is why icons are what it counts.
+function syncProgressText({ page, pages, sent, images }) {
+  const parts = [];
+
+  if (pages > 1) {
+    parts.push(`page ${page} of ${pages}`);
+  }
+
+  // sent is what has landed, so the count names the one in flight and stops
+  // at the total rather than reading "icon 7 of 6" as the last one lands.
+  if (images > 0) {
+    parts.push(`icon ${Math.min(sent + 1, images)} of ${images}`);
+  }
+
+  return `Resyncing${parts.length > 0 ? ` ${parts.join(' \u00b7 ')}` : ''}\u2026`;
+}
+
 function deviceMetaText(row) {
   const parts = [row.boardName, `#${row.deviceId.slice(-4)}`];
 
@@ -204,6 +222,11 @@ class DeviceManager {
     this.companionSettings = { enabled: false, host: '127.0.0.1', port: 16622 };
     this.companionLink = null;
     this.defaultBrightness = 100;
+    // Device ids whose settings panel the person left open.
+    this.expanded = new Set();
+    // Each card's progress line, kept by device id so a sync can tick it
+    // without rebuilding the list under the person's cursor.
+    this.syncNodes = new Map();
   }
 
   async initialize() {
@@ -331,10 +354,14 @@ class DeviceManager {
     const rows = this.inventory();
 
     this.list.replaceChildren();
+    this.syncNodes.clear();
 
     for (const row of rows) {
       this.list.append(this.renderCard(row));
     }
+
+    // A card rebuilt mid-sync has to pick the count back up.
+    this.renderSyncProgress();
 
     if (this.empty) {
       this.empty.hidden = rows.length > 0;
@@ -441,34 +468,59 @@ class DeviceManager {
     toggle.addEventListener('click', () => this.toggleConnection(row, toggle));
     actions.append(toggle);
 
-    card.append(head, meta, firmware);
+    const sync = document.createElement('p');
+    sync.className = 'device-sync';
+    this.syncNodes.set(row.deviceId, sync);
 
-    if (row.supportsBrightness) {
-      card.append(this.renderBrightness(row));
-    }
+    card.append(head, meta, firmware, sync);
 
-    if (row.supportsInvert) {
-      card.append(this.renderInvert(row));
-    }
+    const settings = [
+      row.supportsBrightness && this.renderBrightness(row),
+      row.supportsInvert && this.renderInvert(row),
+      row.supportsRotation && this.renderRotation(row),
+      row.supportsIconSize && this.renderIconSize(row),
+      row.supportsLabelLines && this.renderLabelLines(row),
+      this.companionSettings.enabled && this.renderCompanion(row),
+    ].filter(Boolean);
 
-    if (row.supportsRotation) {
-      card.append(this.renderRotation(row));
-    }
-
-    if (row.supportsIconSize) {
-      card.append(this.renderIconSize(row));
-    }
-
-    if (row.supportsLabelLines) {
-      card.append(this.renderLabelLines(row));
-    }
-
-    if (this.companionSettings.enabled) {
-      card.append(this.renderCompanion(row));
+    if (settings.length > 0) {
+      card.append(this.renderSettings(row, settings));
     }
 
     card.append(actions);
     return card;
+  }
+
+  // Ticks once per streamed icon, so it only touches the text it changes
+  // rather than going through render().
+  renderSyncProgress() {
+    for (const [deviceId, node] of this.syncNodes) {
+      const progress = this.deck.runtime.syncProgress.get(deviceId);
+      node.hidden = !progress;
+      node.textContent = progress ? syncProgressText(progress) : '';
+    }
+  }
+
+  // Most of a card is settings a board is set up with once, so they stay
+  // folded away and the everyday actions stay in reach.
+  renderSettings(row, sections) {
+    const { document } = this;
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+
+    details.className = 'device-settings';
+    summary.textContent = `Settings (${sections.length})`;
+    // Every card has one, so the board's name is what tells them apart.
+    summary.setAttribute('aria-label', `Settings for ${row.name}`);
+    // Every change re-renders the whole list, so the panel has to be told
+    // again that it was open.
+    details.open = this.expanded.has(row.deviceId);
+    details.addEventListener('toggle', () => {
+      this.expanded[details.open ? 'add' : 'delete'](row.deviceId);
+    });
+
+    details.append(summary, ...sections);
+    return details;
   }
 
   renderBrightness(row) {
@@ -974,4 +1026,5 @@ module.exports = {
   deviceMetaText,
   firmwareStatus,
   summarizeInventory,
+  syncProgressText,
 };

--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -922,18 +922,6 @@ class DeviceController {
     return session.hello?.features?.includes('display-invert') === true;
   }
 
-  displayRotationSupported(session) {
-    return session.hello?.features?.includes('display-rotation') === true;
-  }
-
-  displayIconSizeSupported(session) {
-    return session.hello?.features?.includes('display-icon-size') === true;
-  }
-
-  displayLabelLinesSupported(session) {
-    return session.hello?.features?.includes('display-label-lines') === true;
-  }
-
   // A board keeps its own brightness when one is saved; otherwise it follows
   // the app-wide default from Settings.
   brightnessFor(session) {
@@ -985,56 +973,55 @@ class DeviceController {
     this.deckRuntime?.applyDisplayState(deviceId, { invert });
   }
 
-  // The board re-flows its grid at the new shape, which changes keyPx and
-  // makes the next layout-ack pull a fresh copy of every icon.
-  async setDisplayRotation(deviceId, rotation) {
+  // Rotation, icon size and label lines all re-flow the board's grid, so it
+  // drops every stored image and comes back with a different keyPx. Nothing
+  // on the wire announces that, so the deck has to be laid out again from
+  // here; without it the board sits on blank keys until it is reconnected.
+  async setDisplayGeometry(deviceId, feature, refusal, override) {
     const session = this.deckRuntime?.sessionFor(deviceId);
 
     if (!session) {
       throw new Error('The deck is not connected.');
     }
 
-    if (!this.displayRotationSupported(session)) {
-      throw new Error('Screen rotation requires updated board firmware.');
+    if (session.hello?.features?.includes(feature) !== true) {
+      throw new Error(refusal);
     }
 
-    await this.applyDisplayPolicyToSession(session, { rotation });
-    this.deckRuntime?.applyDisplayState(deviceId, { rotation });
+    await this.applyDisplayPolicyToSession(session, override);
+    this.deckRuntime.applyDisplayState(deviceId, override);
+    await this.deckRuntime.relayoutDevice(deviceId);
+  }
+
+  setDisplayRotation(deviceId, rotation) {
+    return this.setDisplayGeometry(
+      deviceId,
+      'display-rotation',
+      'Screen rotation requires updated board firmware.',
+      { rotation },
+    );
   }
 
   // Only the artwork shrinks; the tiles and their labels keep the size the
-  // grid gives them. The board reports the smaller keyPx on the next
-  // layout-ack, which is what pulls a fresh copy of every icon.
-  async setDisplayIconSize(deviceId, iconSize) {
-    const session = this.deckRuntime?.sessionFor(deviceId);
-
-    if (!session) {
-      throw new Error('The deck is not connected.');
-    }
-
-    if (!this.displayIconSizeSupported(session)) {
-      throw new Error('Icon size requires updated board firmware.');
-    }
-
-    await this.applyDisplayPolicyToSession(session, { iconSize });
-    this.deckRuntime?.applyDisplayState(deviceId, { iconSize });
+  // grid gives them.
+  setDisplayIconSize(deviceId, iconSize) {
+    return this.setDisplayGeometry(
+      deviceId,
+      'display-icon-size',
+      'Icon size requires updated board firmware.',
+      { iconSize },
+    );
   }
 
   // Longer labels wrap instead of ellipsizing, and the artwork gives up the
-  // room they need, so this moves keyPx and re-sends icons just like above.
-  async setDisplayLabelLines(deviceId, labelLines) {
-    const session = this.deckRuntime?.sessionFor(deviceId);
-
-    if (!session) {
-      throw new Error('The deck is not connected.');
-    }
-
-    if (!this.displayLabelLinesSupported(session)) {
-      throw new Error('Label lines require updated board firmware.');
-    }
-
-    await this.applyDisplayPolicyToSession(session, { labelLines });
-    this.deckRuntime?.applyDisplayState(deviceId, { labelLines });
+  // room they need.
+  setDisplayLabelLines(deviceId, labelLines) {
+    return this.setDisplayGeometry(
+      deviceId,
+      'display-label-lines',
+      'Label lines require updated board firmware.',
+      { labelLines },
+    );
   }
 
   async broadcastDisplayPolicy() {

--- a/desktop/src/renderer/renderer.js
+++ b/desktop/src/renderer/renderer.js
@@ -577,6 +577,8 @@ const deviceManager = new DeviceManager({
 });
 // Mirror device and session changes into the Device Manager view live.
 deckController.onRender = () => deviceManager.render();
+// Sync progress ticks once per image, far too often to rebuild the cards.
+deckController.onSyncProgress = () => deviceManager.renderSyncProgress();
 deviceManager.initialize().catch((error) => {
   showUpdateStatus({
     message: `Device manager setup failed: ${error.message}`,

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1749,6 +1749,56 @@ progress::-webkit-progress-value {
   background: rgba(10, 18, 23, 0.52);
 }
 
+.device-sync {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0;
+  color: var(--accent-strong);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.device-sync::before {
+  content: "";
+  width: 0.7rem;
+  height: 0.7rem;
+  border: 2px solid currentcolor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: device-sync-spin 700ms linear infinite;
+}
+
+@keyframes device-sync-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .device-sync::before {
+    animation: none;
+  }
+}
+
+.device-settings {
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: rgba(4, 10, 14, 0.4);
+}
+
+.device-settings > summary {
+  padding: 0.5rem 0.7rem;
+  cursor: pointer;
+  color: var(--accent-strong);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.device-settings > :last-child {
+  padding-bottom: 0.7rem;
+}
+
 .device-brightness,
 .device-invert,
 .device-rotation,
@@ -1759,7 +1809,7 @@ progress::-webkit-progress-value {
   align-items: center;
   gap: 0.5rem;
   flex-wrap: wrap;
-  padding-top: 0.55rem;
+  padding: 0.55rem 0.7rem 0;
   border-top: 1px solid var(--line);
 }
 

--- a/desktop/test/deck.test.js
+++ b/desktop/test/deck.test.js
@@ -628,6 +628,51 @@ test('sync resolves the active named profile for a device', async () => {
   assert.equal(session.profileInputBlocked, false);
 });
 
+test('a sync publishes per-device progress and clears it when it finishes', async () => {
+  const controller = createRuntime();
+  const seen = [];
+  const session = { send: async () => {} };
+  controller.devices = {
+    aaaa11112222: {
+      name: 'Desk',
+      boardId: 'test-board',
+      activeProfileId: 'default',
+      defaultProfileId: 'default',
+      profiles: {
+        default: {
+          name: 'Default',
+          boardId: 'test-board',
+          activePage: 0,
+          keyPx: {},
+          pages: [
+            { name: 'One', rows: 1, cols: 1, keys: [] },
+            { name: 'Two', rows: 1, cols: 1, keys: [] },
+          ],
+        },
+      },
+    },
+  };
+  controller.sessions = new Map([['aaaa11112222', session]]);
+  controller.syncRunning = new Map();
+  controller.liveRunning = new Set();
+  controller.pending = new Map();
+  controller.setSyncStatus = () => {};
+  controller.refreshLiveStates = () => {};
+  controller.syncPage = async (deviceId) => {
+    seen.push({ ...controller.syncProgress.get(deviceId) });
+  };
+
+  await controller.syncDevice('aaaa11112222');
+
+  // Pages are counted in the order they are sent, not by page number.
+  assert.deepEqual(seen, [
+    { page: 1, pages: 2, sent: 0, images: 0 },
+    { page: 2, pages: 2, sent: 0, images: 0 },
+  ]);
+  // Anything left behind leaves a card claiming to resync forever.
+  assert.equal(controller.syncProgress.has('aaaa11112222'), false);
+});
+
 test('the visible page accepts input before the other pages finish', async () => {
   const controller = createRuntime();
   const order = [];

--- a/desktop/test/device-manager.test.js
+++ b/desktop/test/device-manager.test.js
@@ -9,6 +9,7 @@ const {
   deviceMetaText,
   firmwareStatus,
   summarizeInventory,
+  syncProgressText,
 } = require('../src/renderer/device-manager');
 
 const WAVESHARE = 'waveshare-esp32-s3-touch-lcd-4-v3';
@@ -186,12 +187,15 @@ function managerFixture() {
   const document = { createElement: (tag) => makeElement(tag) };
   const cleaning = new Set();
   const calibrating = new Set();
+  const syncProgress = new Map();
   const inverted = new Map();
   const rotation = new Map();
   const iconSize = new Map();
   const labelLines = new Map();
 
   manager.document = document;
+  manager.expanded = new Set();
+  manager.syncNodes = new Map();
   manager.companionSettings = { enabled: false, host: '127.0.0.1', port: 16622 };
   manager.list = makeElement('div');
   manager.empty = makeElement('p');
@@ -202,6 +206,7 @@ function managerFixture() {
     devices,
     runtime: {
       sessions,
+      syncProgress,
       cleaning,
       setCleanMode: async (deviceId, active) => {
         calls.cleaned.push([deviceId, active]);
@@ -524,6 +529,105 @@ test('Companion controls appear only once the setting turns them on', () => {
   assert.ok(
     findByText(manager.list, 'Companion surface'),
     'each card offers the surface toggle while Companion is on',
+  );
+});
+
+test('per-device settings fold into a panel that remembers being open', async () => {
+  const { manager } = managerFixture();
+  const sessions = manager.deck.runtime.sessions;
+
+  sessions.get('bbbbbbbbbbbb').hello.features = [
+    'display-invert',
+    'display-rotation',
+  ];
+  manager.render();
+
+  // Connected boards sort by name, so Booth is first and Studio second.
+  const card = manager.list.children[0];
+  const panel = card.children[4];
+
+  assert.equal(panel.tag, 'details');
+  assert.equal(panel.className, 'device-settings');
+  assert.equal(panel.children[0].tag, 'summary');
+  assert.equal(panel.children[0].textContent, 'Settings (2)');
+  assert.equal(panel.open, false);
+
+  // The controls belong to the panel, not the card, so a card is only its
+  // name, meta, firmware badge, sync line, the panel, and the actions.
+  assert.equal(card.children.length, 6);
+  assert.ok(findByClass(panel, 'device-rotation'));
+  assert.ok(findByClass(panel, 'device-invert'));
+
+  // Studio configures nothing, so it is not given an empty panel.
+  assert.equal(findByClass(manager.list.children[1], 'device-settings'), null);
+
+  // Every change re-renders the list, so opening it has to survive that.
+  panel.open = true;
+  await fire(panel, 'toggle');
+  manager.render();
+  assert.equal(manager.list.children[0].children[4].open, true);
+
+  panel.open = false;
+  await fire(panel, 'toggle');
+  manager.render();
+  assert.equal(manager.list.children[0].children[4].open, false);
+});
+
+test('a re-syncing board counts its progress down on its own card', () => {
+  const { manager } = managerFixture();
+  const { syncProgress } = manager.deck.runtime;
+
+  manager.render();
+
+  // Connected boards sort by name, so Booth is first and Studio second.
+  const line = manager.list.children[0].children[3];
+  const other = manager.list.children[1].children[3];
+
+  assert.equal(line.className, 'device-sync');
+  assert.equal(line.hidden, true, 'an idle board shows no progress line');
+
+  syncProgress.set('bbbbbbbbbbbb', { page: 1, pages: 2, sent: 0, images: 4 });
+  manager.renderSyncProgress();
+  assert.equal(line.hidden, false);
+  assert.equal(line.textContent, 'Resyncing page 1 of 2 · icon 1 of 4…');
+
+  // Only the board that is syncing says so.
+  assert.equal(other.hidden, true);
+
+  syncProgress.set('bbbbbbbbbbbb', { page: 2, pages: 2, sent: 3, images: 4 });
+  manager.renderSyncProgress();
+  assert.equal(line.textContent, 'Resyncing page 2 of 2 · icon 4 of 4…');
+
+  // A rebuild mid-sync has to pick the count back up rather than blank it.
+  manager.render();
+  assert.equal(
+    manager.list.children[0].children[3].textContent,
+    'Resyncing page 2 of 2 · icon 4 of 4…',
+  );
+
+  syncProgress.delete('bbbbbbbbbbbb');
+  manager.renderSyncProgress();
+  assert.equal(manager.list.children[0].children[3].hidden, true);
+});
+
+test('progress text drops the parts a sync has nothing to say about', () => {
+  // A single page is not worth counting, and a layout-only page sends no art.
+  assert.equal(
+    syncProgressText({ page: 1, pages: 1, sent: 0, images: 0 }),
+    'Resyncing…',
+  );
+  assert.equal(
+    syncProgressText({ page: 1, pages: 1, sent: 2, images: 6 }),
+    'Resyncing icon 3 of 6…',
+  );
+  assert.equal(
+    syncProgressText({ page: 3, pages: 4, sent: 0, images: 0 }),
+    'Resyncing page 3 of 4…',
+  );
+  // The last icon must not read as "icon 7 of 6" once it lands.
+  assert.equal(
+    syncProgressText({ page: 1, pages: 1, sent: 6, images: 6 }),
+    'Resyncing icon 6 of 6…',
   );
 });
 

--- a/desktop/test/device.test.js
+++ b/desktop/test/device.test.js
@@ -569,6 +569,63 @@ test('sends lock and idle policy only to capable devices', async () => {
   });
 });
 
+test('re-flowing the grid pushes the deck again instead of waiting for a replug', async () => {
+  const controller = Object.create(DeviceController.prototype);
+  const messages = [];
+  const relaidOut = [];
+  const session = {
+    handshakeComplete: true,
+    hello: {
+      features: [
+        'display-control',
+        'display-rotation',
+        'display-icon-size',
+        'display-label-lines',
+      ],
+    },
+    send: async (bytes) => {
+      messages.push(JSON.parse(new TextDecoder().decode(bytes)));
+    },
+  };
+
+  controller.displayPolicy = {
+    brightnessPercent: 60,
+    idleTimeoutMinutes: 5,
+    sleepWhenLocked: false,
+  };
+  controller.machineLocked = false;
+  controller.deckRuntime = {
+    sessionFor: (deviceId) => (deviceId === 'abc123' ? session : undefined),
+    applyDisplayState: () => {},
+    relayoutDevice: async (deviceId) => relaidOut.push(deviceId),
+  };
+
+  await controller.setDisplayRotation('abc123', 270);
+  await controller.setDisplayIconSize('abc123', 70);
+  await controller.setDisplayLabelLines('abc123', 2);
+
+  assert.deepEqual(
+    messages.map((message) => message.rotation ?? message.iconSize ?? message.labelLines),
+    [270, 70, 2],
+  );
+  // The board drops every stored image as it re-flows, so each of the three
+  // has to be followed by a fresh layout or the keys stay blank.
+  assert.deepEqual(relaidOut, ['abc123', 'abc123', 'abc123']);
+
+  // A board whose firmware cannot do it is refused before anything is sent.
+  session.hello.features = ['display-control'];
+  await assert.rejects(
+    controller.setDisplayRotation('abc123', 90),
+    /Screen rotation requires updated board firmware/,
+  );
+  await assert.rejects(
+    controller.setDisplayRotation('missing', 90),
+    /The deck is not connected/,
+  );
+  assert.equal(messages.length, 3);
+  assert.equal(relaidOut.length, 3);
+});
+
 test('applies a locked display policy immediately after reconnect', async () => {
   const controller = Object.create(DeviceController.prototype);
   const messages = [];


### PR DESCRIPTION
## Summary

- Rotation, icon size and label lines now re-sync the deck instead of leaving the board on blank keys until it is unplugged.
- Each Device Manager card shows its own re-sync progress, counting pages and icons as they land.
- The six per-device settings fold into a disclosure panel so the everyday actions stay in reach.

## Why the keys went blank

The three setters sent the `display` message and stopped. Firmware reacts to any of them in `deck_ui_apply_display` by calling `deck_storage_gc(NULL, 0)` — every stored image is the wrong pixel size once the grid re-flows — and rebuilding the page. Nothing on the wire announces that, and the desktop never pushed anything after it, so the artwork was simply gone.

Unplugging worked only because `attachSession` runs `scheduleSync` on reconnect.

The status line already claimed the artwork was "on its way again", which it was not.

## How

`DeckRuntime.relayoutDevice` is extracted from `setCompanionSurface`, which already knew how to rebuild a board through whichever owner drives it. Sharing it is the point: `scheduleSync` deliberately no-ops for a Companion-driven board, so calling it alone would have left a rotated Companion surface on a stale `keyPx` and a bitmap size Companion no longer matches.

Re-sending the icons then falls out of the existing `layout-ack` mechanism — a changed `keyPx` makes `syncPage` re-render, and the firmware's `needImages` covers the rest when `keyPx` happens to be unchanged (a 180° turn).

The three setters were near-identical, so they collapse into one `setDisplayGeometry` and retire three single-use feature predicates. `device.js` is a net deletion.

## Progress reporting

The runtime already had `syncRunning`, but its values are compared with `=== 'again'` as a re-entrancy sentinel, so progress lives in a separate `syncProgress` map. Pages are counted in send order, not by page number, because `syncOrder` leads with whichever page is on screen.

Progress ticks once per streamed icon. Routing that through `render()` would rebuild every card dozens of times a second and flicker under the cursor, so the manager holds each card's line by device id and updates only its text. That is what the new `onSyncProgress` hook is for, separate from the existing `onRender`.

## Test plan

- [x] `npm test` — 258 pass
- [x] `npm run check` — clean
- [x] Each new check verified to fail when its logic is removed, rather than passing vacuously
- [ ] Rotate a real board and confirm artwork returns without a replug
- [ ] Confirm the icon counter reads sensibly rather than blurring past
