### PR TITLE
Let the Waveshare screen be turned any way up

### DIFF
--- a/boards/README.md
+++ b/boards/README.md
@@ -26,6 +26,9 @@ Waveshare `ESP32-S3-Touch-LCD-4` (profiles
   Rev 4.0 replaces it with a CH32V003 expander whose PWM register drives a
   real dimmable backlight
 - The native USB Serial/JTAG connection (`303a:1001`)
+- The panel is square, so all four orientations give the same grid and the
+  same key size. Mount it whichever way the desk wants and set the rotation
+  from the Devices page; the board keeps the answer.
 - An optional
   [power-button bypass](../docs/WAVESHARE_V3_POWER_BUTTON_BYPASS.md) for
   automatic startup, verified on Rev 3.0
@@ -287,21 +290,34 @@ coordinates already and answer `calibrate-unsupported`.
 
 The optional `rotation` field on `display` turns the screen by 0, 90, 180 or
 270 degrees for firmware advertising `display-rotation`, so a board can be
-mounted in any orientation. The grid re-flows to the new shape, which changes
-`keyPx` and makes the desktop re-send every icon on the next `layout-ack`.
+mounted in any orientation. The grid re-flows to the new shape, which on a
+panel that is not square changes `keyPx`, and the desktop re-sends every icon
+on the next `layout-ack`.
 Touch follows without recalibration: the transform is stored against the
 panel's unrotated orientation and turned on the way out.
 
-Rotation needs `esp_lcd_panel_swap_xy`, which the RGB and MIPI-DSI panel
-drivers do not implement, so only the Cheap Yellow Display offers it today.
+There are two ways a board can turn. The Cheap Yellow Display turns its
+panel, through the `esp_lcd_panel_swap_xy` and mirror calls `esp_lvgl_port`
+writes into MADCTL for it. The Waveshare boards cannot: their ST7701 runs as
+an RGB panel, whose driver implements neither. They are registered with
+`sw_rotate` instead, which makes the port rotate each flushed buffer with
+`lv_draw_sw_rotate` and leave the panel's scan order alone. Either way LVGL
+turns every touch sample by the display rotation, so the glass follows
+without recalibration, and either way the board is asked through the same
+`rotation` field. The MIPI-DSI CrowPanel still offers no rotation.
 
-Waveshare Rev 4 mounts its panel upside down relative to Rev 3, and its
-ST7701 ignores the MADCTL and SDIR mirror commands in RGB mode, so its BSP
-asks LVGL for a fixed 180° at start-up instead. `esp_lvgl_port` turns each
-flushed buffer in software and LVGL turns every touch sample the same way,
-which is the one path to a rotated RGB panel that does not need `swap_xy`.
-It is not offered as a runtime setting: the cost is paid on every flush, and
-a board only needs it once, for how it is built.
+Software rotation costs a rotate of every flushed region and one extra draw
+buffer, which is why it is not the default everywhere. On the Waveshare it is
+the only option, and the square panel makes it the cheap case: the grid keeps
+its shape and `keyPx` does not move, so the icons the board asks for after a
+turn are the same pixels it was already holding. It does still ask for them.
+The re-flow empties the artwork pool for any style change, because on a board
+whose keys did change size nothing left in it could be read back.
+
+Waveshare Rev 4 mounts its panel upside down relative to Rev 3. That offset
+is the base every rotation is added to rather than a rotation of its own, so
+0° means upright on both revisions and the stored setting means the same
+thing whichever one it is restored on.
 
 The optional `flipX` and `flipY` fields on `display` mirror the panel's own x
 and y axes for firmware advertising `display-flip`. They are one control and

--- a/boards/tools/deck-protocol-source.test.js
+++ b/boards/tools/deck-protocol-source.test.js
@@ -340,6 +340,66 @@ test('no board redoes a rotation the platform already applies', () => {
   }
 });
 
