### PR TITLE
perf: cut key press latency across firmware and desktop

### DIFF
--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -26,9 +26,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.3.12",
+    "version": "0.3.13",
     "projectPath": "firmware",
-    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.3.12.bin",
+    "imageName": "elecrow-crowpanel-advanced-10-1-esp32-p4-0.3.13.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.3.12")
+set(PROJECT_VER "0.3.13")
 project(stream32_elecrow_crowpanel_advanced_10_1_esp32_p4)

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
@@ -148,6 +148,30 @@ static void queue_event_line(const char *json)
     (void)xQueueSend(event_queue, line, 0);
 }
 
+/* A key press is the one event the desktop is waiting on, so it gets its own
+   task. Draining the queue from the UART task instead made every press wait
+   out that task's receive timeout before it reached the wire, including when
+   the faster USB 2.0 link was the one carrying the session. */
+static void event_writer_task(void *argument)
+{
+    char event_line[STREAM32_EVENT_LINE_CAPACITY];
+
+    (void)argument;
+
+    while (true) {
+        if (xQueueReceive(event_queue, event_line, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+
+        /* Touch and press events are the one writer outside dispatch, so they
+           take the same lock to stay off a half-written reply. Holding it also
+           keeps active_link still while the line goes out. */
+        xSemaphoreTake(protocol_mutex, portMAX_DELAY);
+        serial_write_line(event_line);
+        xSemaphoreGive(protocol_mutex);
+    }
+}
+
 static void update_connection_label(const char *text)
 {
     if (connection_label == NULL || !bsp_display_lock(100)) {
@@ -469,16 +493,6 @@ static void serial_protocol_task(void *argument)
         }
 
         deck_ui_poll();
-
-        char event_line[STREAM32_EVENT_LINE_CAPACITY];
-
-        while (xQueueReceive(event_queue, event_line, 0) == pdTRUE) {
-            /* Touch and press events are the one writer outside dispatch, so
-               they take the same lock to stay off a half-written reply. */
-            xSemaphoreTake(protocol_mutex, portMAX_DELAY);
-            serial_write_line(event_line);
-            xSemaphoreGive(protocol_mutex);
-        }
     }
 }
 
@@ -618,6 +632,12 @@ void app_main(void)
 
     if (task_created != pdPASS) {
         ESP_LOGE(TAG, "Could not create the serial protocol task");
+        return;
+    }
+
+    if (xTaskCreate(event_writer_task, "stream32_events", 3072, NULL, 5, NULL) !=
+        pdPASS) {
+        ESP_LOGE(TAG, "Could not create the event writer task");
         return;
     }
 

--- a/boards/esp32-2432s028r-ili9341/board.json
+++ b/boards/esp32-2432s028r-ili9341/board.json
@@ -26,9 +26,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.16",
+    "version": "0.1.17",
     "projectPath": "firmware",
-    "imageName": "esp32-2432s028r-ili9341-0.1.16.bin",
+    "imageName": "esp32-2432s028r-ili9341-0.1.17.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
+++ b/boards/esp32-2432s028r-ili9341/firmware/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
-set(PROJECT_VER "0.1.16")
+set(PROJECT_VER "0.1.17")
 project(stream32_esp32_2432s028r_ili9341)

--- a/boards/esp32-2432s028r-ili9341/firmware/main/main.c
+++ b/boards/esp32-2432s028r-ili9341/firmware/main/main.c
@@ -91,6 +91,28 @@ static void queue_event_line(const char *json)
     (void)xQueueSend(event_queue, line, 0);
 }
 
