### PR TITLE
feat: let CYD boards correct a swapped RGB/BGR panel

### DIFF
--- a/boards/esp32-2432s028r-ili9341/board.json
+++ b/boards/esp32-2432s028r-ili9341/board.json
@@ -26,9 +26,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.15",
+    "version": "0.1.16",
     "projectPath": "firmware",
-    "imageName": "esp32-2432s028r-ili9341-0.1.15.bin",
+    "imageName": "esp32-2432s028r-ili9341-0.1.16.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
+++ b/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set(PROJECT_VER "0.1.15")
+set(PROJECT_VER "0.1.16")
 project(stream32_esp32_2432s028r_ili9341)

--- a/boards/esp32-2432s028r-ili9341/firmware/components/cyd_bsp/cyd_bsp.c
+++ b/boards/esp32-2432s028r-ili9341/firmware/components/cyd_bsp/cyd_bsp.c
@@ -65,6 +65,13 @@ static bool s_display_awake;
    Overridable at runtime because the same model number ships with panels
    that disagree, and the board remembers the answer. */
 static bool s_invert;
+/* RGB by default, confirmed on hardware for this batch, but clones ship
+   with BGR glass that swaps red and blue. Unlike inversion this is written
+   into the panel's init sequence, so a change only lands on the next boot;
+   s_bgr is what the next init will use and s_bgr_active what the running
+   panel actually got. */
+static bool s_bgr;
+static bool s_bgr_active;
 static uint16_t s_last_raw_x;
 static uint16_t s_last_raw_y;
 static bool s_touch_down;
@@ -136,13 +143,18 @@ static esp_err_t panel_init(void)
     };
     const esp_lcd_panel_dev_config_t panel_config = {
         .reset_gpio_num = GPIO_NUM_NC,
-        /* RGB, not the BGR most of this board's community configs specify.
-           Confirmed on hardware: with BGR the amber title came out blue and
-           the dark background picked up an orange cast, which is what
-           swapping red and blue does to those two colours. */
-        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
+        /* RGB by default, not the BGR most of this board's community configs
+           specify. Confirmed on hardware: with BGR the amber title came out
+           blue and the dark background picked up an orange cast, which is
+           what swapping red and blue does to those two colours. Clones with
+           the opposite glass store the other order and reboot into it. */
+        .rgb_ele_order = s_bgr
+            ? LCD_RGB_ELEMENT_ORDER_BGR
+            : LCD_RGB_ELEMENT_ORDER_RGB,
         .bits_per_pixel = 16,
     };
