### PR TITLE
fix(boards): restart the CrowPanel automatically after a flash

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -380,15 +380,22 @@ If automatic bootloader entry fails:
 2. Hold **BOOT** while reconnecting USB, then release **BOOT**.
 3. Flash again.
 
-After a verified CrowPanel write, the desktop keeps UART0 open for 90 seconds
-and sends a protocol hello once per second. Press and release **RST** during
-that window; do not hold **BOOT**. If the window expires, the firmware is still
-written and verified—press **RST** or power-cycle, then use **Reconnect**. The
-Waveshare profile uses the normal automatic post-flash reset.
+Every current profile restarts automatically after a verified write: the
+desktop pulses the bridge's control lines the way `esptool.py` does, releasing
+IO0 and holding EN low for 100 ms. If a board does not come back, press **RST**
+or power-cycle, then use **Reconnect**.
+
+The CrowPanel needed a physical **RST** press until desktop 1.10.0. That was
+never a limit of its CH340K, which does carry RTS through to EN; it was
+[esptool-js#177](https://github.com/espressif/esptool-js/issues/177), whose
+`HardReset` never asserted RTS at all. Its profile therefore requires desktop
+1.10.0 or newer, the release that replaced that call. Probe a new board with
+`boards/tools/probe-rts-reset.ps1` before assuming it needs a manual press.
 
 Board profiles declare this behavior with `postFlashReset`, validated as
-`automatic` (the default) or `manual`. This is desktop/catalog metadata and
-does not change firmware images or versions.
+`automatic` (the default) or `manual`. A `manual` profile makes the desktop
+hold the port open for 90 seconds and ask for an **RST** press instead. This is
+desktop/catalog metadata and does not change firmware images or versions.
 
 Normal flashing replaces only firmware-image sectors and preserves the
 dedicated deck partition. Use **Full erase (slow troubleshooting)** only when

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/board.json
@@ -6,9 +6,9 @@
   "hardwareRevision": "1.0-1.2",
   "chip": "ESP32-P4",
   "protocolVersion": 1,
-  "minimumDesktopVersion": "0.6.0",
+  "minimumDesktopVersion": "1.10.0",
   "preferredFlashBaud": 921600,
-  "postFlashReset": "manual",
+  "postFlashReset": "automatic",
   "usbFilters": [
     {
       "usbVendorId": 6790,
@@ -44,6 +44,6 @@
     "Hold BOOT, press and release RST, then release BOOT to enter download mode.",
     "If 921600 baud is unstable, the desktop automatically restarts the complete write once at 460800 baud.",
     "Leave Full erase off to preserve saved decks; enable it only for slow, destructive troubleshooting.",
-    "After a successful flash, press and release RST (do not hold BOOT), or reconnect power."
+    "The desktop resets the board automatically after a successful flash. If it does not reconnect, press RST or reconnect power."
   ]
 }

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
@@ -35,7 +35,7 @@
    USB 2.0 high-speed PHY (module pads 50/49), so CDC-ACM turns the port
    Elecrow ships as power-only into a 480 Mbit/s protocol link. UART0 stays
    live beside it: it is the only way to flash this board, and the desktop
-   holds it open across the post-flash restart. */
+   holds it open across the manual post-flash reset. */
 #define STREAM32_USB_CDC TINYUSB_CDC_ACM_0
 #define STREAM32_USB_READ_CHUNK 512
 #define STREAM32_USB_WRITE_TIMEOUT_MS 100

--- a/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
+++ b/boards/elecrow-crowpanel-advanced-10-1-esp32-p4/firmware/main/main.c
@@ -35,7 +35,7 @@
    USB 2.0 high-speed PHY (module pads 50/49), so CDC-ACM turns the port
    Elecrow ships as power-only into a 480 Mbit/s protocol link. UART0 stays
    live beside it: it is the only way to flash this board, and the desktop
-   holds it open across the manual post-flash reset. */
+   holds it open across the post-flash restart. */
 #define STREAM32_USB_CDC TINYUSB_CDC_ACM_0
 #define STREAM32_USB_READ_CHUNK 512
 #define STREAM32_USB_WRITE_TIMEOUT_MS 100

--- a/boards/tools/catalog-helpers.test.js
+++ b/boards/tools/catalog-helpers.test.js
@@ -57,7 +57,11 @@ test('board profiles declare their post-flash reset behavior', () => {
     true,
   );
   assert.equal(profile.preferredFlashBaud, 921600);
-  assert.equal(profile.postFlashReset, 'manual');
+  assert.equal(profile.postFlashReset, 'automatic');
+  // The automatic pulse only works from 1.10.0, the release that stopped
+  // calling esptool-js's HardReset. An older desktop would silently fail to
+  // restart the board instead of asking for the RST press it used to.
+  assert.equal(profile.minimumDesktopVersion, '1.10.0');
 
   const waveshareProfile = JSON.parse(
     readFileSync(

--- a/boards/tools/deck-protocol-source.test.js
+++ b/boards/tools/deck-protocol-source.test.js
@@ -602,7 +602,7 @@ test('the CrowPanel serves both links without risking the flashing one', () => {
   );
 
   // UART0 is the only way to flash this board and the link the desktop holds
-  // across a manual post-flash reset, so USB bring-up may never abort.
+  // across the post-flash restart, so USB bring-up may never abort.
   assert.doesNotMatch(usbTask, /ESP_ERROR_CHECK\(\s*tinyusb/);
   assert.match(usbTask, /vTaskDelete\(NULL\)/);
   assert.match(uartTask, /ESP_ERROR_CHECK\(uart_driver_install\(/);

--- a/boards/tools/probe-rts-reset.ps1
+++ b/boards/tools/probe-rts-reset.ps1
@@ -1,0 +1,223 @@
+<#
+.SYNOPSIS
+Checks whether pulsing RTS restarts a Stream32 board over its USB-serial bridge.
+
+.DESCRIPTION
+The desktop app restarts a freshly flashed board by driving esptool.py's reset
+sequence over the serial control lines: release DTR (IO0), assert RTS to pull EN
+low, hold, then release. Boards whose bridge does not carry RTS through to EN
+cannot be restarted that way and are marked "postFlashReset": "manual" in their
+board.json, which makes the app ask for a physical RST press instead.
+
+This script answers, for one board, whether that pulse actually works. It runs
+three windows and reports what arrived on each:
+
+  1. Baseline  - no signal change. Establishes the idle noise floor.
+  2. Control   - RTS released only. Should produce nothing on its own.
+  3. Pulse     - the real sequence. A board that resets prints its ROM banner.
+
+Any bytes in the pulse window mean the chip restarted, even if they are garbled:
+the ROM banner's baud rate does not always match the protocol baud, so unreadable
+output still counts as evidence of a reset.
+
+Close Stream32 before running this. The serial port is exclusive.
+
+.PARAMETER PortName
+Serial port to probe, for example COM6. Autodetects a CH340/CH910x bridge when
+omitted. For the CrowPanel this must be the UART0 port, not the USB 2.0 port.
+
+.PARAMETER BaudRate
+Read baud. Defaults to 115200, the Stream32 protocol baud.
+
+.EXAMPLE
+.\probe-rts-reset.ps1
+.EXAMPLE
+.\probe-rts-reset.ps1 -PortName COM6
+#>
+
+[CmdletBinding()]
+param(
+    [string]$PortName,
+    [int]$BaudRate = 115200
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Find-BridgePort {
+    $serialPorts = @(
+        Get-CimInstance Win32_PnPEntity -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match '\(COM\d+\)' }
+    )
+
+    # Named bridge chips only. A generic "USB Serial Device" is the CDC class
+    # driver, which on the CrowPanel is its USB 2.0 port: that port cannot flash
+    # the board and has no RTS path to EN, so picking it would fail misleadingly.
+    # Not named $matches: that collides with the automatic variable -match fills.
+    $candidates = @(
+        $serialPorts | Where-Object { $_.Name -match 'CH340|CH910|CP210|FT232' }
+    )
+
+    if ($candidates.Count -eq 0) {
+        $generic = @($serialPorts | Where-Object { $_.Name -match 'USB.?SERIAL' })
+
+        if ($generic.Count -gt 0) {
+            Write-Host '  only a generic USB serial device found, not a known bridge' -ForegroundColor Yellow
+            Write-Host '  pass -PortName explicitly if that really is the flashing port' -ForegroundColor Yellow
+        }
+
+        return $null
+    }
+
+    foreach ($device in $candidates) {
+        Write-Host ("  found {0}" -f $device.Name) -ForegroundColor DarkGray
+    }
+
+    if ($candidates.Count -gt 1) {
+        Write-Host '  more than one bridge present; pass -PortName to pick' -ForegroundColor Yellow
+    }
+
+    if ($candidates[0].Name -match '\((COM\d+)\)') {
+        return $Matches[1]
+    }
+
+    return $null
+}
+
+# Drains whatever arrives over a fixed window rather than stopping at the first
+# byte, so a multi-line ROM banner is captured whole.
+function Read-Window {
+    param(
+        [System.IO.Ports.SerialPort]$Port,
+        [int]$Milliseconds
+    )
+
+    $deadline = [Diagnostics.Stopwatch]::StartNew()
+    $collected = New-Object System.Collections.Generic.List[byte]
+
+    while ($deadline.ElapsedMilliseconds -lt $Milliseconds) {
+        $waiting = 0
+
+        try {
+            $waiting = $Port.BytesToRead
+        } catch {
+            $waiting = 0
+        }
+
+        if ($waiting -gt 0) {
+            $buffer = New-Object byte[] $waiting
+            $read = $Port.Read($buffer, 0, $waiting)
+
+            for ($i = 0; $i -lt $read; $i++) {
+                $collected.Add($buffer[$i])
+            }
+        } else {
+            Start-Sleep -Milliseconds 20
+        }
+    }
+
+    return , $collected.ToArray()
+}
+
+function Show-Bytes {
+    param([byte[]]$Bytes)
+
+    if ($Bytes.Length -eq 0) {
+        Write-Host '    (nothing)' -ForegroundColor DarkGray
+        return
+    }
+
+    $text = [Text.Encoding]::ASCII.GetString($Bytes)
+    $printable = ($text -replace '[^\x20-\x7E\r\n]', '.')
+
+    foreach ($line in ($printable -split "`r?`n")) {
+        if ($line.Trim()) {
+            Write-Host "    | $line" -ForegroundColor Gray
+        }
+    }
+}
+
+if (-not $PortName) {
+    Write-Host 'Looking for a USB-serial bridge...' -ForegroundColor Cyan
+    $PortName = Find-BridgePort
+
+    if (-not $PortName) {
+        throw 'No CH340/CP210x/FTDI bridge found. Pass -PortName, for example -PortName COM6.'
+    }
+}
+
+Write-Host ''
+Write-Host ("Probing {0} at {1} baud" -f $PortName, $BaudRate) -ForegroundColor Cyan
+Write-Host ''
+
+$port = New-Object System.IO.Ports.SerialPort $PortName, $BaudRate, 'None', 8, 'One'
+$port.ReadTimeout = 200
+$port.WriteTimeout = 200
+
+try {
+    $port.Open()
+} catch {
+    throw ("Could not open {0}: {1} (is Stream32 still running?)" -f $PortName, $_.Exception.Message)
+}
+
+try {
+    # Opening the port can itself jog the control lines, so settle and discard
+    # anything that produced before measuring the real windows.
+    $port.DtrEnable = $false
+    $port.RtsEnable = $false
+    Start-Sleep -Milliseconds 600
+    $port.DiscardInBuffer()
+
+    Write-Host '1. Baseline, no signal change (1.5s)' -ForegroundColor White
+    $baseline = Read-Window -Port $port -Milliseconds 1500
+    Write-Host ("   {0} byte(s)" -f $baseline.Length)
+    Show-Bytes -Bytes $baseline
+
+    Write-Host ''
+    Write-Host '2. Control, release RTS only (1.5s)' -ForegroundColor White
+    $port.RtsEnable = $false
+    $control = Read-Window -Port $port -Milliseconds 1500
+    Write-Host ("   {0} byte(s)" -f $control.Length)
+    Show-Bytes -Bytes $control
+
+    Write-Host ''
+    Write-Host '3. Pulse: DTR low, RTS high 100ms, RTS low (3s)' -ForegroundColor White
+    $port.DiscardInBuffer()
+    $port.DtrEnable = $false
+    $port.RtsEnable = $true
+    Start-Sleep -Milliseconds 100
+    $port.RtsEnable = $false
+    $pulse = Read-Window -Port $port -Milliseconds 3000
+    Write-Host ("   {0} byte(s)" -f $pulse.Length)
+    Show-Bytes -Bytes $pulse
+} finally {
+    if ($port.IsOpen) {
+        $port.Close()
+    }
+
+    $port.Dispose()
+}
+
+Write-Host ''
+Write-Host ('-' * 58) -ForegroundColor DarkGray
+
+$quiet = $baseline.Length + $control.Length
+
+if ($pulse.Length -gt 0 -and $quiet -eq 0) {
+    Write-Host 'RESULT: the RTS pulse restarts this board.' -ForegroundColor Green
+    Write-Host 'The board stayed silent until the pulse, then booted. This board'
+    Write-Host 'can use "postFlashReset": "automatic" and drop the RST prompt.'
+} elseif ($pulse.Length -gt 0) {
+    Write-Host 'RESULT: inconclusive, the line was already noisy.' -ForegroundColor Yellow
+    Write-Host 'Output arrived before the pulse, so the pulse cannot be credited'
+    Write-Host 'with it. Power-cycle the board, let it settle, and run again.'
+} else {
+    Write-Host 'RESULT: the RTS pulse does not restart this board.' -ForegroundColor Red
+    Write-Host 'Nothing arrived after the pulse, so RTS most likely does not reach'
+    Write-Host 'EN on this bridge. Keep "postFlashReset": "manual".'
+    Write-Host ''
+    Write-Host 'Worth ruling out first: confirm this is the UART0 port and not the'
+    Write-Host 'USB 2.0 port, and try -BaudRate 74880 in case the ROM banner is'
+    Write-Host 'landing at a baud this run could not read.'
+}
+
+Write-Host ('-' * 58) -ForegroundColor DarkGray

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -53,7 +53,8 @@ and SHA-256 hash, and caches it for offline reflashing.
 3. **Confirm the on-screen board revision matches your silkscreen.** The chip
    family is verified automatically, but only you can confirm the display and
    PCB revision, so this is the final safety check before erasing.
-4. Let the flash complete, then press **RESET** or reconnect power when prompted.
+4. Let the flash complete. The board restarts on its own; only press **RESET**
+   or reconnect power if the app asks you to.
 
 Normal flashing rewrites only the firmware image and **preserves your saved
 decks and artwork**. The advanced **Full erase (slow troubleshooting)** option


### PR DESCRIPTION
## Summary

The CrowPanel 10.1 required a physical **RST** press after every flash. It no longer does.

Its profile was marked `postFlashReset: "manual"` in [`ec4fa41`](https://github.com/FadyFaheem/Stream32/commit/ec4fa41) (Jul 23), reasoning that *the CH340K RTS line does not reliably restart the ESP32-P4*. That was a misreading of [esptool-js#177](https://github.com/espressif/esptool-js/issues/177): the `HardReset` the app called at the time **never asserted RTS at all**, so the line was never actually exercised. The CYD had the identical symptom from the identical bug and was moved to automatic once [`c7bcbd1`](https://github.com/FadyFaheem/Stream32/commit/c7bcbd1) made the app drive the `esptool.py` sequence itself in v1.10.0. The CrowPanel was never retried.

## Hardware evidence

Probed over the UART0 CH340K on COM9:

| Window | Result |
| --- | --- |
| Baseline, no signal change | 0 bytes |
| Control, release RTS only | 0 bytes |
| **Pulse** (DTR low, RTS high 100 ms, RTS low) | **230 bytes** |

```
ESP-ROM:esp32p4-eco2-20240710
rst:0x1 (POWERON),boot:0x31f (SPI_FAST_FLASH_BOOT)
```

Silent until the pulse, then a clean `POWERON` reset. RTS does reach EN.

The probe is included as `boards/tools/probe-rts-reset.ps1` so the next board can be checked rather than assumed.

## Why minimumDesktopVersion moves to 1.10.0

The automatic pulse is only real from v1.10.0. On an older desktop this flag would mean no RTS pulse, no RST prompt, and a silent failure to reconnect, which is strictly worse than today. Raising the floor turns that into a clear "Stream32 1.10.0 or newer is required" message instead.

## Firmware

Untouched, so no version bump. The single `main.c` edit is a stale comment, kept line-count neutral because `ESP_ERROR_CHECK` embeds `__LINE__` and the published 0.3.13 image must stay byte-identical for the publish workflow's immutability check.

## Test plan

- [x] `node boards/tools/build-catalog.js --validate-only`
- [x] `node --test boards/tools/*.test.js` (29 pass)
- [x] `npm test` in `desktop/` (271 pass)
- [x] RTS pulse verified on real hardware (above)
- [ ] Board CI rebuilds all three profiles
- [ ] After merge: flash a CrowPanel and confirm it reboots and reconnects with no RST press