+test('the Waveshare boards turn their square panel in software', () => {
+  // Their ST7701 runs as an RGB panel, so neither swap_xy nor the MADCTL
+  // mirror the other boards rotate with reaches it. sw_rotate is what makes
+  // lv_display_set_rotation turn the flushed buffer instead, and LVGL turns
+  // touch by the same rotation, so it has to stay set for either to work.
+  for (const [board, base] of [
+    ['waveshare-esp32-s3-touch-lcd-4-v3', 0],
+    ['waveshare-esp32-s3-touch-lcd-4-v4', 180],
+  ]) {
+    const bsp = read(
+      path.join(
+        ROOT,
+        'boards',
+        board,
+        'firmware',
+        'components',
+        'waveshare_bsp',
+        'waveshare_bsp.c',
+      ),
+    );
+
+    assert.match(bsp, /\.sw_rotate = true/, board);
+    assert.match(
+      bsp,
+      new RegExp(`#define BSP_ROTATION_BASE_DEGREES ${base}\\b`),
+      `${board} carries the wrong mounting offset`,
+    );
+    assert.match(
+      bsp,
+      /const uint16_t applied = \(degrees \+ BSP_ROTATION_BASE_DEGREES\) % 360;/,
+      `${board} does not fold its mounting offset into the request`,
+    );
+
+    // Rev 4 used to turn its own 180° at start-up as well. Two places setting
+    // a rotation is how a board ends up 180° from where it was asked to be.
+    assert.equal(
+      bsp.match(/lv_display_set_rotation\(/g)?.length,
+      1,
+      `${board} sets a rotation from more than one place`,
+    );
+  }
+});
+
+test('a board offering rotation says which way it is already turned', () => {
+  // It is stored in NVS, so a board that never reports it leaves the Devices
+  // page showing 0° for a screen that came up sideways.
+  for (const board of BOARDS) {
+    const main = read(
+      path.join(ROOT, 'boards', board, 'firmware', 'main', 'main.c'),
+    );
+
+    if (!main.includes('display-rotation')) {
+      continue;
+    }
+
+    assert.match(main, /\\"rotation\\":%u/, board);
+    assert.match(main, /\(unsigned\)bsp_display_rotation\(\)/, board);
+  }
+});
+
 test('the CYD flip survives a rotation and takes touch with it', () => {
   const bsp = read(
     path.join(

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.3.13",
+    "version": "0.3.14",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.13.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v3-0.3.14.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.3.13")
+set(PROJECT_VER "0.3.14")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v3)

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/components/waveshare_bsp/waveshare_bsp.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/components/waveshare_bsp/waveshare_bsp.c
@@ -38,6 +38,10 @@ sdmmc_card_t *bsp_sdcard = NULL;
 static esp_lcd_touch_handle_t tp = NULL;
 static esp_lcd_panel_handle_t panel_handle = NULL;
 static bool s_invert = false;
+/* How far this revision's panel is mounted from upright. Rev 3 is upright,
+   so the user's degrees reach LVGL unchanged. */
+#define BSP_ROTATION_BASE_DEGREES 0
+static uint16_t s_rotation = 0;
 
 static const st7701_lcd_init_cmd_t lcd_init_cmds[] = {
     {0x11, (uint8_t[]){0x00}, 0, 120},
@@ -516,17 +520,42 @@ bool bsp_display_invert(void)
     return s_invert;
 }
 
-/* The ST7701 runs as an RGB panel, whose esp_lcd driver has no swap_xy, so
-   there is no rotation to offer on a square 480x480 screen anyway. */
+/* The ST7701 runs as an RGB panel, whose esp_lcd driver implements neither
+   swap_xy nor mirror, so the turn is done in software: the display is
+   registered with sw_rotate, which makes esp_lvgl_port rotate each flushed
+   buffer and leave the panel's own scan order alone. LVGL turns every touch
+   sample by the same rotation, so the glass follows without recalibration.
+   The screen is square, so all four orientations keep the same 480x480 grid
+   and the same key size. */
 esp_err_t bsp_display_set_rotation(uint16_t degrees)
 {
-    (void)degrees;
-    return ESP_ERR_NOT_SUPPORTED;
+    static const lv_display_rotation_t ROTATIONS[] = {
+        LV_DISPLAY_ROTATION_0,
+        LV_DISPLAY_ROTATION_90,
+        LV_DISPLAY_ROTATION_180,
+        LV_DISPLAY_ROTATION_270,
+    };
+
+    if (degrees % 90 != 0 || degrees > 270) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (disp == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    const uint16_t applied = (degrees + BSP_ROTATION_BASE_DEGREES) % 360;
+
+    lvgl_port_lock(0);
+    lv_display_set_rotation(disp, ROTATIONS[applied / 90]);
+    s_rotation = degrees;
+    lvgl_port_unlock();
+    return ESP_OK;
 }
 
 uint16_t bsp_display_rotation(void)
 {
-    return 0;
+    return s_rotation;
 }
 
 /* Mirroring is a MADCTL bit, which an RGB panel driven straight from the

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v3/firmware/main/main.c
@@ -120,7 +120,8 @@ static void send_hello(void)
         "{\"type\":\"hello\",\"protocol\":%d,\"boardId\":\"%s\","
         "\"firmwareVersion\":\"%s\",\"deviceId\":\"%02x%02x%02x%02x%02x%02x\","
         "\"features\":[\"display-control\",\"display-blank\","
-        "\"display-invert\",\"display-icon-size\",\"display-label-lines\","
+        "\"display-invert\",\"display-rotation\",\"display-icon-size\","
+        "\"display-label-lines\","
         "\"key-update\",\"image-rle\",\"clean-mode\"]}",
         STREAM32_PROTOCOL_VERSION,
         STREAM32_BOARD_ID,
@@ -182,16 +183,17 @@ static void handle_host_message(const char *line, size_t length)
                 usb_write_line("{\"type\":\"clean\",\"active\":true}");
             }
 
-            /* Inversion is stored on the board, so the desktop has to be told
-               where the toggle actually sits. */
+            /* Inversion and rotation are stored on the board, so the desktop
+               has to be told where its controls actually sit. */
             char state[128];
 
             snprintf(
                 state,
                 sizeof(state),
-                "{\"type\":\"display\",\"invert\":%s,\"iconSize\":%u,"
-                "\"labelLines\":%u}",
+                "{\"type\":\"display\",\"invert\":%s,\"rotation\":%u,"
+                "\"iconSize\":%u,\"labelLines\":%u}",
                 bsp_display_invert() ? "true" : "false",
+                (unsigned)bsp_display_rotation(),
                 (unsigned)deck_layout_icon_percent(),
                 (unsigned)deck_layout_label_lines()
             );

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v4/board.json
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v4/board.json
@@ -20,9 +20,9 @@
     "maxPages": 8
   },
   "firmware": {
-    "version": "0.1.0",
+    "version": "0.1.1",
     "projectPath": "firmware",
-    "imageName": "waveshare-esp32-s3-touch-lcd-4-v4-0.1.0.bin",
+    "imageName": "waveshare-esp32-s3-touch-lcd-4-v4-0.1.1.bin",
     "offset": 0
   },
   "capabilities": [

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/CMakeLists.txt
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/CMakeLists.txt
@@ -5,5 +5,5 @@ set(EXTRA_COMPONENT_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../common/components")
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 
-set(PROJECT_VER "0.1.0")
+set(PROJECT_VER "0.1.1")
 project(stream32_waveshare_esp32_s3_touch_lcd_4_v4)

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/components/waveshare_bsp/waveshare_bsp.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/components/waveshare_bsp/waveshare_bsp.c
@@ -38,6 +38,11 @@ sdmmc_card_t *bsp_sdcard = NULL;
 static esp_lcd_touch_handle_t tp = NULL;
 static esp_lcd_panel_handle_t panel_handle = NULL;
 static bool s_invert = false;
+/* How far this revision's panel is mounted from upright. Rev 4 carries it
+   upside down, so the user's 0 degrees is LVGL's 180 and every request is
+   turned by that on the way in. */
+#define BSP_ROTATION_BASE_DEGREES 180
+static uint16_t s_rotation = 0;
 /* The requested backlight level survives blanking: wake restores it. */
 static uint32_t s_brightness_percent = 100;
 static bool s_display_awake = false;
@@ -505,15 +510,10 @@ lv_display_t *bsp_display_start_with_config(const bsp_display_cfg_t *cfg)
 
     /* Rev 4 mounts the panel rotated 180° vs Rev 3, and the ST7701 ignores
        the MADCTL MY/MX and SDIR/ML mirror commands in RGB mode (both were
-       tried on hardware). Rotate in software instead: sw_rotate is set on
-       this display, so the port rotates every flushed buffer 180° via
-       lv_draw_sw_rotate before it reaches the panel. Touch stays aligned
-       because the port maps touch coordinates through the same display
-       rotation; the natively oriented digitizer needs no mirroring. */
-    if (lvgl_port_lock(0)) {
-        lv_display_set_rotation(disp, LV_DISPLAY_ROTATION_180);
-        lvgl_port_unlock();
-    }
+       tried on hardware), so that offset is carried as the base of every
+       rotation instead. Asking for zero here is what puts it upright; a
+       stored orientation replaces it later from deck_settings_apply. */
+    bsp_display_set_rotation(0);
 
     return disp;
 }
@@ -585,17 +585,42 @@ bool bsp_display_invert(void)
     return s_invert;
 }
 
-/* The ST7701 runs as an RGB panel, whose esp_lcd driver has no swap_xy, so
-   there is no rotation to offer on a square 480x480 screen anyway. */
+/* The ST7701 runs as an RGB panel, whose esp_lcd driver implements neither
+   swap_xy nor mirror, so the turn is done in software: the display is
+   registered with sw_rotate, which makes esp_lvgl_port rotate each flushed
+   buffer and leave the panel's own scan order alone. LVGL turns every touch
+   sample by the same rotation, so the glass follows without recalibration.
+   The screen is square, so all four orientations keep the same 480x480 grid
+   and the same key size. */
 esp_err_t bsp_display_set_rotation(uint16_t degrees)
 {
-    (void)degrees;
-    return ESP_ERR_NOT_SUPPORTED;
+    static const lv_display_rotation_t ROTATIONS[] = {
+        LV_DISPLAY_ROTATION_0,
+        LV_DISPLAY_ROTATION_90,
+        LV_DISPLAY_ROTATION_180,
+        LV_DISPLAY_ROTATION_270,
+    };
+
+    if (degrees % 90 != 0 || degrees > 270) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (disp == NULL) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    const uint16_t applied = (degrees + BSP_ROTATION_BASE_DEGREES) % 360;
+
+    lvgl_port_lock(0);
+    lv_display_set_rotation(disp, ROTATIONS[applied / 90]);
+    s_rotation = degrees;
+    lvgl_port_unlock();
+    return ESP_OK;
 }
 
 uint16_t bsp_display_rotation(void)
 {
-    return 0;
+    return s_rotation;
 }
 
 /* Mirroring is a MADCTL bit, which an RGB panel driven straight from the

--- a/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/main/main.c
+++ b/boards/waveshare-esp32-s3-touch-lcd-4-v4/firmware/main/main.c
@@ -120,7 +120,8 @@ static void send_hello(void)
         "{\"type\":\"hello\",\"protocol\":%d,\"boardId\":\"%s\","
         "\"firmwareVersion\":\"%s\",\"deviceId\":\"%02x%02x%02x%02x%02x%02x\","
         "\"features\":[\"display-control\",\"display-brightness\",\"display-blank\","
-        "\"display-invert\",\"display-icon-size\",\"display-label-lines\","
+        "\"display-invert\",\"display-rotation\",\"display-icon-size\","
+        "\"display-label-lines\","
         "\"key-update\",\"image-rle\",\"clean-mode\"]}",
         STREAM32_PROTOCOL_VERSION,
         STREAM32_BOARD_ID,
@@ -182,16 +183,17 @@ static void handle_host_message(const char *line, size_t length)
                 usb_write_line("{\"type\":\"clean\",\"active\":true}");
             }
 
-            /* Inversion is stored on the board, so the desktop has to be told
-               where the toggle actually sits. */
+            /* Inversion and rotation are stored on the board, so the desktop
+               has to be told where its controls actually sit. */
             char state[128];
 
             snprintf(
                 state,
                 sizeof(state),
-                "{\"type\":\"display\",\"invert\":%s,\"iconSize\":%u,"
-                "\"labelLines\":%u}",
+                "{\"type\":\"display\",\"invert\":%s,\"rotation\":%u,"
+                "\"iconSize\":%u,\"labelLines\":%u}",
                 bsp_display_invert() ? "true" : "false",
+                (unsigned)bsp_display_rotation(),
                 (unsigned)deck_layout_icon_percent(),
                 (unsigned)deck_layout_label_lines()
             );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Both Waveshare revisions now offer 0°, 90°, 180° and 270° from the Devices page, the same control the Cheap Yellow Display has. The panel is square, so every orientation gives the same grid and the same key size, and a board can sit whichever way the desk wants.

## Why this was refused before

The BSP returned `ESP_ERR_NOT_SUPPORTED` with the note that the ST7701 runs as an RGB panel and its driver has no `swap_xy`. That is true, and it is only half the picture: `esp_lvgl_port` has a second path. Both Waveshare revisions already register their display with `sw_rotate`, and in that mode `lvgl_port_disp_rotation_update` returns before it touches MADCTL, while the flush callback turns each region with `lv_draw_sw_rotate` and rewrites the flush area. LVGL turns every touch sample by the display rotation on its own, so the glass follows without recalibration.

That path was already carrying the Rev 4 board: its fixed 180° for an upside-down panel is the same mechanism, verified on hardware in [#26](https://github.com/FadyFaheem/Stream32/pull/26). So the BSP only had to hand LVGL the rotation and remember which one the board is on.

Rev 4's upside-down mounting is now the base every rotation is added to (`BSP_ROTATION_BASE_DEGREES`, 180 there and 0 on Rev 3) rather than a fixed turn of its own. That way 0° means upright on both revisions and a stored orientation means the same thing whichever one restores it. Getting that offset wrong would leave a board 180° from where it was asked to be, so a source check pins both values and asserts each BSP sets a rotation from exactly one place.

## No desktop release is needed

I checked this before changing anything, since it is the part that looks like it should need an app update. The desktop's rotation support is entirely feature-driven and has been since the Cheap Yellow Display got it: `device-manager.js` renders the control when `hello.features` contains `display-rotation`, `setDisplayRotation` refuses on the same check, and `protocol.js` already validates the field. Nothing in the desktop names a board. The existing test is called "screen rotation appears only on boards that can turn the panel" and it builds its board out of a feature list.

The catalog is fetched from the rolling `boards-current` release rather than bundled in the app, so installed desktops see the new firmware on their own. All 271 desktop tests pass on this branch with no desktop change, so there is nothing to release: cutting one would publish an identical binary under a new version number.

## What a user sees

Turning the screen re-sends the artwork. That is the shared re-flow emptying the artwork pool for any style change, which it has to do on a board whose keys really did change size. On a square panel the icons that come back are the same pixels the board was already holding, and they come back over native USB Serial/JTAG, so it is quick. Leaving that alone kept this change inside the two BSPs.

The rotation lives in NVS beside inversion, so a deck running without a computer comes up the way it was left, and both boards now report it in the display state they announce after every hello so the Devices page opens on the right value.

## Verification

`node boards/tools/build-catalog.js --validate-only` validates 4 profiles and `node --test boards/tools/*.test.js` passes 33 tests, including two new ones. Both new checks were confirmed to fail when the logic is broken: flipping Rev 4's offset to 0 reports `waveshare-esp32-s3-touch-lcd-4-v4 carries the wrong mounting offset`, and dropping the reported rotation from Rev 3 fails the announcement check. Board CI compiles both firmwares with ESP-IDF 5.4.4, which is the real check on the C.

Firmware moves to 0.3.14 on Rev 3 and 0.1.1 on Rev 4, aligned across `board.json`, `imageName` and `PROJECT_VER`.

What I could not verify here is the hardware itself: that the turned image lands the right way up on a real panel, and that a finger lands on the key under it at 90° and 270°. The mechanism is the one already proven at 180° on Rev 4, but it is worth a look at a real board before this is called done.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01789-f93a-7fdf-b1c4-d298c65d5910?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01789-f93a-7fdf-b1c4-d298c65d5910&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

