### PR TITLE
fix(ci): publish the board catalog without a firmware build

### DIFF
--- a/.github/workflows/release-boards.yml
+++ b/.github/workflows/release-boards.yml
@@ -95,10 +95,14 @@ jobs:
     needs:
       - validate
       - build
+    # Runs when nothing was rebuilt too. The catalog also carries postFlashReset,
+    # minimumDesktopVersion, recovery text and deck limits, and gating this on a
+    # firmware build left those edits unpublishable. build-catalog.js reuses the
+    # published image metadata for firmware it was not handed.
     if: >-
       always() &&
-      needs.validate.outputs.has_boards == 'true' &&
-      needs.build.result == 'success'
+      needs.validate.result == 'success' &&
+      (needs.build.result == 'success' || needs.build.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -110,6 +114,7 @@ jobs:
           node-version: 22
 
       - name: Download firmware images
+        if: needs.validate.outputs.has_boards == 'true'
         uses: actions/download-artifact@v7
         with:
           pattern: board-*
@@ -135,6 +140,7 @@ jobs:
           fi
 
       - name: Enforce immutable firmware versions
+        if: needs.validate.outputs.has_boards == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -165,6 +171,7 @@ jobs:
           done
 
       - name: Publish versioned firmware assets
+        if: needs.validate.outputs.has_boards == 'true'
         uses: softprops/action-gh-release@v3
         with:
           tag_name: boards-current


### PR DESCRIPTION
## Summary

The `Publish Board Support` publish job required at least one rebuilt firmware image:

```yaml
if: needs.validate.outputs.has_boards == 'true' && needs.build.result == 'success'
```

A change touching only catalog metadata produces an empty build matrix, so `has_boards` is `false`, the build job is skipped, and **publish is skipped with it**. The run still reports success.

That means `postFlashReset`, `minimumDesktopVersion`, `recoveryInstructions`, deck limits and USB filters could only ever reach users as a side effect of an unrelated firmware version bump.

[#23](https://github.com/FadyFaheem/Stream32/pull/23) hit this directly. It switched the CrowPanel to an automatic post-flash reset, passed CI, merged, and the published `catalog-v1.json` still reads `"postFlashReset": "manual"`. The fix was inert.

## Fix

`build-catalog.js` already handles this case: when an image is absent from `boards/dist/`, `reusePublishedImage` carries the published `assetName`, `offset`, `size` and `sha256` forward, requiring an exact firmware-version match. So the catalog builds correctly with an empty dist.

- Publish now runs when the build job is either `success` or `skipped`.
- The three firmware-only steps (download artifacts, immutability check, upload `.bin`s) are guarded on `has_boards == 'true'`, since `fail_on_unmatched_files: true` would otherwise fail the upload with nothing to upload.
- Catalog generation and the final catalog publish now always run.

Firmware immutability is unaffected: that check still runs whenever firmware is actually built, and a catalog-only run uploads no images at all.

## Verification

Reproduced the CI path locally with no firmware built:

```
rm -rf boards/dist
node boards/tools/build-catalog.js --previous-catalog <published catalog>
```

```
Built catalog-v1.json with 3 board profile(s).

waveshare-esp32-s3-touch-lcd-4-v3         reset=automatic  minDesktop=0.1.0   fw=0.3.13 imgs=1
elecrow-crowpanel-advanced-10-1-esp32-p4  reset=automatic  minDesktop=1.10.0  fw=0.3.13 imgs=1
esp32-2432s028r-ili9341                   reset=automatic  minDesktop=1.4.0   fw=0.1.17 imgs=1
```

Correct metadata, and every board keeps its published image entry.

Merging this touches `release-boards.yml`, which is itself a trigger path, so the run it kicks off should publish the corrected catalog and finally deliver the CrowPanel change.

## Test plan

- [x] Catalog generates with an empty `boards/dist`
- [x] Generated catalog shows the CrowPanel as `automatic` / `1.10.0`
- [x] `node --test boards/tools/*.test.js` (29 pass)
- [ ] After merge: publish runs to completion instead of skipping
- [ ] After merge: the published `catalog-v1.json` reports the CrowPanel as `automatic`