+
+    s_bgr_active = s_bgr;
 
     s_status = "display-spi-bus";
     ESP_RETURN_ON_ERROR(
@@ -516,6 +528,20 @@ esp_err_t bsp_touch_set_calibration(
     memcpy(s_calibration, coefficients, sizeof(s_calibration));
     s_calibrated = true;
     return ESP_OK;
+}
+
+esp_err_t bsp_display_set_color_order(bool bgr)
+{
+    /* Recorded, not applied: the order is part of the panel init sequence,
+       so before bsp_display_start this selects what the panel comes up
+       with, and afterwards it waits for the caller to restart the board. */
+    s_bgr = bgr;
+    return ESP_OK;
+}
+
+bool bsp_display_color_order_bgr(void)
+{
+    return s_bgr_active;
 }
 
 esp_err_t bsp_display_set_invert(bool invert)

--- a/boards/esp32-2432s028r-ili9341/firmware/components/cyd_bsp/include/bsp/esp-bsp.h
+++ b/boards/esp32-2432s028r-ili9341/firmware/components/cyd_bsp/include/bsp/esp-bsp.h
@@ -96,6 +96,22 @@ esp_err_t bsp_display_set_invert(bool invert);
 bool bsp_display_invert(void);
 
 /**
+ * @brief Choose the order the panel multiplexes sub-pixels in.
+ *
+ * The same model number also ships with RGB and BGR glass, and the wrong
+ * order swaps red and blue everywhere. The order is part of the panel's
+ * init sequence: before bsp_display_start it selects what the panel comes
+ * up with, and afterwards it only takes effect on the next boot, so the
+ * caller owns persisting the choice and restarting the board.
+ */
+esp_err_t bsp_display_set_color_order(bool bgr);
+
+/**
+ * @brief Colour order the running panel was actually initialised with.
+ */
+bool bsp_display_color_order_bgr(void);
+
+/**
  * @brief Rotate the display by 0, 90, 180 or 270 degrees clockwise.
  *
  * The panel is 240x320 portrait glass, so the deck runs in whichever

--- a/boards/esp32-2432s028r-ili9341/firmware/main/main.c
+++ b/boards/esp32-2432s028r-ili9341/firmware/main/main.c
@@ -7,6 +7,7 @@
 #include "cJSON.h"
 #include "deck_layout.h"
 #include "deck_protocol.h"
+#include "deck_settings.h"
 #include "deck_ui.h"
 #include "driver/gpio.h"
 #include "driver/uart.h"
@@ -14,11 +15,14 @@
 #include "esp_err.h"
 #include "esp_log.h"
 #include "esp_mac.h"
+#include "esp_system.h"
+#include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 #include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "lvgl.h"
+#include "nvs.h"
 
 #define STREAM32_BOARD_ID "esp32-2432s028r-ili9341"
 #define STREAM32_PROTOCOL_VERSION 1
@@ -35,6 +39,15 @@
 #define STREAM32_UART_BUFFER_SIZE 4096
 #define STREAM32_EVENT_LINE_CAPACITY 128
 #define STREAM32_REPLY_CAPACITY 384
+/* The colour order key sits beside the shared deck settings in NVS, but it
+   is owned here: this is the one board whose clones disagree about it, and
+   the shared deck component sits at its size budget. ponytail: promote it
+   into deck_settings if a second board ever grows a colour order. */
+#define STREAM32_NVS_NAMESPACE "stream32"
+#define STREAM32_NVS_KEY_COLOR_ORDER "colororder"
+/* Long enough for the refusal or ack of the current line to leave the UART
+   ring before the board goes down for a colour-order change. */
+#define STREAM32_RESTART_DELAY_MS 400
 
 /* Assembler for newline-delimited JSON. */
 typedef struct {
@@ -53,6 +66,14 @@ static lv_obj_t *connection_label;
 static lv_obj_t *touch_label;
 static lv_obj_t *touch_surface;
 static volatile bool system_ready;
+/* -1 means no restart is due. Written under protocol_mutex, read by the
+   serial task's poll so the reboot happens between lines, not inside one. */
+static volatile int64_t s_restart_at_ms = -1;
+
+static int64_t uptime_ms(void)
+{
+    return esp_timer_get_time() / 1000;
+}
 
 static void serial_write_line(const char *json)
 {
@@ -80,6 +101,81 @@ static void update_connection_label(const char *text)
     bsp_display_unlock();
 }
 
+static bool color_order_load_bgr(void)
+{
+    nvs_handle_t handle;
+    uint8_t stored = 0;
+
+    if (nvs_open(STREAM32_NVS_NAMESPACE, NVS_READONLY, &handle) != ESP_OK) {
+        return false;
+    }
+
+    if (nvs_get_u8(handle, STREAM32_NVS_KEY_COLOR_ORDER, &stored) != ESP_OK) {
+        stored = 0;
+    }
+
+    nvs_close(handle);
+    return stored != 0;
+}
+
+static esp_err_t color_order_store_bgr(bool bgr)
+{
+    nvs_handle_t handle;
+    esp_err_t error = nvs_open(STREAM32_NVS_NAMESPACE, NVS_READWRITE, &handle);
+
+    if (error != ESP_OK) {
+        return error;
+    }
+
+    error = nvs_set_u8(handle, STREAM32_NVS_KEY_COLOR_ORDER, bgr ? 1 : 0);
+
+    if (error == ESP_OK) {
+        error = nvs_commit(handle);
+    }
+
+    nvs_close(handle);
+    return error;
+}
+
+/* The panel's colour order is written into its init sequence, so unlike the
+   display message's other fields it cannot be applied by the shared handler
+   at runtime. It is picked off here before dispatch, persisted, and applied
+   by restarting the board; the rest of the message is dispatched untouched
+   because the shared decoder ignores fields it does not know. */
+static const char *apply_color_order(const cJSON *message)
+{
+    const cJSON *order =
+        cJSON_GetObjectItemCaseSensitive(message, "colorOrder");
+
+    if (order == NULL) {
+        return NULL;
+    }
+
+    if (!cJSON_IsString(order) || order->valuestring == NULL) {
+        return "display-invalid";
+    }
+
+    const bool bgr = strcmp(order->valuestring, "bgr") == 0;
+
+    if (!bgr && strcmp(order->valuestring, "rgb") != 0) {
+        return "display-invalid";
+    }
+
+    bsp_display_set_color_order(bgr);
+
+    if (color_order_store_bgr(bgr) != ESP_OK) {
+        return "display-color-order-failed";
+    }
+
+    /* Only an actual change is worth a reboot; re-saving the running order
+       must not blank the screen. */
+    if (bgr != bsp_display_color_order_bgr()) {
+        s_restart_at_ms = uptime_ms() + STREAM32_RESTART_DELAY_MS;
+    }
+
+    return NULL;
+}
+
 static void send_hello(void)
 {
     uint8_t mac[6];
@@ -99,8 +195,8 @@ static void send_hello(void)
         "\"firmwareVersion\":\"%s\",\"deviceId\":\"%02x%02x%02x%02x%02x%02x\","
         "\"features\":[\"display-control\",\"display-brightness\","
         "\"display-blank\",\"display-invert\",\"display-rotation\","
-        "\"display-flip\",\"display-icon-size\",\"display-label-lines\","
-        "\"key-update\",\"image-rle\",\"clean-mode\","
+        "\"display-flip\",\"display-color-order\",\"display-icon-size\","
+        "\"display-label-lines\",\"key-update\",\"image-rle\",\"clean-mode\","
         "\"touch-calibration\"]}",
         STREAM32_PROTOCOL_VERSION,
         STREAM32_BOARD_ID,
@@ -175,12 +271,13 @@ static void handle_host_message(const char *line, size_t length)
                 state,
                 sizeof(state),
                 "{\"type\":\"display\",\"invert\":%s,\"rotation\":%u,"
-                "\"flipX\":%s,\"flipY\":%s,"
+                "\"flipX\":%s,\"flipY\":%s,\"colorOrder\":\"%s\","
                 "\"iconSize\":%u,\"labelLines\":%u}",
                 bsp_display_invert() ? "true" : "false",
                 (unsigned)bsp_display_rotation(),
                 flip_x ? "true" : "false",
                 flip_y ? "true" : "false",
+                bsp_display_color_order_bgr() ? "bgr" : "rgb",
                 (unsigned)deck_layout_icon_percent(),
                 (unsigned)deck_layout_label_lines()
             );
@@ -203,18 +300,23 @@ static void handle_host_message(const char *line, size_t length)
             serial_write_line(response);
         }
     } else {
-        const char *error = NULL;
-        const bool handled = deck_protocol_dispatch(
-            message,
-            line,
-            length,
-            reply,
-            sizeof(reply),
-            serial_write_line,
-            &error
-        );
+        /* colorOrder is this board's own display field; a bad value refuses
+           the whole line, the same way the shared handler treats its own. */
+        const char *error = strcmp(type->valuestring, "display") == 0
+            ? apply_color_order(message)
+            : NULL;
 
-        if (!handled) {
+        if (error != NULL) {
+            send_error(error);
+        } else if (!deck_protocol_dispatch(
+                message,
+                line,
+                length,
+                reply,
+                sizeof(reply),
+                serial_write_line,
+                &error
+            )) {
             send_error("unknown-type");
         } else if (error != NULL) {
             send_error(error);
@@ -321,6 +423,12 @@ static void serial_protocol_task(void *argument)
             xSemaphoreTake(protocol_mutex, portMAX_DELAY);
             serial_write_line(event_line);
             xSemaphoreGive(protocol_mutex);
+        }
+
+        /* A saved colour-order change reboots into the new panel init once
+           the reply to the line that asked for it has left. */
+        if (s_restart_at_ms >= 0 && uptime_ms() >= s_restart_at_ms) {
+            esp_restart();
         }
     }
 }