+/* A key press is the one event the desktop is waiting on, so it gets its own
+   task. Draining the queue from the serial task instead made every press wait
+   out that task's receive timeout before it reached the wire. */
+static void event_writer_task(void *argument)
+{
+    char event_line[STREAM32_EVENT_LINE_CAPACITY];
+
+    (void)argument;
+
+    while (true) {
+        if (xQueueReceive(event_queue, event_line, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+
+        /* Touch and press events are the one writer outside dispatch, so they
+           take the same lock to stay off a half-written reply. */
+        xSemaphoreTake(protocol_mutex, portMAX_DELAY);
+        serial_write_line(event_line);
+        xSemaphoreGive(protocol_mutex);
+    }
+}
+
 static void update_connection_label(const char *text)
 {
     if (connection_label == NULL || !bsp_display_lock(100)) {
@@ -415,16 +437,6 @@ static void serial_protocol_task(void *argument)
 
         deck_ui_poll();
 
-        char event_line[STREAM32_EVENT_LINE_CAPACITY];
-
-        while (xQueueReceive(event_queue, event_line, 0) == pdTRUE) {
-            /* Touch and press events are the one writer outside dispatch, so
-               they take the same lock to stay off a half-written reply. */
-            xSemaphoreTake(protocol_mutex, portMAX_DELAY);
-            serial_write_line(event_line);
-            xSemaphoreGive(protocol_mutex);
-        }
-
         /* A saved colour-order change reboots into the new panel init once
            the reply to the line that asked for it has left. */
         if (s_restart_at_ms >= 0 && uptime_ms() >= s_restart_at_ms) {
@@ -571,6 +583,12 @@ void app_main(void)
 
     if (task_created != pdPASS) {
         ESP_LOGE(TAG, "Could not create the serial protocol task");
+        return;
+    }
+
+    if (xTaskCreate(event_writer_task, "stream32_events", 3072, NULL, 5, NULL) !=
+        pdPASS) {
+        ESP_LOGE(TAG, "Could not create the event writer task");
         return;
     }
 

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.3.12",
+    "version": "0.3.13",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.12.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.13.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.3.12")
+set(PROJECT_VER "0.3.13")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v3)

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
@@ -15,6 +15,7 @@
 #include "esp_mac.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
+#include "freertos/semphr.h"
 #include "freertos/task.h"
 #include "lvgl.h"
 
@@ -28,6 +29,9 @@
 
 static const char *TAG = "stream32";
 static QueueHandle_t event_queue;
+/* Serializes dispatch and every physical write. Queued touch events are the
+   one writer outside dispatch, and they now run on their own task. */
+static SemaphoreHandle_t protocol_mutex;
 static lv_obj_t *connection_label;
 static lv_obj_t *touch_label;
 static lv_obj_t *touch_surface;
@@ -65,6 +69,28 @@ static void queue_event_line(const char *json)
 
     strlcpy(line, json, sizeof(line));
     (void)xQueueSend(event_queue, line, 0);
+}
+
+/* A key press is the one event the desktop is waiting on, so it gets its own
+   task. Draining the queue from the protocol task instead made every press
+   wait out that task's receive timeout before it reached the wire. */
+static void event_writer_task(void *argument)
+{
+    char event_line[STREAM32_EVENT_LINE_CAPACITY];
+
+    (void)argument;
+
+    while (true) {
+        if (xQueueReceive(event_queue, event_line, portMAX_DELAY) != pdTRUE) {
+            continue;
+        }
+
+        /* Events are the one writer outside dispatch, so they take the same
+           lock to stay off a half-written reply. */
+        xSemaphoreTake(protocol_mutex, portMAX_DELAY);
+        usb_write_line(event_line);
+        xSemaphoreGive(protocol_mutex);
+    }
 }
 
 static void update_connection_label(const char *text)
@@ -235,12 +261,15 @@ static void usb_protocol_task(void *argument)
             const char byte = (char)incoming[index];
 
             if (byte == '\n') {
+                xSemaphoreTake(protocol_mutex, portMAX_DELAY);
+
                 if (dropping_oversized_line) {
                     send_error("message-too-large");
                 } else if (line_length > 0) {
                     handle_host_message(line, line_length);
                 }
 
+                xSemaphoreGive(protocol_mutex);
                 line_length = 0;
                 dropping_oversized_line = false;
             } else if (byte != '\r' && !dropping_oversized_line) {
@@ -253,12 +282,6 @@ static void usb_protocol_task(void *argument)
         }
 
         deck_ui_poll();
-
-        char event_line[STREAM32_EVENT_LINE_CAPACITY];
-
-        while (xQueueReceive(event_queue, event_line, 0) == pdTRUE) {
-            usb_write_line(event_line);
-        }
     }
 }
 
@@ -377,9 +400,10 @@ static void create_self_test_ui(void)
 void app_main(void)
 {
     event_queue = xQueueCreate(24, STREAM32_EVENT_LINE_CAPACITY);
+    protocol_mutex = xSemaphoreCreateMutex();
 
-    if (event_queue == NULL) {
-        ESP_LOGE(TAG, "Could not allocate the event queue");
+    if (event_queue == NULL || protocol_mutex == NULL) {
+        ESP_LOGE(TAG, "Could not allocate the protocol primitives");
         return;
     }
 
@@ -415,5 +439,11 @@ void app_main(void)
 
     if (task_created != pdPASS) {
         ESP_LOGE(TAG, "Could not create the USB protocol task");
+        return;
+    }
+
+    if (xTaskCreate(event_writer_task, "stream32_events", 3072, NULL, 5, NULL) !=
+        pdPASS) {
+        ESP_LOGE(TAG, "Could not create the event writer task");
     }
 }

--- a/desktop/src/actions.js
+++ b/desktop/src/actions.js
@@ -853,7 +853,18 @@ function createActionRunner({
     keyChild = null;
   }
 
-  return { dispose, getCapabilities, runAction };
+  // The Windows child compiles its SendInput definition with Add-Type, which
+  // costs far more than the keystroke it goes on to send. Paying it at startup
+  // keeps it off the first press. ponytail: a child that later dies still makes
+  // the next press pay again; respawning on exit needs a backoff first so a
+  // machine that cannot run PowerShell does not spawn in a loop.
+  function warmUp() {
+    if (platform === 'win32') {
+      windowsKeyChild();
+    }
+  }
+
+  return { dispose, getCapabilities, runAction, warmUp };
 }
 
 module.exports = {

--- a/desktop/src/diagnostic-log.js
+++ b/desktop/src/diagnostic-log.js
@@ -115,6 +115,10 @@ function createDiagnosticLogger({
   mkdirSync(directory, { recursive: true });
   const filePath = path.join(directory, 'stream32.log');
   const sanitizingOptions = { homeDirectory, userDataDirectory };
+  // Every action logs, so the size is tracked here rather than paying an
+  // existsSync and a statSync per line. This is the only writer; null means the
+  // size is unknown and the next line measures the file again.
+  let currentBytes = null;
 
   function log(level, event, details = {}) {
     const entry = {
@@ -131,17 +135,24 @@ function createDiagnosticLogger({
     }
 
     try {
-      if (
-        existsSync(filePath) &&
-        statSync(filePath).size + Buffer.byteLength(line, 'utf8') > maxBytes
-      ) {
+      if (currentBytes === null) {
+        currentBytes = existsSync(filePath) ? statSync(filePath).size : 0;
+      }
+
+      const bytes = Buffer.byteLength(line, 'utf8');
+
+      if (currentBytes + bytes > maxBytes) {
         rotateLogs(filePath, keepFiles);
+        currentBytes = 0;
       }
 
       appendFileSync(filePath, line, 'utf8');
+      currentBytes += bytes;
       return true;
     } catch {
-      // Diagnostics must never take down the application.
+      // Diagnostics must never take down the application. Remeasure next time:
+      // the failure may have been the file moving out from under us.
+      currentBytes = null;
       return false;
     }
   }

--- a/desktop/src/main.js
+++ b/desktop/src/main.js
@@ -96,6 +96,12 @@ let rendererLogWindow = { count: 0, startedAt: 0 };
 // Electron otherwise applies Chromium's serial-device blocklist even after
 // the user explicitly selects a port. Permission remains limited in serial.js.
 app.commandLine.appendSwitch('disable-serial-blocklist');
+// A deck spends nearly all of its life hidden in the tray behind a game, and
+// the serial link and press dispatch both live in the renderer. Chromium would
+// otherwise drop that renderer to a background priority class exactly when a
+// key press has to be answered fastest.
+app.commandLine.appendSwitch('disable-renderer-backgrounding');
+app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 
 // Windows gets the .ico, which carries a rendition drawn for each of the
 // small sizes the taskbar, title bar and tray ask for. Scaling the single PNG
@@ -280,6 +286,10 @@ function createMainWindow() {
     backgroundColor: '#0b1116',
     icon: getIconPath(),
     webPreferences: {
+      // Closing only hides the window, so the renderer that owns the serial
+      // link keeps running with the page marked hidden. Throttled timers there
+      // would stall Multi Action delays and the device sync loop.
+      backgroundThrottling: false,
       contextIsolation: true,
       nodeIntegration: false,
       preload: path.join(__dirname, 'preload.js'),
@@ -773,6 +783,7 @@ if (!hasSingleInstanceLock) {
     }
 
     mainWindow = createMainWindow();
+    actionRunner.warmUp();
     startLockMonitoring();
     boardService = createDefaultBoardService(sendBoardDownloadProgress);
     pluginService = createPluginService({

--- a/desktop/test/diagnostics.test.js
+++ b/desktop/test/diagnostics.test.js
@@ -4,6 +4,7 @@ const {
   readFileSync,
   readdirSync,
   rmSync,
+  writeFileSync,
 } = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
@@ -52,6 +53,39 @@ test('rotates persistent logs and redacts sensitive values', () => {
       .join('');
     assert.doesNotMatch(content, /private-user|example\.com|AAAA|secret-value/);
     assert.match(content, /\[redacted\]|\[redacted-path\]/);
+  } finally {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+test('a restarted logger rotates the log left behind by the last run', () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'stream32-logs-'));
+
+  try {
+    // The size is tracked in memory, so a fresh logger has to measure a file it
+    // did not write before deciding the next line overflows it.
+    writeFileSync(path.join(directory, 'stream32.log'), 'x'.repeat(250), 'utf8');
+    const logger = createDiagnosticLogger({
+      directory,
+      keepFiles: 3,
+      maxBytes: 260,
+      now: () => new Date(0),
+    });
+
+    assert.equal(logger.log('info', 'test:event', { sequence: 1 }), true);
+    assert.deepEqual(readdirSync(directory).sort(), [
+      'stream32.log',
+      'stream32.log.1',
+    ]);
+    // The pre-existing bytes moved aside rather than being appended to.
+    assert.equal(
+      readFileSync(path.join(directory, 'stream32.log.1'), 'utf8'),
+      'x'.repeat(250),
+    );
+    assert.doesNotMatch(
+      readFileSync(path.join(directory, 'stream32.log'), 'utf8'),
+      /x{250}/,
+    );
   } finally {
     rmSync(directory, { force: true, recursive: true });
   }


### PR DESCRIPTION
## Summary

Reduces the delay between touching a key on the deck and the action running on the host. Three fixed costs and one large first-press stall are removed.

**Firmware (all three boards).** A press was queued by the LVGL task but written by the protocol task, which spends its idle time blocked in a serial read with a 20 ms timeout. Nothing woke it early, so every press waited out most of that window. A dedicated task now blocks on the event queue and writes immediately, taking the same lock the dispatch path holds so replies still cannot interleave. Waveshare gains that lock, having relied on being single-tasked for the same guarantee. Worth roughly 10 ms on average, 20 ms worst case.

**Desktop.** The window only hides on close, and that hidden renderer owns the Web Serial link and the whole press dispatch path, so Chromium was throttling its timers and backgrounding the process in exactly the state a deck runs in. Multi Action delays were clamped by the same rule.

**Desktop.** The Windows input child spawned on first use, so the first hotkey of a session paid a PowerShell start plus an \Add-Type\ C# compile. It now warms at startup.

**Desktop.** Every action logged, and every log line ran an \existsSync\ and a \statSync\ before appending. The size is tracked in memory now.

## Test plan

- [x] \
pm test\ (271 pass, including a new test that a restarted logger rotates the log left by the previous run)
- [x] \
pm run check\
- [x] \
ode boards/tools/build-catalog.js --validate-only\
- [ ] Board CI compiles all three firmware profiles
- [ ] Hardware check: press a key on each board and confirm actions still fire, and that a layout sync still acks cleanly while pressing

## Notes

Firmware versions are bumped (Waveshare and CrowPanel to 0.3.13, CYD to 0.1.17) since the bytes change. I could not build the firmware locally, so Board CI is the first compile of these changes.

Made with [Cursor](https://cursor.com)