@@ -464,6 +572,13 @@ void app_main(void)
     if (task_created != pdPASS) {
         ESP_LOGE(TAG, "Could not create the serial protocol task");
         return;
+    }
+
+    /* The colour order is part of the panel's init sequence, so it has to be
+       read before the display starts rather than with the rest of the stored
+       settings in deck_ui_init. The second init inside deck_ui is a no-op. */
+    if (deck_settings_init() == ESP_OK) {
+        bsp_display_set_color_order(color_order_load_bgr());
     }
 
     lv_display_t *display = bsp_display_start();

--- a/boards/tools/deck-protocol-source.test.js
+++ b/boards/tools/deck-protocol-source.test.js
@@ -401,6 +401,60 @@ test('the CYD flip survives a rotation and takes touch with it', () => {
   );
 });
 
+test('the CYD colour order is chosen before the panel starts and persists', () => {
+  const boardPath = (...parts) =>
+    path.join(ROOT, 'boards', 'esp32-2432s028r-ili9341', 'firmware', ...parts);
+  const main = read(boardPath('main', 'main.c'));
+  const bsp = read(boardPath('components', 'cyd_bsp', 'cyd_bsp.c'));
+
+  // The order is written into the panel's init sequence, so it must be
+  // loaded from NVS before bsp_display_start, not by deck_settings_apply.
+  const loadsOrder = main.indexOf(
+    'bsp_display_set_color_order(color_order_load_bgr())',
+  );
+  assert.ok(loadsOrder > 0, 'main.c never loads the stored colour order');
+  assert.ok(
+    main.indexOf('deck_settings_init()') < loadsOrder &&
+      loadsOrder < main.indexOf('bsp_display_start()'),
+    'the stored order must be applied between NVS mount and display start',
+  );
+
+  // Board-owned field: picked off before the shared dispatch, refusing the
+  // whole line on a bad value the way the shared handler would.
+  assert.ok(
+    main.indexOf('apply_color_order(message)') <
+      main.indexOf('deck_protocol_dispatch('),
+  );
+  assert.match(main, /"display-invalid"/);
+
+  // A change reboots the board, but only an actual change, and only after
+  // the reply to the line that asked for it has left the wire.
+  assert.match(main, /bgr != bsp_display_color_order_bgr\(\)/);
+  assert.match(
+    main,
+    /s_restart_at_ms = uptime_ms\(\) \+ STREAM32_RESTART_DELAY_MS/,
+  );
+  assert.match(
+    main,
+    /s_restart_at_ms >= 0 && uptime_ms\(\) >= s_restart_at_ms[\s\S]{0,80}esp_restart\(\)/,
+  );
+
+  // The desktop learns about it as a capability and as the stored value.
+  assert.match(main, /display-color-order/);
+  assert.match(main, /\\"colorOrder\\":\\"%s\\"/);
+  assert.match(main, /bsp_display_color_order_bgr\(\) \? "bgr" : "rgb"/);
+
+  // The BSP keeps the pending order apart from the one the panel booted
+  // with, which is what makes "reboot only on an actual change" decidable.
+  assert.match(
+    bsp,
+    /s_bgr\s*\? LCD_RGB_ELEMENT_ORDER_BGR\s*: LCD_RGB_ELEMENT_ORDER_RGB/,
+  );
+  assert.match(bsp, /s_bgr_active = s_bgr;/);
+  assert.match(bsp, /esp_err_t bsp_display_set_color_order\(bool bgr\)/);
+  assert.match(bsp, /bool bsp_display_color_order_bgr\(void\)/);
+});
+
 test('every board answers the calibration and invert BSP contract', () => {
   const bsps = [
     ['waveshare-esp32-s3-touch-lcd-4-v3', 'waveshare_bsp/waveshare_bsp.c'],

--- a/desktop/src/renderer/deck-runtime.js
+++ b/desktop/src/renderer/deck-runtime.js
@@ -107,6 +107,7 @@ class DeckRuntime {
     this.rotation = new Map();
     this.flipX = new Map();
     this.flipY = new Map();
+    this.colorOrder = new Map();
     this.iconSize = new Map();
     this.labelLines = new Map();
     this.liveValues = new Map();
@@ -540,6 +541,7 @@ class DeckRuntime {
       this.rotation.delete(deviceId);
       this.flipX.delete(deviceId);
       this.flipY.delete(deviceId);
+      this.colorOrder.delete(deviceId);
       this.iconSize.delete(deviceId);
       this.labelLines.delete(deviceId);
       this.clearLiveRuntime(deviceId);
@@ -886,7 +888,7 @@ class DeckRuntime {
   // this only records what it last told us.
   applyDisplayState(
     deviceId,
-    { invert, rotation, flipX, flipY, iconSize, labelLines },
+    { invert, rotation, flipX, flipY, colorOrder, iconSize, labelLines },
   ) {
     if (invert !== undefined) {
       this.inverted.set(deviceId, invert);
@@ -902,6 +904,10 @@ class DeckRuntime {
 
     if (flipY !== undefined) {
       this.flipY.set(deviceId, flipY);
+    }
+
+    if (colorOrder !== undefined) {
+      this.colorOrder.set(deviceId, colorOrder);
     }
 
     if (iconSize !== undefined) {

--- a/desktop/src/renderer/device-manager.js
+++ b/desktop/src/renderer/device-manager.js
@@ -38,6 +38,7 @@ function deviceInventory({
   rotation,
   flipX,
   flipY,
+  colorOrder,
   iconSize,
   labelLines,
 } = {}) {
@@ -99,6 +100,11 @@ function deviceInventory({
         : false,
       flipX: connected && flipX ? flipX.get(deviceId) === true : false,
       flipY: connected && flipY ? flipY.get(deviceId) === true : false,
+      supportsColorOrder: connected
+        ? (session.hello?.features ?? []).includes('display-color-order')
+        : false,
+      colorOrder:
+        connected && colorOrder ? colorOrder.get(deviceId) ?? 'rgb' : 'rgb',
       supportsIconSize: connected
         ? (session.hello?.features ?? []).includes('display-icon-size')
         : false,
@@ -354,6 +360,7 @@ class DeviceManager {
       rotation: this.deck.runtime.rotation,
       flipX: this.deck.runtime.flipX,
       flipY: this.deck.runtime.flipY,
+      colorOrder: this.deck.runtime.colorOrder,
       iconSize: this.deck.runtime.iconSize,
       labelLines: this.deck.runtime.labelLines,
     });
@@ -494,6 +501,7 @@ class DeviceManager {
     const settings = [
       row.supportsBrightness && this.renderBrightness(row),
       row.supportsInvert && this.renderInvert(row),
+      row.supportsColorOrder && this.renderColorOrder(row),
       row.supportsRotation && this.renderRotation(row),
       row.supportsFlip && this.renderFlip(row),
       row.supportsIconSize && this.renderIconSize(row),
@@ -674,6 +682,73 @@ class DeviceManager {
 
     section.append(label, helper);
     return section;
+  }
+
+  // The same board model ships with RGB and BGR glass, so red and blue can
+  // arrive swapped everywhere. The order is part of the panel's power-up
+  // sequence, so the board saves the answer and restarts to apply it.
+  renderColorOrder(row) {
+    const { document } = this;
+    const section = document.createElement('div');
+    const label = document.createElement('label');
+    const select = document.createElement('select');
+
+    section.className = 'device-color-order';
+    label.className = 'field-label';
+    label.textContent = 'Colour order';
+    label.htmlFor = `color-order-${row.deviceId}`;
+    select.id = label.htmlFor;
+
+    for (const [value, caption] of [
+      ['rgb', 'RGB (standard)'],
+      ['bgr', 'BGR (red and blue swapped)'],
+    ]) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = caption;
+      select.append(option);
+    }
+
+    select.value = row.colorOrder;
+    select.addEventListener('change', () => this.saveColorOrder(row, select));
+
+    const helper = document.createElement('p');
+    helper.className = 'helper';
+    helper.textContent =
+      'Pick whichever stops red and blue trading places. The board ' +
+      'restarts for a moment and remembers the answer.';
+
+    section.append(label, select, helper);
+    return section;
+  }
+
+  async saveColorOrder(row, select) {
+    const order = select.value === 'bgr' ? 'bgr' : 'rgb';
+    let status;
+
+    select.disabled = true;
+    this.setStatus(
+      `${row.name} is restarting to apply the ${order.toUpperCase()} ` +
+        'colour order…',
+      'working',
+    );
+
+    try {
+      await this.deviceController.setDisplayColorOrder(row.deviceId, order);
+      status = [
+        `${row.name} is back with the ${order.toUpperCase()} colour order.`,
+        'ready',
+      ];
+    } catch (error) {
+      status = [
+        `Could not change the colour order: ${error.message}`,
+        'error',
+      ];
+    }
+
+    // render() rewrites the status line, so the outcome has to follow it.
+    this.render();
+    this.setStatus(...status);
   }
 
   // A panel mounted sideways or upside down still reads correctly, and the

--- a/desktop/src/renderer/device.js
+++ b/desktop/src/renderer/device.js
@@ -1042,6 +1042,35 @@ class DeviceController {
     );
   }
 
+  // The colour order is wired into the panel's init sequence, so the board
+  // saves the choice and reboots to apply it. Its UART bridge port never
+  // disconnects on its own, so the dead session is dropped deliberately and
+  // the handshake chased until the board is back.
+  async setDisplayColorOrder(deviceId, colorOrder) {
+    const session = this.deckRuntime?.sessionFor(deviceId);
+
+    if (!session) {
+      throw new Error('The deck is not connected.');
+    }
+
+    if (session.hello?.features?.includes('display-color-order') !== true) {
+      throw new Error('The colour order requires updated board firmware.');
+    }
+
+    await this.applyDisplayPolicyToSession(session, { colorOrder });
+    this.deckRuntime?.applyDisplayState(deviceId, { colorOrder });
+
+    const { port } = session;
+    const boardId = session.hello.boardId;
+
+    // Give the board time to persist the order and start its reboot before
+    // hunting for the fresh hello; reconnecting sooner can catch the old
+    // session answering right before it goes down.
+    await sleep(1500);
+    await this.closeSessionForPort(port);
+    return this.connectWithRetries(port, boardId);
+  }
+
   async broadcastDisplayPolicy() {
     const tasks = this.connectedSessions()
       .filter((session) => this.displayControlSupported(session))

--- a/desktop/src/renderer/protocol.js
+++ b/desktop/src/renderer/protocol.js
@@ -538,6 +538,9 @@ function encodePageMessage(index) {
 }
 
 const DISPLAY_ROTATIONS = new Set([0, 90, 180, 270]);
+// Sub-pixel order of the glass itself. Boards like the CYD ship the same
+// model with RGB or BGR panels, so the board stores which one it has.
+const DISPLAY_COLOR_ORDERS = new Set(['rgb', 'bgr']);
 // Artwork size as a percentage of the key tile, and how far a key label may
 // wrap. Both bounds match DECK_ICON_PERCENT_MIN and DECK_LABEL_LINES_MAX in
 // the firmware's deck_settings.h.
@@ -552,6 +555,7 @@ function encodeDisplayMessage({
   rotation,
   flipX,
   flipY,
+  colorOrder,
   iconSize,
   labelLines,
 }) {
@@ -602,6 +606,14 @@ function encodeDisplayMessage({
 
     message.flipX = flipX;
     message.flipY = flipY;
+  }
+
+  if (colorOrder !== undefined) {
+    if (!DISPLAY_COLOR_ORDERS.has(colorOrder)) {
+      throw new TypeError('Display colour order must be rgb or bgr.');
+    }
+
+    message.colorOrder = colorOrder;
   }
 
   if (iconSize !== undefined) {
@@ -655,6 +667,14 @@ function validateDisplayStateMessage(message) {
 
       state[axis] = message[axis];
     }
+  }
+
+  if (message.colorOrder !== undefined) {
+    if (!DISPLAY_COLOR_ORDERS.has(message.colorOrder)) {
+      throw new TypeError('Display colour order must be rgb or bgr.');
+    }
+
+    state.colorOrder = message.colorOrder;
   }
 
   if (message.iconSize !== undefined) {

--- a/desktop/src/renderer/styles.css
+++ b/desktop/src/renderer/styles.css
@@ -1805,6 +1805,7 @@ progress::-webkit-progress-value {
    helper explains it underneath. */
 .device-brightness,
 .device-invert,
+.device-color-order,
 .device-flip,
 .device-rotation,
 .device-icon-size,
@@ -1824,6 +1825,7 @@ progress::-webkit-progress-value {
 }
 
 .device-brightness .field-label,
+.device-color-order .field-label,
 .device-rotation .field-label,
 .device-icon-size .field-label,
 .device-label-lines .field-label {
@@ -1834,6 +1836,7 @@ progress::-webkit-progress-value {
 
 .device-brightness .helper,
 .device-invert .helper,
+.device-color-order .helper,
 .device-flip .helper,
 .device-rotation .helper,
 .device-icon-size .helper,
@@ -1860,6 +1863,7 @@ progress::-webkit-progress-value {
   font-weight: 700;
 }
 
+.device-color-order select,
 .device-rotation select,
 .device-icon-size select,
 .device-label-lines select {

--- a/desktop/test/device-manager.test.js
+++ b/desktop/test/device-manager.test.js
@@ -184,6 +184,7 @@ function managerFixture() {
     invertedTo: [],
     rotatedTo: [],
     flippedTo: [],
+    colorOrderedTo: [],
     iconSizedTo: [],
     labelLinedTo: [],
   };
@@ -196,6 +197,7 @@ function managerFixture() {
   const rotation = new Map();
   const flipX = new Map();
   const flipY = new Map();
+  const colorOrder = new Map();
   const iconSize = new Map();
   const labelLines = new Map();
 
@@ -228,6 +230,7 @@ function managerFixture() {
       rotation,
       flipX,
       flipY,
+      colorOrder,
       iconSize,
       labelLines,
       setCalibrating: async (deviceId, active) => {
@@ -279,6 +282,10 @@ function managerFixture() {
       calls.flippedTo.push([deviceId, x, y]);
       flipX.set(deviceId, x);
       flipY.set(deviceId, y);
+    },
+    setDisplayColorOrder: async (deviceId, order) => {
+      calls.colorOrderedTo.push([deviceId, order]);
+      colorOrder.set(deviceId, order);
     },
     setDisplayIconSize: async (deviceId, percent) => {
       calls.iconSizedTo.push([deviceId, percent]);
@@ -515,6 +522,38 @@ test('mirroring appears only on boards that can flip an axis', async () => {
   assert.deepEqual(calls.flippedTo, [['bbbbbbbbbbbb', true, true]]);
   assert.equal(axis(0).checked, true);
   assert.equal(axis(1).checked, true);
+});
+
+test('colour order appears only on boards whose glass can disagree', async () => {
+  const { manager, calls } = managerFixture();
+  const sessions = manager.deck.runtime.sessions;
+
+  manager.render();
+  assert.equal(findByClass(manager.list, 'device-color-order'), null);
+
+  sessions.get('bbbbbbbbbbbb').hello.features = ['display-color-order'];
+  manager.deck.runtime.colorOrder.set('bbbbbbbbbbbb', 'bgr');
+  manager.render();
+
+  const picker = () =>
+    findByClass(manager.list, 'device-color-order').children[1];
+
+  // The board owns the stored value, so the control shows what it reported.
+  assert.equal(picker().value, 'bgr');
+  assert.deepEqual(
+    picker().children.map((option) => option.value),
+    ['rgb', 'bgr'],
+  );
+
+  const select = picker();
+  select.value = 'rgb';
+  await fire(select, 'change');
+  assert.deepEqual(calls.colorOrderedTo, [['bbbbbbbbbbbb', 'rgb']]);
+  assert.equal(picker().value, 'rgb');
+
+  // The panel re-initialises, so the status has to explain the restart
+  // rather than looking like the board dropped off on its own.
+  assert.match(manager.status.textContent, /RGB colour order/);
 });
 
 test('screen rotation appears only on boards that can turn the panel', async () => {

--- a/desktop/test/device.test.js
+++ b/desktop/test/device.test.js
@@ -670,6 +670,62 @@ test('automatic post-flash reset pulses RTS to restart the board', async () => {
   assert.deepEqual(events, [['disconnect']]);
 });
 
+test('changing the colour order rides the board reboot', async () => {
+  const controller = Object.create(DeviceController.prototype);
+  const messages = [];
+  const closed = [];
+  const reconnected = [];
+  const applied = [];
+  const port = { id: 'cyd-port' };
+  const session = {
+    handshakeComplete: true,
+    port,
+    hello: {
+      boardId: TEST_BOARD_ID,
+      features: ['display-control', 'display-color-order'],
+    },
+    send: async (bytes) => {
+      messages.push(JSON.parse(new TextDecoder().decode(bytes)));
+    },
+  };
+
+  controller.displayPolicy = {
+    brightnessPercent: 60,
+    idleTimeoutMinutes: 5,
+    sleepWhenLocked: false,
+  };
+  controller.machineLocked = false;
+  controller.deckRuntime = {
+    sessionFor: (deviceId) => (deviceId === 'abc123' ? session : undefined),
+    applyDisplayState: (deviceId, state) => applied.push([deviceId, state]),
+  };
+  controller.closeSessionForPort = async (target) => closed.push(target);
+  controller.connectWithRetries = async (...args) => {
+    reconnected.push(args);
+    return session.hello;
+  };
+
+  await controller.setDisplayColorOrder('abc123', 'bgr');
+
+  assert.equal(messages[0].colorOrder, 'bgr');
+  assert.deepEqual(applied, [['abc123', { colorOrder: 'bgr' }]]);
+  // The panel re-initialises on boot, so the stale session is dropped and
+  // the handshake chased on the same port with the same board expected.
+  assert.deepEqual(closed, [port]);
+  assert.deepEqual(reconnected, [[port, TEST_BOARD_ID]]);
+
+  session.hello.features = ['display-control'];
+  await assert.rejects(
+    controller.setDisplayColorOrder('abc123', 'bgr'),
+    /colour order requires updated board firmware/,
+  );
+  await assert.rejects(
+    controller.setDisplayColorOrder('missing', 'bgr'),
+    /The deck is not connected/,
+  );
+  assert.equal(messages.length, 1);
+});
+
 test('applies a locked display policy immediately after reconnect', async () => {
   const controller = Object.create(DeviceController.prototype);
   const messages = [];

--- a/desktop/test/protocol.test.js
+++ b/desktop/test/protocol.test.js
@@ -689,6 +689,50 @@ test('carries colour inversion on the display message in both directions', () =>
   );
 });
 
+test('carries the colour order on the display message in both directions', () => {
+  assert.equal(
+    new TextDecoder().decode(
+      encodeDisplayMessage({
+        awake: true,
+        idleTimeoutSeconds: 600,
+        colorOrder: 'bgr',
+      }),
+    ),
+    '{"type":"display","awake":true,"idleTimeoutSeconds":600,' +
+      '"colorOrder":"bgr"}\n',
+  );
+
+  // Absent means "leave it alone": the board owns the stored value, and a
+  // routine policy push must never restart the panel.
+  assert.doesNotMatch(
+    new TextDecoder().decode(
+      encodeDisplayMessage({ awake: true, idleTimeoutSeconds: 600 }),
+    ),
+    /colorOrder/,
+  );
+
+  for (const invalid of ['RGB', 'grb', true, 1]) {
+    assert.throws(
+      () =>
+        encodeDisplayMessage({
+          awake: true,
+          idleTimeoutSeconds: 600,
+          colorOrder: invalid,
+        }),
+      /rgb or bgr/,
+    );
+    assert.throws(
+      () => validateDisplayStateMessage({ type: 'display', colorOrder: invalid }),
+      /rgb or bgr/,
+    );
+  }
+
+  assert.deepEqual(
+    validateDisplayStateMessage({ type: 'display', colorOrder: 'bgr' }),
+    { colorOrder: 'bgr' },
+  );
+});
+
 test('carries screen rotation on the display message in both directions', () => {
   for (const rotation of [0, 90, 180, 270]) {
     assert.match(


### PR DESCRIPTION
## Summary

- The ESP32-2432S028R (Cheap Yellow Display) ships the same model number with RGB and BGR glass; on the wrong one, red and blue trade places everywhere. This adds a **Colour order** setting to the Devices tab so users can pick the order their panel actually has.
- The colour order is part of the panel''s init sequence, so it cannot be applied live like invert or mirroring. The firmware picks the `colorOrder` field off the display message before shared dispatch, persists it in NVS, and reboots ~400 ms later; on boot the stored order is loaded before `bsp_display_start()`. The hello advertises `display-color-order` and the post-hello display announcement carries the stored value.
- The desktop sends the choice, then deliberately drops the dead session and re-runs the handshake on the same port (a UART bridge never disconnects on its own), so the deck resyncs automatically once the board is back.
- The feature is deliberately CYD-local: it is the one board whose clones disagree, and `deck_protocol.c`/`deck_ui.c` both sit against their 1000-line budgets. Shared firmware is untouched, so only the CYD bumps (0.1.15 → 0.1.16); the other boards do not rebuild. Old desktops ignore the new feature flag and announcement field; new desktops hide the control on old firmware.

## Test plan

- [x] `node boards/tools/build-catalog.js --validate-only` (3 profiles)
- [x] `node --test boards/tools/*.test.js` including a new source test covering boot ordering, pre-dispatch handling, reboot-on-change, and the BSP contract
- [x] `desktop: npm test` (269 passing, 3 new: protocol round-trip, controller reboot-reconnect, Devices tab gating) and `npm run check`
- [x] Board CI builds the CYD firmware image with ESP-IDF 5.4.4
- [x] Flash the CI-built 0.1.16 image onto a real CYD and toggle RGB/BGR end to end