### PR TITLE
Seed the community gallery with the Windows workspace decks

### DIFF
--- a/decks/index.json
+++ b/decks/index.json
@@ -1,4 +1,302 @@
 {
   "schemaVersion": 1,
-  "decks": []
+  "decks": [
+    {
+      "id": "windows-workspace",
+      "source": "profiles/windows-workspace.json",
+      "name": "Windows Workspace",
+      "author": "FadyFaheem",
+      "summary": "All eight pages with a hub and per-app pages that follow the focused app.",
+      "board": "crowpanel-10",
+      "tags": [
+        "windows",
+        "office",
+        "workspace"
+      ]
+    },
+    {
+      "id": "chrome-shortcuts",
+      "source": "profiles/chrome-shortcuts.json",
+      "name": "Chrome Shortcuts",
+      "author": "FadyFaheem",
+      "summary": "Tabs, navigation, zoom, devtools, and window management for Chrome.",
+      "board": "crowpanel-10",
+      "tags": [
+        "chrome",
+        "browser"
+      ]
+    },
+    {
+      "id": "cursor-shortcuts",
+      "source": "profiles/cursor-shortcuts.json",
+      "name": "Cursor Shortcuts",
+      "author": "FadyFaheem",
+      "summary": "Editing, navigation, panel, and AI shortcuts for Cursor.",
+      "board": "crowpanel-10",
+      "tags": [
+        "cursor",
+        "editor",
+        "coding"
+      ]
+    },
+    {
+      "id": "outlook-shortcuts",
+      "source": "profiles/outlook-shortcuts.json",
+      "name": "Outlook Shortcuts",
+      "author": "FadyFaheem",
+      "summary": "Mail, calendar, reply, and folder shortcuts for Outlook.",
+      "board": "crowpanel-10",
+      "tags": [
+        "outlook",
+        "email",
+        "office"
+      ]
+    },
+    {
+      "id": "excel-shortcuts",
+      "source": "profiles/excel-shortcuts.json",
+      "name": "Excel Shortcuts",
+      "author": "FadyFaheem",
+      "summary": "Formatting, formulas, navigation, and paste shortcuts for Excel.",
+      "board": "crowpanel-10",
+      "tags": [
+        "excel",
+        "office",
+        "spreadsheet"
+      ]
+    },
+    {
+      "id": "word-shortcuts",
+      "source": "profiles/word-shortcuts.json",
+      "name": "Word Shortcuts",
+      "author": "FadyFaheem",
+      "summary": "Formatting, review, navigation, and layout shortcuts for Word.",
+      "board": "crowpanel-10",
+      "tags": [
+        "word",
+        "office",
+        "writing"
+      ]
+    },
+    {
+      "id": "teams-controls",
+      "source": "profiles/teams-controls.json",
+      "name": "Teams Call Controls",
+      "author": "FadyFaheem",
+      "summary": "Mic, camera, screen share, hand, and leave for Teams calls.",
+      "board": "crowpanel-10",
+      "tags": [
+        "teams",
+        "meetings",
+        "office"
+      ]
+    },
+    {
+      "id": "vlc-controls",
+      "source": "profiles/vlc-controls.json",
+      "name": "VLC Controls",
+      "author": "FadyFaheem",
+      "summary": "Playback, seek, volume, subtitle, and speed control for VLC.",
+      "board": "crowpanel-10",
+      "tags": [
+        "vlc",
+        "media",
+        "video"
+      ]
+    },
+    {
+      "id": "chrome-shortcuts-waveshare-v3",
+      "source": "profiles/chrome-shortcuts-waveshare-v3.json",
+      "name": "Chrome Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Tabs, navigation, zoom, devtools, and window management for Chrome. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "chrome",
+        "browser",
+        "mini"
+      ]
+    },
+    {
+      "id": "cursor-shortcuts-waveshare-v3",
+      "source": "profiles/cursor-shortcuts-waveshare-v3.json",
+      "name": "Cursor Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Editing, navigation, panel, and AI shortcuts for Cursor. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "cursor",
+        "editor",
+        "coding",
+        "mini"
+      ]
+    },
+    {
+      "id": "outlook-shortcuts-waveshare-v3",
+      "source": "profiles/outlook-shortcuts-waveshare-v3.json",
+      "name": "Outlook Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Mail, calendar, reply, and folder shortcuts for Outlook. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "outlook",
+        "email",
+        "office",
+        "mini"
+      ]
+    },
+    {
+      "id": "excel-shortcuts-waveshare-v3",
+      "source": "profiles/excel-shortcuts-waveshare-v3.json",
+      "name": "Excel Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Formatting, formulas, navigation, and paste shortcuts for Excel. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "excel",
+        "office",
+        "spreadsheet",
+        "mini"
+      ]
+    },
+    {
+      "id": "word-shortcuts-waveshare-v3",
+      "source": "profiles/word-shortcuts-waveshare-v3.json",
+      "name": "Word Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Formatting, review, navigation, and layout shortcuts for Word. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "word",
+        "office",
+        "writing",
+        "mini"
+      ]
+    },
+    {
+      "id": "teams-controls-waveshare-v3",
+      "source": "profiles/teams-controls-waveshare-v3.json",
+      "name": "Teams Call Controls (mini)",
+      "author": "FadyFaheem",
+      "summary": "Mic, camera, screen share, hand, and leave for Teams calls. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "teams",
+        "meetings",
+        "office",
+        "mini"
+      ]
+    },
+    {
+      "id": "vlc-controls-waveshare-v3",
+      "source": "profiles/vlc-controls-waveshare-v3.json",
+      "name": "VLC Controls (mini)",
+      "author": "FadyFaheem",
+      "summary": "Playback, seek, volume, subtitle, and speed control for VLC. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 3",
+      "tags": [
+        "vlc",
+        "media",
+        "video",
+        "mini"
+      ]
+    },
+    {
+      "id": "chrome-shortcuts-waveshare-v4",
+      "source": "profiles/chrome-shortcuts-waveshare-v4.json",
+      "name": "Chrome Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Tabs, navigation, zoom, devtools, and window management for Chrome. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "chrome",
+        "browser",
+        "mini"
+      ]
+    },
+    {
+      "id": "cursor-shortcuts-waveshare-v4",
+      "source": "profiles/cursor-shortcuts-waveshare-v4.json",
+      "name": "Cursor Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Editing, navigation, panel, and AI shortcuts for Cursor. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "cursor",
+        "editor",
+        "coding",
+        "mini"
+      ]
+    },
+    {
+      "id": "outlook-shortcuts-waveshare-v4",
+      "source": "profiles/outlook-shortcuts-waveshare-v4.json",
+      "name": "Outlook Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Mail, calendar, reply, and folder shortcuts for Outlook. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "outlook",
+        "email",
+        "office",
+        "mini"
+      ]
+    },
+    {
+      "id": "excel-shortcuts-waveshare-v4",
+      "source": "profiles/excel-shortcuts-waveshare-v4.json",
+      "name": "Excel Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Formatting, formulas, navigation, and paste shortcuts for Excel. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "excel",
+        "office",
+        "spreadsheet",
+        "mini"
+      ]
+    },
+    {
+      "id": "word-shortcuts-waveshare-v4",
+      "source": "profiles/word-shortcuts-waveshare-v4.json",
+      "name": "Word Shortcuts (mini)",
+      "author": "FadyFaheem",
+      "summary": "Formatting, review, navigation, and layout shortcuts for Word. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "word",
+        "office",
+        "writing",
+        "mini"
+      ]
+    },
+    {
+      "id": "teams-controls-waveshare-v4",
+      "source": "profiles/teams-controls-waveshare-v4.json",
+      "name": "Teams Call Controls (mini)",
+      "author": "FadyFaheem",
+      "summary": "Mic, camera, screen share, hand, and leave for Teams calls. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "teams",
+        "meetings",
+        "office",
+        "mini"
+      ]
+    },
+    {
+      "id": "vlc-controls-waveshare-v4",
+      "source": "profiles/vlc-controls-waveshare-v4.json",
+      "name": "VLC Controls (mini)",
+      "author": "FadyFaheem",
+      "summary": "Playback, seek, volume, subtitle, and speed control for VLC. Sized for the 4in Waveshare panel.",
+      "board": "Waveshare 4in Rev 4",
+      "tags": [
+        "vlc",
+        "media",
+        "video",
+        "mini"
+      ]
+    }
+  ]
 }

--- a/decks/profiles/chrome-shortcuts-waveshare-v3.json
+++ b/decks/profiles/chrome-shortcuts-waveshare-v3.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Chrome Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "chrome.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "chrome.exe"
+          }
+        },
+        "name": "Chrome Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Close Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reopen Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Previous Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 5,
+            "label": "Address Bar",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Hard Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Forward",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Home",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Home",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Find",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Downloads",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4BAABXRUJQVlA4TEIBAAAvf8AfEAXkSJIUSam/0v7IHlrrOoYIyLFtm7bWfW1HcDN6Ldvv27ZtMyGncF8eB3MCov9cGgLAv/++0MiYfRld4Z5k/MPVi5iGSLgjGf8AXLyESQAi4X7EfKGdvYBxtEh8O5ECW3DymDEszUUbVmQLjh4ywi8sRFtWZgsOH9Hn0ZaiTatyBfsP6PFoK9G21biCvdt0eLS1aOMaXMHOTdo82ka0dS2uYOsWTQ5tK9q8Nl+wcYMGh7YTbV+XL1i/pMah7UUD6vMFqxdUObSDaEQjfMHyKWUW7Sga0hhfsHhCiUU7icY0voD5AwUW7Swa1OQC5hbyDNpFNKrpBdhi0K6iYc0uzrqJxjV/wW00sMVT7qORLZ/wGA1t9cBzNLb1hVfBXJFNAN4F0eS24VMQzS4riH7MlDN8ZbNb0sIr2/2U+sci",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "History",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4EAABXRUJQVlA4TAIEAAAvf8AfEDVAkiQ3bJP/f7qrLECiCPAcIUISbdumHeUhNnq2bdu2rbLt2HZaZduxbbdtO48HgttGjiS5Djdx15s6VNcLvv9aRJidm+r8N2PVPhJhy5wp9cpd5kz4JODs5JrAgkehDcrjDD8DeoqtgWVZV8aoPRDeOsFLGRUIaQ1P0+BBCDuWLdlGPHkxI7wvtLWAGznSIEsIXRLRDzHaQqRpcABupJNmT3B6hgQJy8rY4Hy2BWOt2Hz2hZKPuyGUjYMojD88oKvWhotvmPwclNrB137a8oH6O3tUvUwb9gXXw25mmGXcS+2MLnrv7dLRng66X87MjLn0a1eS3kwJe5oG1xxHl4ohfVCXfk9ktn1F9USfXkC6oBAElG1s1mFq02YT3I7P5vxe0x6mG1rADXOBFLTbtShkCMENoGA39KpC9tsWFX8plMqB6Qv+JUXfFSeN4q7Gs+BeYY3x+GDyi6GCuNAKrQEWnhRFsxb14IdtkqvOXJc6M+/aH8ehtSoldiIilp2ZAzPzzrprwbbwMrK0fHVAQh9kBlIMhmYhH53wwQksxuuvks/L8AzFaPLiRvwKoBr+MSo6vCKpBXy+hR7zZLiE+Qj8YKBhMMz5YD7FF/Jqxp0rIlcC6wuDbeZBJcAcgBk04YP5NIQTJyPtwuWTEXKh/GRoX6g/GWIXpk7mQ8yMuaOx/cPW0VgCM4ijsdwcWsfv2NgQzvpeogmEoHnuAxHWvydoxXavdVh/GYJju99UhLaE1NjvtQ19MWi8QX3s9/tHz3EPTTfUs9oQekNYWw+WheM+/pbCF3ZfUF9FYWHygRH4YRGywR/BdwExd8GlaN9CtLwvrK4F5zjvKULJhZ9/HFtCTwxqK/ga531FUL9AU6wNymneW6WQtvDqj2NP6A7h5TOex3l/GfxD3oP6xlCP+7nPiXmPOiDGQuJhk0cCulf+IFpT3qdOvMOnKXpXyF1Icbqc8l6V0nphi2SVaUop71cKVWfBOqyGCb8FFK3ifk1qZfJWTcz7lq/2xZGFcxV4kPPe1SJnL7R+/PcjEhvz/h1W/IrWPUTmdY8OchOETQl7cR+b1v56SNkEKYJufKL4aKOkzWK/6pQAJ7kLirpu1v3aSHl8IXb2NKEQlxyl7VYVCO5i0sENrRi9XBzgQbd1b4epvMRLqi+3fMemJWIh/db9DeZ1CF+4QpfbSJ6+Y/uu+38fTplIkGReIVv4wm+NnTrbN3UPCnD3nONQ1wxuZE+DTAH0iUaGliCp/t/XfdDqO8viZ+yx7sWupbHlbKHupbV463pd9yMI0r70iPqruifljM+ovIKykGsC/QzGsAKu8JNqz/CzdUu1/2at2Ech7Vgwo1GFK7+6t39a9AE=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Bookmarks",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRs4DAABXRUJQVlA4TMEDAAAvf8AfEHXQkiTJbiPt/S/ttuhqCAC7v6fwKCACDgCAZaTj27Ztezrf9LZt27b9v9m2bVuTbfs/kNxGciQx9mZ7XHZk9w/yXy8hRnR2QgXPzrzZyWH3/2GfG1egOM9Nf5XeqaHxVXW9M2NaVcV4ZuobtRND4qm5vnkhVgj8vJRGiqcF6jxyds6KenWhOiupPcmzstezO2vlqIX7s6qK6KSVo1GpqhE8aeVo6DNozE5aORY+UD7v4sM+aeWo0pmpq2rS8qG/Yf8/Do3eSStH+cOcieVcXO+klcNEZqbJScuH+oZfwz+Uj0krB4GGYCwfU1YOGxlic8ryobQRF4kP5WPKykEhojho+WBnbFfMAAtH2cVxVZWZfcf5/uSLs09gb+T15NfePL8ayxQd7AXVg97LAcWffRO9rn3cQfRu9/tc3y/f3sL97aFi7fhU7nFeP/5AQLuKbFLC93dWTzXvhoOiaD1y/f38P+IwFR+AE2rHHi0VRxWYxpm/D4SsCvHF40jcLiCQDTnGBKLvOT4KNSiP8qiuEM8MhhmBRGxWiG1iB/VxW91b9clxgkJF90wyPAIjLxWoRJHb89MhLBdyr/PuRi2X3JEfD2GzuPd5zVXgkNKAp1r0OivELcIeTwGBbgxjnuuF+Q0Pyr94sK2+038ctSKGvRAA1Q1hQ1i2KcNHjNphhrAzWlvUszJqRw6EzApRsIVCIJADmYOHvt8GeguY8J5kmDk6In9Vjsy/ygeJ8QlulOWmqGiEjc9sQ3sbuo2F4WH7Fl6Rbzw5ea+qD+foONdCU26M1nZM3Eant2G2AlyCRLAVrBsDM1xt8I12fdQawtzD4Ccc1NiY1EJfdmg4rap6r+xiOLwoY1PXcO3w9l0heXd4NeonuNqAM0CtoVbyZYA3dDMkI0OohaVwCCTt1WrsxnlrtaoKcWRKGpENc69dF88KeZg1Yhqlw19tIJOJRGG3i3DPvK8KUfhlkm9cnOOiFrbo/yCJx3wFjqis71gvnsxwCNTHJSUUi4Tv2qVejBly6+sa6ZvyGqmD32iAERN38VMU6ErhvLtDEQPb2B8WUWDhp2uXbu5cDdxXIYbfqirioxICrMUMrj8XDrOrByV0VOaa7evXea8xP+yNhp5nRrsWzoFvQ3Cpji2iexfuKi5j0lf7F2qUqjrXuJWjyifXnTdjrqphb0MwOWihpuwwHN49ZOU4aqEu3c09ZOU4bKE+P39j3oZAOHKhhjmBegasHIcu1PdXSsarHM6OvYZ4yn5AR0Pi8GuIDEnkP1KSAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Incognito",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4TCoAAAAvf8AfEB8w//M//0ICQjTPSzcDXIRBJm1Tpmz+TdVEj4j+TwCxfV07FTU=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "DevTools",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkwBAABXRUJQVlA4TD8BAAAvf8AfEBa4kSQptp4Z6b+v/T629mFG+vxFpomYEzi3rR1zxlPZ8xNs22od2+6yUk4Zq7JT2rZttbaNdwLm1v9XrnvT4KT+9puvfOAxVznFzF7Zq442vNyu9yxtt/52artd59Vbh9fzp5k9XDkz82+UcWaYZ5eDPjlivWBol2y7z9I60GlM9HzygaGdxmRfhrWx1DgqubHVv0+Drw0tNc4Pa2ErW5PjW5mYXNFqfBPcV8s7weu1PBF8Xsv9wU+13Bn8WcvtwX+1noPfa3k8+L6Wt8JrLV8GT7UyxiC6oZVVyTmtnJusaeWl4EcjSplnEN02pd6SzaWcbhB9ZGglY11jkB0yZQwz2mSz7f7xq0H26l2N0/42Z8o5aco5ON387czp5jnzppl/3GXrlDyZ//zha+950CX2m3wAcuv/K9wBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "View Source",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRngDAABXRUJQVlA4TGwDAAAvf8AfEBemoI2kqDLw7/RewMFEzAmCtm2bWpL+BJI2PMBdDdwZMAbvB5OAGgJCiIcAgBDDNtZY5wVwMWAdhiB+GCehKws3w674TLuUbBUoPD8DkHbbliFJt9y2bYxt27Zt27Zt27aq+/21iRsRNZHzTRH9nwD89/8fpmtHrj316H3048PrR+Z0L3TurtBmVkYLHacRP/amGB7uGnRrOltg5ThpyGNdH4vF63VOVbDHfgs5DeQw1L4FYvfbcJdwnkhLC8OFDiKLxPpAl8ayRRaOkq8pqj5iP9rKodwG8ixglBklW6FMfhEDuRF0B4eItDYaKrSzapLQxj0Da9OCicUdV31lMsyhQWyJ0UHyNqK6Q+40BS+/xc45lPKFvAwapP8gK6AsFPWnAujmvyVS4A62EmljMFhoa1U7sgP6E1k/hzqzlQZ7ySO/agBZb5DdSKY6FHlLXoe0Ur+TeVD3Ik/i9XCTLHcIK4i01eovtAlpRWRDWM8TW7PVWrvIbdBCJje6BT3G/4i8i2gkfSXTGK4wkSfzmwe8BPOIdNToLbRMY7KOiLzePLTEO5qw9RrbyRloJj3R+/ne4jZhb8Bt8iGeJHwmo3TQ20xE3i5r5gnTiHQh3UUdzdbCTBsicraDB5SxzWQL2Q9932I7IrtznMNZ8ilBEf+R9DMABry3Iw9rnRtNpLuii6g/JxkhY94XK/K0xLXsKNmm2EA2wWbaqKs25GzQMRwgX5IARN6TjlYAVIw/+t1Ihrs2gEgfAB1F/TpsC0Bi+4V3DR74HUv+QnYCWEOWIsalY07qSAvHsIV8S0X4LWkZKwB1+zSmu9aJyAC0FfUD3y8AzGfbXAu/IXuwisyCdmJ122EzN51+2tco7gE54xqWke/Zr0id3mVRLzPCGnLTuVZEtoj6BvRXkmcho4XksnP+h4RPNhhBpKfREXLQOcwxKjaoYfcTDCobyFz36k1OwPQikR1BreQLQju6h5sGw4xGMTlapFF5QeirsAdM0fuRYZT4kMm3dT1KkwKpVX23fhc+Ax5Yorcb5l01rD5P9gKc0uptARtj0dgWnjhS51OCjfCeGEyAN2b90FgPq/EbbX0fBa/cp9HWDtDthZVLTeGZfdnLkC0kDjlvEj3QxYffbHmfBcduPv4U/fj82q7ZnTPx3/9/RgY=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Full Screen",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8wGBMxJ4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F11",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Print",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRvoAAABXRUJQVlA4TO4AAAAvf8AfEBq3sW2rShu7/1axp8FHLwd9Ee4e/hI+USN64rYBAKQJq39AOMGZ7QFGl5kroD73gl7gvuncdGSsu7t3AmyiSnz+ge4qLjYMvFoOcM1rPV4eBHEqNHssLYQ/r5uW8uvxRgw8EgweSiZ31CjgeSuhC9gYKCqpZGNgnxZ2MUgSE4gkLiUplmJJLNUPMiFbUgA5A+MgCTtnMJJEOmeAzCWh5MwgadDDs6xFXyXdEAK9pWunQHcVF10yXt85qM1rPWyCS9Mj/VBOTY//mNyG4LaKmbpsQmmmLmNwugtlZ8muCNgUr5aDECusyRQB",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Save Page",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRg4BAABXRUJQVlA4TAIBAAAvf8AfEBYItu2mjbbx9r9VtUOyhkH/nHIDGmafRvTEbQAAZBNNtu2ckVNySnbdkDM62t462e4HnYB8+iwQMrbjeesPjJw3f9efA6izPyZyz2jli0oNHFwB823BJ5AnFEniR7OqWBt2dUFXZltV1SVp9oRtKjOT1JDlBd2Zt8zMMsMj8vrqgvZ2XewbJ6/3Tgwk50/cuJ3On/omjO7fWdMI4y3PmuRm7W232+2gIytJGq7L2MNHJ1ZwcUGwMWIJG1ZisjViDhtWYo1GzGDCymFlxPQlrBzYG41VtTLbqqpuGNbJWRpudcrehMT5M579JS6H6BKPY3T5eowuoQbPIE14yjo=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/chrome-shortcuts-waveshare-v4.json
+++ b/decks/profiles/chrome-shortcuts-waveshare-v4.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Chrome Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "chrome.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "chrome.exe"
+          }
+        },
+        "name": "Chrome Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Close Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reopen Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Previous Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 5,
+            "label": "Address Bar",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Hard Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Forward",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Home",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Home",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Find",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Downloads",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4BAABXRUJQVlA4TEIBAAAvf8AfEAXkSJIUSam/0v7IHlrrOoYIyLFtm7bWfW1HcDN6Ldvv27ZtMyGncF8eB3MCov9cGgLAv/++0MiYfRld4Z5k/MPVi5iGSLgjGf8AXLyESQAi4X7EfKGdvYBxtEh8O5ECW3DymDEszUUbVmQLjh4ywi8sRFtWZgsOH9Hn0ZaiTatyBfsP6PFoK9G21biCvdt0eLS1aOMaXMHOTdo82ka0dS2uYOsWTQ5tK9q8Nl+wcYMGh7YTbV+XL1i/pMah7UUD6vMFqxdUObSDaEQjfMHyKWUW7Sga0hhfsHhCiUU7icY0voD5AwUW7Swa1OQC5hbyDNpFNKrpBdhi0K6iYc0uzrqJxjV/wW00sMVT7qORLZ/wGA1t9cBzNLb1hVfBXJFNAN4F0eS24VMQzS4riH7MlDN8ZbNb0sIr2/2U+sci",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "History",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4EAABXRUJQVlA4TAIEAAAvf8AfEDVAkiQ3bJP/f7qrLECiCPAcIUISbdumHeUhNnq2bdu2rbLt2HZaZduxbbdtO48HgttGjiS5Djdx15s6VNcLvv9aRJidm+r8N2PVPhJhy5wp9cpd5kz4JODs5JrAgkehDcrjDD8DeoqtgWVZV8aoPRDeOsFLGRUIaQ1P0+BBCDuWLdlGPHkxI7wvtLWAGznSIEsIXRLRDzHaQqRpcABupJNmT3B6hgQJy8rY4Hy2BWOt2Hz2hZKPuyGUjYMojD88oKvWhotvmPwclNrB137a8oH6O3tUvUwb9gXXw25mmGXcS+2MLnrv7dLRng66X87MjLn0a1eS3kwJe5oG1xxHl4ohfVCXfk9ktn1F9USfXkC6oBAElG1s1mFq02YT3I7P5vxe0x6mG1rADXOBFLTbtShkCMENoGA39KpC9tsWFX8plMqB6Qv+JUXfFSeN4q7Gs+BeYY3x+GDyi6GCuNAKrQEWnhRFsxb14IdtkqvOXJc6M+/aH8ehtSoldiIilp2ZAzPzzrprwbbwMrK0fHVAQh9kBlIMhmYhH53wwQksxuuvks/L8AzFaPLiRvwKoBr+MSo6vCKpBXy+hR7zZLiE+Qj8YKBhMMz5YD7FF/Jqxp0rIlcC6wuDbeZBJcAcgBk04YP5NIQTJyPtwuWTEXKh/GRoX6g/GWIXpk7mQ8yMuaOx/cPW0VgCM4ijsdwcWsfv2NgQzvpeogmEoHnuAxHWvydoxXavdVh/GYJju99UhLaE1NjvtQ19MWi8QX3s9/tHz3EPTTfUs9oQekNYWw+WheM+/pbCF3ZfUF9FYWHygRH4YRGywR/BdwExd8GlaN9CtLwvrK4F5zjvKULJhZ9/HFtCTwxqK/ga531FUL9AU6wNymneW6WQtvDqj2NP6A7h5TOex3l/GfxD3oP6xlCP+7nPiXmPOiDGQuJhk0cCulf+IFpT3qdOvMOnKXpXyF1Icbqc8l6V0nphi2SVaUop71cKVWfBOqyGCb8FFK3ifk1qZfJWTcz7lq/2xZGFcxV4kPPe1SJnL7R+/PcjEhvz/h1W/IrWPUTmdY8OchOETQl7cR+b1v56SNkEKYJufKL4aKOkzWK/6pQAJ7kLirpu1v3aSHl8IXb2NKEQlxyl7VYVCO5i0sENrRi9XBzgQbd1b4epvMRLqi+3fMemJWIh/db9DeZ1CF+4QpfbSJ6+Y/uu+38fTplIkGReIVv4wm+NnTrbN3UPCnD3nONQ1wxuZE+DTAH0iUaGliCp/t/XfdDqO8viZ+yx7sWupbHlbKHupbV463pd9yMI0r70iPqruifljM+ovIKykGsC/QzGsAKu8JNqz/CzdUu1/2at2Ech7Vgwo1GFK7+6t39a9AE=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Bookmarks",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRs4DAABXRUJQVlA4TMEDAAAvf8AfEHXQkiTJbiPt/S/ttuhqCAC7v6fwKCACDgCAZaTj27Ztezrf9LZt27b9v9m2bVuTbfs/kNxGciQx9mZ7XHZk9w/yXy8hRnR2QgXPzrzZyWH3/2GfG1egOM9Nf5XeqaHxVXW9M2NaVcV4ZuobtRND4qm5vnkhVgj8vJRGiqcF6jxyds6KenWhOiupPcmzstezO2vlqIX7s6qK6KSVo1GpqhE8aeVo6DNozE5aORY+UD7v4sM+aeWo0pmpq2rS8qG/Yf8/Do3eSStH+cOcieVcXO+klcNEZqbJScuH+oZfwz+Uj0krB4GGYCwfU1YOGxlic8ryobQRF4kP5WPKykEhojho+WBnbFfMAAtH2cVxVZWZfcf5/uSLs09gb+T15NfePL8ayxQd7AXVg97LAcWffRO9rn3cQfRu9/tc3y/f3sL97aFi7fhU7nFeP/5AQLuKbFLC93dWTzXvhoOiaD1y/f38P+IwFR+AE2rHHi0VRxWYxpm/D4SsCvHF40jcLiCQDTnGBKLvOT4KNSiP8qiuEM8MhhmBRGxWiG1iB/VxW91b9clxgkJF90wyPAIjLxWoRJHb89MhLBdyr/PuRi2X3JEfD2GzuPd5zVXgkNKAp1r0OivELcIeTwGBbgxjnuuF+Q0Pyr94sK2+038ctSKGvRAA1Q1hQ1i2KcNHjNphhrAzWlvUszJqRw6EzApRsIVCIJADmYOHvt8GeguY8J5kmDk6In9Vjsy/ygeJ8QlulOWmqGiEjc9sQ3sbuo2F4WH7Fl6Rbzw5ea+qD+foONdCU26M1nZM3Eant2G2AlyCRLAVrBsDM1xt8I12fdQawtzD4Ccc1NiY1EJfdmg4rap6r+xiOLwoY1PXcO3w9l0heXd4NeonuNqAM0CtoVbyZYA3dDMkI0OohaVwCCTt1WrsxnlrtaoKcWRKGpENc69dF88KeZg1Yhqlw19tIJOJRGG3i3DPvK8KUfhlkm9cnOOiFrbo/yCJx3wFjqis71gvnsxwCNTHJSUUi4Tv2qVejBly6+sa6ZvyGqmD32iAERN38VMU6ErhvLtDEQPb2B8WUWDhp2uXbu5cDdxXIYbfqirioxICrMUMrj8XDrOrByV0VOaa7evXea8xP+yNhp5nRrsWzoFvQ3Cpji2iexfuKi5j0lf7F2qUqjrXuJWjyifXnTdjrqphb0MwOWihpuwwHN49ZOU4aqEu3c09ZOU4bKE+P39j3oZAOHKhhjmBegasHIcu1PdXSsarHM6OvYZ4yn5AR0Pi8GuIDEnkP1KSAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Incognito",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4TCoAAAAvf8AfEB8w//M//0ICQjTPSzcDXIRBJm1Tpmz+TdVEj4j+TwCxfV07FTU=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "DevTools",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkwBAABXRUJQVlA4TD8BAAAvf8AfEBa4kSQptp4Z6b+v/T629mFG+vxFpomYEzi3rR1zxlPZ8xNs22od2+6yUk4Zq7JT2rZttbaNdwLm1v9XrnvT4KT+9puvfOAxVznFzF7Zq442vNyu9yxtt/52artd59Vbh9fzp5k9XDkz82+UcWaYZ5eDPjlivWBol2y7z9I60GlM9HzygaGdxmRfhrWx1DgqubHVv0+Drw0tNc4Pa2ErW5PjW5mYXNFqfBPcV8s7weu1PBF8Xsv9wU+13Bn8WcvtwX+1noPfa3k8+L6Wt8JrLV8GT7UyxiC6oZVVyTmtnJusaeWl4EcjSplnEN02pd6SzaWcbhB9ZGglY11jkB0yZQwz2mSz7f7xq0H26l2N0/42Z8o5aco5ON387czp5jnzppl/3GXrlDyZ//zha+950CX2m3wAcuv/K9wBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "View Source",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRngDAABXRUJQVlA4TGwDAAAvf8AfEBemoI2kqDLw7/RewMFEzAmCtm2bWpL+BJI2PMBdDdwZMAbvB5OAGgJCiIcAgBDDNtZY5wVwMWAdhiB+GCehKws3w674TLuUbBUoPD8DkHbbliFJt9y2bYxt27Zt27Zt27aq+/21iRsRNZHzTRH9nwD89/8fpmtHrj316H3048PrR+Z0L3TurtBmVkYLHacRP/amGB7uGnRrOltg5ThpyGNdH4vF63VOVbDHfgs5DeQw1L4FYvfbcJdwnkhLC8OFDiKLxPpAl8ayRRaOkq8pqj5iP9rKodwG8ixglBklW6FMfhEDuRF0B4eItDYaKrSzapLQxj0Da9OCicUdV31lMsyhQWyJ0UHyNqK6Q+40BS+/xc45lPKFvAwapP8gK6AsFPWnAujmvyVS4A62EmljMFhoa1U7sgP6E1k/hzqzlQZ7ySO/agBZb5DdSKY6FHlLXoe0Ur+TeVD3Ik/i9XCTLHcIK4i01eovtAlpRWRDWM8TW7PVWrvIbdBCJje6BT3G/4i8i2gkfSXTGK4wkSfzmwe8BPOIdNToLbRMY7KOiLzePLTEO5qw9RrbyRloJj3R+/ne4jZhb8Bt8iGeJHwmo3TQ20xE3i5r5gnTiHQh3UUdzdbCTBsicraDB5SxzWQL2Q9932I7IrtznMNZ8ilBEf+R9DMABry3Iw9rnRtNpLuii6g/JxkhY94XK/K0xLXsKNmm2EA2wWbaqKs25GzQMRwgX5IARN6TjlYAVIw/+t1Ihrs2gEgfAB1F/TpsC0Bi+4V3DR74HUv+QnYCWEOWIsalY07qSAvHsIV8S0X4LWkZKwB1+zSmu9aJyAC0FfUD3y8AzGfbXAu/IXuwisyCdmJ122EzN51+2tco7gE54xqWke/Zr0id3mVRLzPCGnLTuVZEtoj6BvRXkmcho4XksnP+h4RPNhhBpKfREXLQOcwxKjaoYfcTDCobyFz36k1OwPQikR1BreQLQju6h5sGw4xGMTlapFF5QeirsAdM0fuRYZT4kMm3dT1KkwKpVX23fhc+Ax5Yorcb5l01rD5P9gKc0uptARtj0dgWnjhS51OCjfCeGEyAN2b90FgPq/EbbX0fBa/cp9HWDtDthZVLTeGZfdnLkC0kDjlvEj3QxYffbHmfBcduPv4U/fj82q7ZnTPx3/9/RgY=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Full Screen",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8wGBMxJ4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F11",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Print",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRvoAAABXRUJQVlA4TO4AAAAvf8AfEBq3sW2rShu7/1axp8FHLwd9Ee4e/hI+USN64rYBAKQJq39AOMGZ7QFGl5kroD73gl7gvuncdGSsu7t3AmyiSnz+ge4qLjYMvFoOcM1rPV4eBHEqNHssLYQ/r5uW8uvxRgw8EgweSiZ31CjgeSuhC9gYKCqpZGNgnxZ2MUgSE4gkLiUplmJJLNUPMiFbUgA5A+MgCTtnMJJEOmeAzCWh5MwgadDDs6xFXyXdEAK9pWunQHcVF10yXt85qM1rPWyCS9Mj/VBOTY//mNyG4LaKmbpsQmmmLmNwugtlZ8muCNgUr5aDECusyRQB",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Save Page",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRg4BAABXRUJQVlA4TAIBAAAvf8AfEBYItu2mjbbx9r9VtUOyhkH/nHIDGmafRvTEbQAAZBNNtu2ckVNySnbdkDM62t462e4HnYB8+iwQMrbjeesPjJw3f9efA6izPyZyz2jli0oNHFwB823BJ5AnFEniR7OqWBt2dUFXZltV1SVp9oRtKjOT1JDlBd2Zt8zMMsMj8vrqgvZ2XewbJ6/3Tgwk50/cuJ3On/omjO7fWdMI4y3PmuRm7W232+2gIytJGq7L2MNHJ1ZwcUGwMWIJG1ZisjViDhtWYo1GzGDCymFlxPQlrBzYG41VtTLbqqpuGNbJWRpudcrehMT5M579JS6H6BKPY3T5eowuoQbPIE14yjo=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/chrome-shortcuts.json
+++ b/decks/profiles/chrome-shortcuts.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Chrome Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "chrome.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "chrome.exe"
+          }
+        },
+        "name": "Chrome Shortcuts",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Close Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reopen Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Previous Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 5,
+            "label": "Address Bar",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Hard Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Forward",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Home",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Home",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Find",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Downloads",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4BAABXRUJQVlA4TEIBAAAvf8AfEAXkSJIUSam/0v7IHlrrOoYIyLFtm7bWfW1HcDN6Ldvv27ZtMyGncF8eB3MCov9cGgLAv/++0MiYfRld4Z5k/MPVi5iGSLgjGf8AXLyESQAi4X7EfKGdvYBxtEh8O5ECW3DymDEszUUbVmQLjh4ywi8sRFtWZgsOH9Hn0ZaiTatyBfsP6PFoK9G21biCvdt0eLS1aOMaXMHOTdo82ka0dS2uYOsWTQ5tK9q8Nl+wcYMGh7YTbV+XL1i/pMah7UUD6vMFqxdUObSDaEQjfMHyKWUW7Sga0hhfsHhCiUU7icY0voD5AwUW7Swa1OQC5hbyDNpFNKrpBdhi0K6iYc0uzrqJxjV/wW00sMVT7qORLZ/wGA1t9cBzNLb1hVfBXJFNAN4F0eS24VMQzS4riH7MlDN8ZbNb0sIr2/2U+sci",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "History",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4EAABXRUJQVlA4TAIEAAAvf8AfEDVAkiQ3bJP/f7qrLECiCPAcIUISbdumHeUhNnq2bdu2rbLt2HZaZduxbbdtO48HgttGjiS5Djdx15s6VNcLvv9aRJidm+r8N2PVPhJhy5wp9cpd5kz4JODs5JrAgkehDcrjDD8DeoqtgWVZV8aoPRDeOsFLGRUIaQ1P0+BBCDuWLdlGPHkxI7wvtLWAGznSIEsIXRLRDzHaQqRpcABupJNmT3B6hgQJy8rY4Hy2BWOt2Hz2hZKPuyGUjYMojD88oKvWhotvmPwclNrB137a8oH6O3tUvUwb9gXXw25mmGXcS+2MLnrv7dLRng66X87MjLn0a1eS3kwJe5oG1xxHl4ohfVCXfk9ktn1F9USfXkC6oBAElG1s1mFq02YT3I7P5vxe0x6mG1rADXOBFLTbtShkCMENoGA39KpC9tsWFX8plMqB6Qv+JUXfFSeN4q7Gs+BeYY3x+GDyi6GCuNAKrQEWnhRFsxb14IdtkqvOXJc6M+/aH8ehtSoldiIilp2ZAzPzzrprwbbwMrK0fHVAQh9kBlIMhmYhH53wwQksxuuvks/L8AzFaPLiRvwKoBr+MSo6vCKpBXy+hR7zZLiE+Qj8YKBhMMz5YD7FF/Jqxp0rIlcC6wuDbeZBJcAcgBk04YP5NIQTJyPtwuWTEXKh/GRoX6g/GWIXpk7mQ8yMuaOx/cPW0VgCM4ijsdwcWsfv2NgQzvpeogmEoHnuAxHWvydoxXavdVh/GYJju99UhLaE1NjvtQ19MWi8QX3s9/tHz3EPTTfUs9oQekNYWw+WheM+/pbCF3ZfUF9FYWHygRH4YRGywR/BdwExd8GlaN9CtLwvrK4F5zjvKULJhZ9/HFtCTwxqK/ga531FUL9AU6wNymneW6WQtvDqj2NP6A7h5TOex3l/GfxD3oP6xlCP+7nPiXmPOiDGQuJhk0cCulf+IFpT3qdOvMOnKXpXyF1Icbqc8l6V0nphi2SVaUop71cKVWfBOqyGCb8FFK3ifk1qZfJWTcz7lq/2xZGFcxV4kPPe1SJnL7R+/PcjEhvz/h1W/IrWPUTmdY8OchOETQl7cR+b1v56SNkEKYJufKL4aKOkzWK/6pQAJ7kLirpu1v3aSHl8IXb2NKEQlxyl7VYVCO5i0sENrRi9XBzgQbd1b4epvMRLqi+3fMemJWIh/db9DeZ1CF+4QpfbSJ6+Y/uu+38fTplIkGReIVv4wm+NnTrbN3UPCnD3nONQ1wxuZE+DTAH0iUaGliCp/t/XfdDqO8viZ+yx7sWupbHlbKHupbV463pd9yMI0r70iPqruifljM+ovIKykGsC/QzGsAKu8JNqz/CzdUu1/2at2Ech7Vgwo1GFK7+6t39a9AE=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Bookmarks",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRs4DAABXRUJQVlA4TMEDAAAvf8AfEHXQkiTJbiPt/S/ttuhqCAC7v6fwKCACDgCAZaTj27Ztezrf9LZt27b9v9m2bVuTbfs/kNxGciQx9mZ7XHZk9w/yXy8hRnR2QgXPzrzZyWH3/2GfG1egOM9Nf5XeqaHxVXW9M2NaVcV4ZuobtRND4qm5vnkhVgj8vJRGiqcF6jxyds6KenWhOiupPcmzstezO2vlqIX7s6qK6KSVo1GpqhE8aeVo6DNozE5aORY+UD7v4sM+aeWo0pmpq2rS8qG/Yf8/Do3eSStH+cOcieVcXO+klcNEZqbJScuH+oZfwz+Uj0krB4GGYCwfU1YOGxlic8ryobQRF4kP5WPKykEhojho+WBnbFfMAAtH2cVxVZWZfcf5/uSLs09gb+T15NfePL8ayxQd7AXVg97LAcWffRO9rn3cQfRu9/tc3y/f3sL97aFi7fhU7nFeP/5AQLuKbFLC93dWTzXvhoOiaD1y/f38P+IwFR+AE2rHHi0VRxWYxpm/D4SsCvHF40jcLiCQDTnGBKLvOT4KNSiP8qiuEM8MhhmBRGxWiG1iB/VxW91b9clxgkJF90wyPAIjLxWoRJHb89MhLBdyr/PuRi2X3JEfD2GzuPd5zVXgkNKAp1r0OivELcIeTwGBbgxjnuuF+Q0Pyr94sK2+038ctSKGvRAA1Q1hQ1i2KcNHjNphhrAzWlvUszJqRw6EzApRsIVCIJADmYOHvt8GeguY8J5kmDk6In9Vjsy/ygeJ8QlulOWmqGiEjc9sQ3sbuo2F4WH7Fl6Rbzw5ea+qD+foONdCU26M1nZM3Eant2G2AlyCRLAVrBsDM1xt8I12fdQawtzD4Ccc1NiY1EJfdmg4rap6r+xiOLwoY1PXcO3w9l0heXd4NeonuNqAM0CtoVbyZYA3dDMkI0OohaVwCCTt1WrsxnlrtaoKcWRKGpENc69dF88KeZg1Yhqlw19tIJOJRGG3i3DPvK8KUfhlkm9cnOOiFrbo/yCJx3wFjqis71gvnsxwCNTHJSUUi4Tv2qVejBly6+sa6ZvyGqmD32iAERN38VMU6ErhvLtDEQPb2B8WUWDhp2uXbu5cDdxXIYbfqirioxICrMUMrj8XDrOrByV0VOaa7evXea8xP+yNhp5nRrsWzoFvQ3Cpji2iexfuKi5j0lf7F2qUqjrXuJWjyifXnTdjrqphb0MwOWihpuwwHN49ZOU4aqEu3c09ZOU4bKE+P39j3oZAOHKhhjmBegasHIcu1PdXSsarHM6OvYZ4yn5AR0Pi8GuIDEnkP1KSAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Incognito",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4TCoAAAAvf8AfEB8w//M//0ICQjTPSzcDXIRBJm1Tpmz+TdVEj4j+TwCxfV07FTU=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "DevTools",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkwBAABXRUJQVlA4TD8BAAAvf8AfEBa4kSQptp4Z6b+v/T629mFG+vxFpomYEzi3rR1zxlPZ8xNs22od2+6yUk4Zq7JT2rZttbaNdwLm1v9XrnvT4KT+9puvfOAxVznFzF7Zq442vNyu9yxtt/52artd59Vbh9fzp5k9XDkz82+UcWaYZ5eDPjlivWBol2y7z9I60GlM9HzygaGdxmRfhrWx1DgqubHVv0+Drw0tNc4Pa2ErW5PjW5mYXNFqfBPcV8s7weu1PBF8Xsv9wU+13Bn8WcvtwX+1noPfa3k8+L6Wt8JrLV8GT7UyxiC6oZVVyTmtnJusaeWl4EcjSplnEN02pd6SzaWcbhB9ZGglY11jkB0yZQwz2mSz7f7xq0H26l2N0/42Z8o5aco5ON387czp5jnzppl/3GXrlDyZ//zha+950CX2m3wAcuv/K9wBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "View Source",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRngDAABXRUJQVlA4TGwDAAAvf8AfEBemoI2kqDLw7/RewMFEzAmCtm2bWpL+BJI2PMBdDdwZMAbvB5OAGgJCiIcAgBDDNtZY5wVwMWAdhiB+GCehKws3w674TLuUbBUoPD8DkHbbliFJt9y2bYxt27Zt27Zt27aq+/21iRsRNZHzTRH9nwD89/8fpmtHrj316H3048PrR+Z0L3TurtBmVkYLHacRP/amGB7uGnRrOltg5ThpyGNdH4vF63VOVbDHfgs5DeQw1L4FYvfbcJdwnkhLC8OFDiKLxPpAl8ayRRaOkq8pqj5iP9rKodwG8ixglBklW6FMfhEDuRF0B4eItDYaKrSzapLQxj0Da9OCicUdV31lMsyhQWyJ0UHyNqK6Q+40BS+/xc45lPKFvAwapP8gK6AsFPWnAujmvyVS4A62EmljMFhoa1U7sgP6E1k/hzqzlQZ7ySO/agBZb5DdSKY6FHlLXoe0Ur+TeVD3Ik/i9XCTLHcIK4i01eovtAlpRWRDWM8TW7PVWrvIbdBCJje6BT3G/4i8i2gkfSXTGK4wkSfzmwe8BPOIdNToLbRMY7KOiLzePLTEO5qw9RrbyRloJj3R+/ne4jZhb8Bt8iGeJHwmo3TQ20xE3i5r5gnTiHQh3UUdzdbCTBsicraDB5SxzWQL2Q9932I7IrtznMNZ8ilBEf+R9DMABry3Iw9rnRtNpLuii6g/JxkhY94XK/K0xLXsKNmm2EA2wWbaqKs25GzQMRwgX5IARN6TjlYAVIw/+t1Ihrs2gEgfAB1F/TpsC0Bi+4V3DR74HUv+QnYCWEOWIsalY07qSAvHsIV8S0X4LWkZKwB1+zSmu9aJyAC0FfUD3y8AzGfbXAu/IXuwisyCdmJ122EzN51+2tco7gE54xqWke/Zr0id3mVRLzPCGnLTuVZEtoj6BvRXkmcho4XksnP+h4RPNhhBpKfREXLQOcwxKjaoYfcTDCobyFz36k1OwPQikR1BreQLQju6h5sGw4xGMTlapFF5QeirsAdM0fuRYZT4kMm3dT1KkwKpVX23fhc+Ax5Yorcb5l01rD5P9gKc0uptARtj0dgWnjhS51OCjfCeGEyAN2b90FgPq/EbbX0fBa/cp9HWDtDthZVLTeGZfdnLkC0kDjlvEj3QxYffbHmfBcduPv4U/fj82q7ZnTPx3/9/RgY=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Full Screen",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8wGBMxJ4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F11",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Print",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRvoAAABXRUJQVlA4TO4AAAAvf8AfEBq3sW2rShu7/1axp8FHLwd9Ee4e/hI+USN64rYBAKQJq39AOMGZ7QFGl5kroD73gl7gvuncdGSsu7t3AmyiSnz+ge4qLjYMvFoOcM1rPV4eBHEqNHssLYQ/r5uW8uvxRgw8EgweSiZ31CjgeSuhC9gYKCqpZGNgnxZ2MUgSE4gkLiUplmJJLNUPMiFbUgA5A+MgCTtnMJJEOmeAzCWh5MwgadDDs6xFXyXdEAK9pWunQHcVF10yXt85qM1rPWyCS9Mj/VBOTY//mNyG4LaKmbpsQmmmLmNwugtlZ8muCNgUr5aDECusyRQB",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Save Page",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRg4BAABXRUJQVlA4TAIBAAAvf8AfEBYItu2mjbbx9r9VtUOyhkH/nHIDGmafRvTEbQAAZBNNtu2ckVNySnbdkDM62t462e4HnYB8+iwQMrbjeesPjJw3f9efA6izPyZyz2jli0oNHFwB823BJ5AnFEniR7OqWBt2dUFXZltV1SVp9oRtKjOT1JDlBd2Zt8zMMsMj8vrqgvZ2XewbJ6/3Tgwk50/cuJ3On/omjO7fWdMI4y3PmuRm7W232+2gIytJGq7L2MNHJ1ZwcUGwMWIJG1ZisjViDhtWYo1GzGDCymFlxPQlrBzYG41VtTLbqqpuGNbJWRpudcrehMT5M579JS6H6BKPY3T5eowuoQbPIE14yjo=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/cursor-shortcuts-waveshare-v3.json
+++ b/decks/profiles/cursor-shortcuts-waveshare-v3.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Cursor Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "cursor.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "cursor.exe"
+          }
+        },
+        "name": "Cursor Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Command Palette",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 1,
+            "label": "Quick Open",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "New File",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Save",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Close Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Reopen Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Split Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backslash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Toggle Terminal",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Explorer",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 10,
+            "label": "Source Control",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 11,
+            "label": "Run / Debug",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 12,
+            "label": "Extensions",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4TEYAAAAvf8AfEC8w//M//4raNmI6Dsz8HbXjrwD+SCwCB7WRpDa4Vshphv67cVLkJ6L/EwDf2ubZNaMw8x4QxjWjMPMeFpfl8k8N",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Toggle Sidebar",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwCAABXRUJQVlA4TAACAAAvf8AfEHVIciPJkaT6/6c5KyIzC5txW+ErYhEBBwDAMlJ797Zt+yf7J9u2bfsn27Zt27Zt28oE5Jf/vyeNj7NSE848+/Xq1Kp+sXTR3cEg8DrxBZjcrQOb+mhBaYWWc+CgVfx9gCUBZ31xbEMacJx5E4yA837JtADPzQtjDUoH/IHSv3bm+BBCgYORqgKf1XD4tta5FV6zb6uwRSA1VhuVmQbQzde9oc0qao/F/L8fpULTA63zq5jcj1mhfAO5/0Lw/RgULmCuxXoh935kilEBbe2+L6CrxhodKC3FUjXjQiIJyIYErMyMe9VsMXUD18Xal/ZlkIXWSRjuzYxHOUQbiagTM2OaSh9gGWdmtKHoImHm+cw4xddGkIj3cWRcYmojQcjF8okxDaWPJNh4GvC9NRxbSQKHsmTbG04gmvkS82/jK0OyoST4dS4I7ymRWKm/HRzcFDmIUmXSJeMtGE4KU7ezOF+XsxUlhfXbyS9cQd2SXFi8Hadi6G/pL/TcDk/lCPYGTn+FuNvFfDGaoCzBMzcl1etxqcYA+gWc5oDSHbTrwXFajS9l9DDDhUSAi7E630At8oGuF1oLR13DayAq3/BPMR1A0/4C37QQmH9P+ebyQE0kdNwcsUAgfQQOG7M7fnXTBD9Qs1gZSTJk3bk3v/9cW9EihgbSB/rl/+8mAw==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Problems",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Settings",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Format Document",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 17,
+            "label": "Rename Symbol",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvICAABXRUJQVlA4TOUCAAAvf8AfEHVIciPJkaT6/6e5ojwzazvmtiJGxCJCAgCAZSM1Z9u2bdu2bdu2bVtv27b/bNu+Kyag//n/d9MkhOvzybIDsCNL/nupjCOO1/Matv/pxJ5FvzxVL4wkcASxaCOwTS/YwStn0YI4xHvsrMxB/0mWNWOM5Aages46F1rX2CW/pn6O865rLKFf4TbnwbTrGj0LKGw+MIbh1QUhnCTDItRD3iRQw0OGm6VOZ2mEvJ6uvgfgIkCKnqIcK2mUJOPBOPnO+I0m3+qIGLxJhgMO2L1j7L2K1V6Y/9U0WvsBgvSOWXDngtYlJR7ltI4weO94BQMbGKFBej2SEsk7LsEq4rU2ErTVIz/huqMdxiCCtdd/wO2E9A5HGsMc4L0F+MDB8AVFf9KMVVXU4VaH1dhE1UnKyszYcVUgnpoABCiwkmCu2vFEKOGE3Oraz2Y0MkRQx3kDF7TIdW9m7GmlUpw51Cut+MTM+MqiMktEexnQeGbGA0xleYe9d3k5ODOWSNTkF6c+iE6F0yNjDU851tyVRqwPoxbh74nxFV41hkn3kwTEeuVia4S+nK4GEGKmLtdeGBcSnuhuZMzVmNiwCOf1btF5H2bUA4/8jFeUjytDo4hG4mOar8e6m6THC7KraCy20kj5BbpVJTfLaNYLYGoryIgyFaLYFZ+tcd9CZDH4UkcbSGMO2YLfc691q/UGI4WgtZ5G3YKO8Al/S03wu5DmvAClkoSF4bzlZfCsknY/jb/wArFkHukGYUhQXgo2+2nEhvYzjDufSyj8mMiylOa/4BBLEJHGK5wLhP2ARdsIamnP0hgKyCylca6fE17kcFER4e6GC1iWe0HF4HKYhu5ds1s4agNFNS10wSj8uzb0BJRplwN4nUZiQODhAx9dT+N1nBxhv2vEn6dciLigilp0GtdDNwebR/wi3zXB8TENg9TIBPi+A/aULXBBbyx+bqq9MWLFMdiRDf/cU8oG/QX98/9vkQEA",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go to Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Peek Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Line Comment",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Duplicate Line",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOEAAAAvf8AfEFU4cNvGkf7/al1LNuuzr/eLYFpr25IFkO4MwAg6ypeorPAPgo3ACG6N5Bq9cv72m2nbxg2AXQPxeW8yFMjqcaPaU+ROkjlN9sAc8/GV3BGvOAuWpmRPkTtJ5jR5E2VNlTNZxnT5EpYBDZgMh/8wbGA3OHeEkNVjhrenyJ0kc5rsEYKmI2pyh/WZDoA0xepK1ZYLl6UUC4RQi/VpitWVqi1UXyIO4v3ofqXYv/P7laDS/VAualAoC6N2Jhrxa2h/0MJow4x2VfsCk5Efg9kIH4NwcogGNiXdteCtyT4A",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 22,
+            "label": "Move Line Up",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Move Line Down",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/cursor-shortcuts-waveshare-v4.json
+++ b/decks/profiles/cursor-shortcuts-waveshare-v4.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Cursor Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "cursor.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "cursor.exe"
+          }
+        },
+        "name": "Cursor Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Command Palette",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 1,
+            "label": "Quick Open",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "New File",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Save",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Close Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Reopen Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Split Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backslash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Toggle Terminal",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Explorer",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 10,
+            "label": "Source Control",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 11,
+            "label": "Run / Debug",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 12,
+            "label": "Extensions",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4TEYAAAAvf8AfEC8w//M//4raNmI6Dsz8HbXjrwD+SCwCB7WRpDa4Vshphv67cVLkJ6L/EwDf2ubZNaMw8x4QxjWjMPMeFpfl8k8N",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Toggle Sidebar",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwCAABXRUJQVlA4TAACAAAvf8AfEHVIciPJkaT6/6c5KyIzC5txW+ErYhEBBwDAMlJ797Zt+yf7J9u2bfsn27Zt27Zt28oE5Jf/vyeNj7NSE848+/Xq1Kp+sXTR3cEg8DrxBZjcrQOb+mhBaYWWc+CgVfx9gCUBZ31xbEMacJx5E4yA837JtADPzQtjDUoH/IHSv3bm+BBCgYORqgKf1XD4tta5FV6zb6uwRSA1VhuVmQbQzde9oc0qao/F/L8fpULTA63zq5jcj1mhfAO5/0Lw/RgULmCuxXoh935kilEBbe2+L6CrxhodKC3FUjXjQiIJyIYErMyMe9VsMXUD18Xal/ZlkIXWSRjuzYxHOUQbiagTM2OaSh9gGWdmtKHoImHm+cw4xddGkIj3cWRcYmojQcjF8okxDaWPJNh4GvC9NRxbSQKHsmTbG04gmvkS82/jK0OyoST4dS4I7ymRWKm/HRzcFDmIUmXSJeMtGE4KU7ezOF+XsxUlhfXbyS9cQd2SXFi8Hadi6G/pL/TcDk/lCPYGTn+FuNvFfDGaoCzBMzcl1etxqcYA+gWc5oDSHbTrwXFajS9l9DDDhUSAi7E630At8oGuF1oLR13DayAq3/BPMR1A0/4C37QQmH9P+ebyQE0kdNwcsUAgfQQOG7M7fnXTBD9Qs1gZSTJk3bk3v/9cW9EihgbSB/rl/+8mAw==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Problems",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Settings",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Format Document",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 17,
+            "label": "Rename Symbol",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvICAABXRUJQVlA4TOUCAAAvf8AfEHVIciPJkaT6/6e5ojwzazvmtiJGxCJCAgCAZSM1Z9u2bdu2bdu2bVtv27b/bNu+Kyag//n/d9MkhOvzybIDsCNL/nupjCOO1/Matv/pxJ5FvzxVL4wkcASxaCOwTS/YwStn0YI4xHvsrMxB/0mWNWOM5Aages46F1rX2CW/pn6O865rLKFf4TbnwbTrGj0LKGw+MIbh1QUhnCTDItRD3iRQw0OGm6VOZ2mEvJ6uvgfgIkCKnqIcK2mUJOPBOPnO+I0m3+qIGLxJhgMO2L1j7L2K1V6Y/9U0WvsBgvSOWXDngtYlJR7ltI4weO94BQMbGKFBej2SEsk7LsEq4rU2ErTVIz/huqMdxiCCtdd/wO2E9A5HGsMc4L0F+MDB8AVFf9KMVVXU4VaH1dhE1UnKyszYcVUgnpoABCiwkmCu2vFEKOGE3Oraz2Y0MkRQx3kDF7TIdW9m7GmlUpw51Cut+MTM+MqiMktEexnQeGbGA0xleYe9d3k5ODOWSNTkF6c+iE6F0yNjDU851tyVRqwPoxbh74nxFV41hkn3kwTEeuVia4S+nK4GEGKmLtdeGBcSnuhuZMzVmNiwCOf1btF5H2bUA4/8jFeUjytDo4hG4mOar8e6m6THC7KraCy20kj5BbpVJTfLaNYLYGoryIgyFaLYFZ+tcd9CZDH4UkcbSGMO2YLfc691q/UGI4WgtZ5G3YKO8Al/S03wu5DmvAClkoSF4bzlZfCsknY/jb/wArFkHukGYUhQXgo2+2nEhvYzjDufSyj8mMiylOa/4BBLEJHGK5wLhP2ARdsIamnP0hgKyCylca6fE17kcFER4e6GC1iWe0HF4HKYhu5ds1s4agNFNS10wSj8uzb0BJRplwN4nUZiQODhAx9dT+N1nBxhv2vEn6dciLigilp0GtdDNwebR/wi3zXB8TENg9TIBPi+A/aULXBBbyx+bqq9MWLFMdiRDf/cU8oG/QX98/9vkQEA",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go to Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Peek Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Line Comment",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Duplicate Line",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOEAAAAvf8AfEFU4cNvGkf7/al1LNuuzr/eLYFpr25IFkO4MwAg6ypeorPAPgo3ACG6N5Bq9cv72m2nbxg2AXQPxeW8yFMjqcaPaU+ROkjlN9sAc8/GV3BGvOAuWpmRPkTtJ5jR5E2VNlTNZxnT5EpYBDZgMh/8wbGA3OHeEkNVjhrenyJ0kc5rsEYKmI2pyh/WZDoA0xepK1ZYLl6UUC4RQi/VpitWVqi1UXyIO4v3ofqXYv/P7laDS/VAualAoC6N2Jhrxa2h/0MJow4x2VfsCk5Efg9kIH4NwcogGNiXdteCtyT4A",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 22,
+            "label": "Move Line Up",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Move Line Down",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/cursor-shortcuts.json
+++ b/decks/profiles/cursor-shortcuts.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Cursor Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "cursor.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "cursor.exe"
+          }
+        },
+        "name": "Cursor Shortcuts",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Command Palette",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 1,
+            "label": "Quick Open",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "New File",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Save",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Close Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Reopen Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Split Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backslash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Toggle Terminal",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Explorer",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 10,
+            "label": "Source Control",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 11,
+            "label": "Run / Debug",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 12,
+            "label": "Extensions",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4TEYAAAAvf8AfEC8w//M//4raNmI6Dsz8HbXjrwD+SCwCB7WRpDa4Vshphv67cVLkJ6L/EwDf2ubZNaMw8x4QxjWjMPMeFpfl8k8N",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Toggle Sidebar",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwCAABXRUJQVlA4TAACAAAvf8AfEHVIciPJkaT6/6c5KyIzC5txW+ErYhEBBwDAMlJ797Zt+yf7J9u2bfsn27Zt27Zt28oE5Jf/vyeNj7NSE848+/Xq1Kp+sXTR3cEg8DrxBZjcrQOb+mhBaYWWc+CgVfx9gCUBZ31xbEMacJx5E4yA837JtADPzQtjDUoH/IHSv3bm+BBCgYORqgKf1XD4tta5FV6zb6uwRSA1VhuVmQbQzde9oc0qao/F/L8fpULTA63zq5jcj1mhfAO5/0Lw/RgULmCuxXoh935kilEBbe2+L6CrxhodKC3FUjXjQiIJyIYErMyMe9VsMXUD18Xal/ZlkIXWSRjuzYxHOUQbiagTM2OaSh9gGWdmtKHoImHm+cw4xddGkIj3cWRcYmojQcjF8okxDaWPJNh4GvC9NRxbSQKHsmTbG04gmvkS82/jK0OyoST4dS4I7ymRWKm/HRzcFDmIUmXSJeMtGE4KU7ezOF+XsxUlhfXbyS9cQd2SXFi8Hadi6G/pL/TcDk/lCPYGTn+FuNvFfDGaoCzBMzcl1etxqcYA+gWc5oDSHbTrwXFajS9l9DDDhUSAi7E630At8oGuF1oLR13DayAq3/BPMR1A0/4C37QQmH9P+ebyQE0kdNwcsUAgfQQOG7M7fnXTBD9Qs1gZSTJk3bk3v/9cW9EihgbSB/rl/+8mAw==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Problems",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Settings",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Format Document",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 17,
+            "label": "Rename Symbol",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvICAABXRUJQVlA4TOUCAAAvf8AfEHVIciPJkaT6/6e5ojwzazvmtiJGxCJCAgCAZSM1Z9u2bdu2bdu2bVtv27b/bNu+Kyag//n/d9MkhOvzybIDsCNL/nupjCOO1/Matv/pxJ5FvzxVL4wkcASxaCOwTS/YwStn0YI4xHvsrMxB/0mWNWOM5Aages46F1rX2CW/pn6O865rLKFf4TbnwbTrGj0LKGw+MIbh1QUhnCTDItRD3iRQw0OGm6VOZ2mEvJ6uvgfgIkCKnqIcK2mUJOPBOPnO+I0m3+qIGLxJhgMO2L1j7L2K1V6Y/9U0WvsBgvSOWXDngtYlJR7ltI4weO94BQMbGKFBej2SEsk7LsEq4rU2ErTVIz/huqMdxiCCtdd/wO2E9A5HGsMc4L0F+MDB8AVFf9KMVVXU4VaH1dhE1UnKyszYcVUgnpoABCiwkmCu2vFEKOGE3Oraz2Y0MkRQx3kDF7TIdW9m7GmlUpw51Cut+MTM+MqiMktEexnQeGbGA0xleYe9d3k5ODOWSNTkF6c+iE6F0yNjDU851tyVRqwPoxbh74nxFV41hkn3kwTEeuVia4S+nK4GEGKmLtdeGBcSnuhuZMzVmNiwCOf1btF5H2bUA4/8jFeUjytDo4hG4mOar8e6m6THC7KraCy20kj5BbpVJTfLaNYLYGoryIgyFaLYFZ+tcd9CZDH4UkcbSGMO2YLfc691q/UGI4WgtZ5G3YKO8Al/S03wu5DmvAClkoSF4bzlZfCsknY/jb/wArFkHukGYUhQXgo2+2nEhvYzjDufSyj8mMiylOa/4BBLEJHGK5wLhP2ARdsIamnP0hgKyCylca6fE17kcFER4e6GC1iWe0HF4HKYhu5ds1s4agNFNS10wSj8uzb0BJRplwN4nUZiQODhAx9dT+N1nBxhv2vEn6dciLigilp0GtdDNwebR/wi3zXB8TENg9TIBPi+A/aULXBBbyx+bqq9MWLFMdiRDf/cU8oG/QX98/9vkQEA",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go to Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Peek Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Line Comment",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Duplicate Line",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOEAAAAvf8AfEFU4cNvGkf7/al1LNuuzr/eLYFpr25IFkO4MwAg6ypeorPAPgo3ACG6N5Bq9cv72m2nbxg2AXQPxeW8yFMjqcaPaU+ROkjlN9sAc8/GV3BGvOAuWpmRPkTtJ5jR5E2VNlTNZxnT5EpYBDZgMh/8wbGA3OHeEkNVjhrenyJ0kc5rsEYKmI2pyh/WZDoA0xepK1ZYLl6UUC4RQi/VpitWVqi1UXyIO4v3ofqXYv/P7laDS/VAualAoC6N2Jhrxa2h/0MJow4x2VfsCk5Efg9kIH4NwcogGNiXdteCtyT4A",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 22,
+            "label": "Move Line Up",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Move Line Down",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/excel-shortcuts-waveshare-v3.json
+++ b/decks/profiles/excel-shortcuts-waveshare-v3.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Excel Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "excel.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "excel.exe"
+          }
+        },
+        "name": "Excel Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Workbook",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Format Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Edit Cell",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "AutoSum",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Toggle Formulas",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Insert Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Delete Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Fill Down",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Fill Right",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Create Table",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Toggle Filter",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Bold",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Italic",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Underline",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Repeat Action",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F4",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Current Date",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRr4CAABXRUJQVlA4TLICAAAvf8AfEIXkRpIcSUr9lbbdu4tiMfdjEbJo2zYdacdJ2bZt21XdX7Zt27Zt27Zt27ZiJ3sCBv/9/4dkcnWmOOKZv4ys1N67YJFWPH4/0mygxmVWR9VueYC7zHR+eu6sVXqK/xDCHMCDLkq6lN3RgegD6EyHRxn1eQPRU9lthJbhcfMfQWa9ughtwovGP4JoVJUZeFXlK6hNkQa46KM5SoWScRGvi4sr3lO8wii+hrvvid5oskFU5WNCffcsGQwGAyJSrvylqG+S1wvoOkGLORgpFQxW+XmSfCI+k9X6mlCLEr70gVH2YF04ZUC1dwY8XEueE3QYgdGwwa4ByfpLA15+BFTe4WXwjWyLghIRWd0xTwOetwbaJxsrxGE0ebBvvcumquU8WD1H5Evwi6BBvyT9wP65gVkBpTfYGvwnaFKddGnwJDg/aOKRLG5gDFZXDfwOjhbwwmhil8fBvQKJSf8u54NvBbKTHl2OBaoCRUnXLgcCY4HCpHeXfYGtQEYytMvRQF8gKpnR5Vzwr4Ai2dLlYfC6YOBncL3Lj+Big9OBnviAVk5ry/ERzhhtaDA9oLwDtiDS2KCc4AUFycAGFcmMPQr/8GcfTRFzz4ikqIGEMvhBtqUTRqfuuRkoiRsGlgU0dIfM66T9NSkYbRtUSmIPDDI2TMNIz/maA0llx8DOgP7KXNIJs+WDW/pg9JKgRCRdQBoDiAK52ZjpBVziYg1mLQet+iZEr0ySJ4CEhzwTfMdFMwbHCMl4SdTYBlrM7hDWDGxdOOke+YHTjJIGveTOXKAUMXhG90EzuUPH/JIzeMakQTehCaxnvBY9eIVZv0G9TLcOMJpCMXjFVSmDT6i+E6xrvpkpfLB7jMVB1YNPyVcbK1zymYaVxmeP7DZMKdFgf4+NwS9PnTBfc16D//7/Mzo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Current Time",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/excel-shortcuts-waveshare-v4.json
+++ b/decks/profiles/excel-shortcuts-waveshare-v4.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Excel Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "excel.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "excel.exe"
+          }
+        },
+        "name": "Excel Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Workbook",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Format Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Edit Cell",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "AutoSum",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Toggle Formulas",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Insert Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Delete Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Fill Down",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Fill Right",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Create Table",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Toggle Filter",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Bold",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Italic",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Underline",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Repeat Action",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F4",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Current Date",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRr4CAABXRUJQVlA4TLICAAAvf8AfEIXkRpIcSUr9lbbdu4tiMfdjEbJo2zYdacdJ2bZt21XdX7Zt27Zt27Zt27ZiJ3sCBv/9/4dkcnWmOOKZv4ys1N67YJFWPH4/0mygxmVWR9VueYC7zHR+eu6sVXqK/xDCHMCDLkq6lN3RgegD6EyHRxn1eQPRU9lthJbhcfMfQWa9ughtwovGP4JoVJUZeFXlK6hNkQa46KM5SoWScRGvi4sr3lO8wii+hrvvid5oskFU5WNCffcsGQwGAyJSrvylqG+S1wvoOkGLORgpFQxW+XmSfCI+k9X6mlCLEr70gVH2YF04ZUC1dwY8XEueE3QYgdGwwa4ByfpLA15+BFTe4WXwjWyLghIRWd0xTwOetwbaJxsrxGE0ebBvvcumquU8WD1H5Evwi6BBvyT9wP65gVkBpTfYGvwnaFKddGnwJDg/aOKRLG5gDFZXDfwOjhbwwmhil8fBvQKJSf8u54NvBbKTHl2OBaoCRUnXLgcCY4HCpHeXfYGtQEYytMvRQF8gKpnR5Vzwr4Ai2dLlYfC6YOBncL3Lj+Big9OBnviAVk5ry/ERzhhtaDA9oLwDtiDS2KCc4AUFycAGFcmMPQr/8GcfTRFzz4ikqIGEMvhBtqUTRqfuuRkoiRsGlgU0dIfM66T9NSkYbRtUSmIPDDI2TMNIz/maA0llx8DOgP7KXNIJs+WDW/pg9JKgRCRdQBoDiAK52ZjpBVziYg1mLQet+iZEr0ySJ4CEhzwTfMdFMwbHCMl4SdTYBlrM7hDWDGxdOOke+YHTjJIGveTOXKAUMXhG90EzuUPH/JIzeMakQTehCaxnvBY9eIVZv0G9TLcOMJpCMXjFVSmDT6i+E6xrvpkpfLB7jMVB1YNPyVcbK1zymYaVxmeP7DZMKdFgf4+NwS9PnTBfc16D//7/Mzo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Current Time",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/excel-shortcuts.json
+++ b/decks/profiles/excel-shortcuts.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Excel Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "excel.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "excel.exe"
+          }
+        },
+        "name": "Excel Shortcuts",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Workbook",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Format Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Edit Cell",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "AutoSum",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Toggle Formulas",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Insert Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Delete Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Fill Down",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Fill Right",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Create Table",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Toggle Filter",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Bold",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Italic",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Underline",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Repeat Action",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F4",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Current Date",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRr4CAABXRUJQVlA4TLICAAAvf8AfEIXkRpIcSUr9lbbdu4tiMfdjEbJo2zYdacdJ2bZt21XdX7Zt27Zt27Zt27ZiJ3sCBv/9/4dkcnWmOOKZv4ys1N67YJFWPH4/0mygxmVWR9VueYC7zHR+eu6sVXqK/xDCHMCDLkq6lN3RgegD6EyHRxn1eQPRU9lthJbhcfMfQWa9ughtwovGP4JoVJUZeFXlK6hNkQa46KM5SoWScRGvi4sr3lO8wii+hrvvid5oskFU5WNCffcsGQwGAyJSrvylqG+S1wvoOkGLORgpFQxW+XmSfCI+k9X6mlCLEr70gVH2YF04ZUC1dwY8XEueE3QYgdGwwa4ByfpLA15+BFTe4WXwjWyLghIRWd0xTwOetwbaJxsrxGE0ebBvvcumquU8WD1H5Evwi6BBvyT9wP65gVkBpTfYGvwnaFKddGnwJDg/aOKRLG5gDFZXDfwOjhbwwmhil8fBvQKJSf8u54NvBbKTHl2OBaoCRUnXLgcCY4HCpHeXfYGtQEYytMvRQF8gKpnR5Vzwr4Ai2dLlYfC6YOBncL3Lj+Big9OBnviAVk5ry/ERzhhtaDA9oLwDtiDS2KCc4AUFycAGFcmMPQr/8GcfTRFzz4ikqIGEMvhBtqUTRqfuuRkoiRsGlgU0dIfM66T9NSkYbRtUSmIPDDI2TMNIz/maA0llx8DOgP7KXNIJs+WDW/pg9JKgRCRdQBoDiAK52ZjpBVziYg1mLQet+iZEr0ySJ4CEhzwTfMdFMwbHCMl4SdTYBlrM7hDWDGxdOOke+YHTjJIGveTOXKAUMXhG90EzuUPH/JIzeMakQTehCaxnvBY9eIVZv0G9TLcOMJpCMXjFVSmDT6i+E6xrvpkpfLB7jMVB1YNPyVcbK1zymYaVxmeP7DZMKdFgf4+NwS9PnTBfc16D//7/Mzo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Current Time",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/outlook-shortcuts-waveshare-v3.json
+++ b/decks/profiles/outlook-shortcuts-waveshare-v3.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Outlook Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "outlook.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "outlook.exe"
+          }
+        },
+        "name": "Outlook Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Email",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Send",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqADAABXRUJQVlA4TJQDAAAvf8AfEHVIkiRJkhT+/2k9ZLbX0hFngiUhQgIAAGTb2LZt27Zt27Zt27Zt27ZtG2ccuG0bSXIxMDrX3hunP5ifFwloe9BrJ9J94x5giQHI1kPjOccFH6iN4XiWfEhH3haMG+f4p5lg1x0eAJ8yRwdEy6HpJDnjAbkhnABZ3iQjaQem7RDjwfirHm/LHXBxqvEnTJimAbzV0LygO4NIgtdgHHOB2AjOC7kzMxC5Og7Gi4S/bcC8sDubgNMyHYw/qnF22eERcM6BMx/Cp8HfMGGcKrAWQ8uCTnocSKV6D8Y+B/AN4LKQM1GQeToPxpMY+OXBsrAzFwJBz0IwfivHWhxgv/YdlyKs1b8wYZgi0NJD64L2nceDUqbPYOyyAVsYrgvZc0vQ+LkMxoMIOGXBurA9NwWSkZVg/FKCqeoOz+ecA3tui7hO/8OEfrJASw5tC1rzQGjk+Q7GJgswBeG2kDWPBEOQ22DcCYFVDmwLW/NQoJnbCOafAnQld7zwapLRF4z/uknWGtoXNOcFYVDkJ0xYYwq6ENwXMucVwRbuPhjXAqCXAfv2jXrrMYJlbScYX3JQV9nhZdvxXqVCwVD6AGonWmPo2Ha8+l+t3O8wYYkhyALwWDg18aocniSXBYIzjvNt+ZCB4suA8Afwdfkn5Ltg+LrzXyfxL284fBlfctF8fVrDghWCF4U1/hO7EQSjwGnu9tLzNf2Xm5x1ZqBLtN/uVV7v1EF6SRf53WW/RY93ABXrQD8K0Zf531G/Ra83gMbPVSp/hFUqf7aiCu5zUMpKOcAWq1LlH7o9el/xLAcZJFes/GW3kPcMkPQtpvJfKeapJnULek+AwivlYI8i4Rasu90s4N8HmTTvKf6xAzcFhXbrMMxd8GvyLzijlIrGX7YLBTf/jmmbTfFfJbayuVPtgsEdIHF3GpxnsZXbH64XCK9BIslbcA45QajcdkCzPbO5Ao86f4MzQa14+4vNQlEGOHWTqf2nFtdUl5oFowQEzo6C8yoR0Xyo+h7EnyAU5yW1f7m1aP+i3p7hZ/2tKra/aTVpf7NeKNnSF2Vjqf2vEd90keoFkxnw7O0H510q0umjrZL5B0+0p7T8w7PV8g+qLTYpSzHSPL1my1+srtKTFkLTTapyepSJouG6m8uUnvm2XP5FeT6wzAjktBTLPbbqINZ23VnlFltRN153d3FcC4QxjYXSGlNQP0BaC8y010//6cIA",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reply",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Reply All",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 4,
+            "label": "Forward",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Search",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Address Book",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Close",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Mail",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Calendar",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Contacts",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgQEAABXRUJQVlA4TPcDAAAvf8AfEJVIchtJkqT6/6d58KjMSHTEub33xaZ6IiQAAEC2TTHbtm3btm3btm3btm3b222bdTMB/XxMlLz1ufYL2l/PTIvBtSV06sAB92HNEt0OsDh/chxGG9K9IDaa865x7OTHce5Ceu//nfiCfx/ARjN0IxI3cDc6HlYG8RjlNsSn+sMX9Aa6S9uTErO7QP8oXhPto6islzDYhIYkeRDr40jdFJcgW0ANUfj1WULQSfKzBb5J4h70VGsuuragv4ju82SKd1twW/BMaG+SBPUO/E4CBTzDWiGxA+gk3vdM/YXKDvwBJP5NMV9I7cCzJEEzw23BsgNThcsErEniZ+9QbLEwQUIxswV8JTROofK98NlCWy0eozwBbBiQxA/Ee6BVYg3pIWDFgCqzN2m0xDXBA6iMAKpXiHaBxtsSKPUkBtgl+5n6RaW3ScqvksRrK/rMuQWMYfncQBsl79PoMOT7DbRVMROMIdgJPsuZ6RnDfbADy2R5IOsBJvui1cy3MVV8cR6SBJuxpxqFMKPNmJcSx/9HMYtgMQjFe5n7TrjDvSMnY4Pk+j4ORWCDmH1dyo+3Oe6e9uAnQ7vk+jhWnYPoXQh8XTn9Xz7IDdTkIQaqQG+g09zfS3gvA7n9zNT9++siVeANNJOS38Vf3Iv4NZ+hr1rZksdPjY8ZiEFUiEyVewPNZQKTJAYXoSgVTCbiHuPUP8h7MQ08qSUUWNJLIAxdvCPbR3m9lwqOvWeDuksSXUswmyR+4OvjHO4p6vnMi7+IF0A69V+fVT4CR31BO0+SzwWoLFb7NArfBsb6ykdRvQAPhcG5VjDgfwnB4vjpIUkSP+FOIDcgcwmwv0l+nh7RYrsnwoUtqC5p14Ak8J8c5WJwRvtc4Fxj1MvH44H2yZEvxqf4mcT/3iDe4nAGoiTxdgefEEnekU1gWKzsoO0nCdcJWou8LUgqf3BO4YYoFLeAFSpJJJ0BsZAk7oC30LoLDIsTylJ59x4f/icJlJAjPzpTXfxtogWWxDqF0Scnz1PBiPc2tQ4ST9WI4ydVj++AISy33ieo7tHxNwG9VUMTBPVOMeoFTASTjmAfDP3IXDd4diEBJmNox7oUy1ZuxOM7+aO3B2kZ238g6zFW8V4PAk5nB8Iy9Ih1H0Ygwc8S/yiu7xtqoAVen8XkqMQblKtD5nmSwIroiQgNlhhZnfxUST0V1FIJ/bVh9K/ou4Emo/CoOAVemsIk8QXZrKZawmhlIN4VoT3fVDGwMrpJ4jXcC4gUMKQLk19k95X2k4TewqwVCpdIKlIX5jsggYRzCfVidF2gsEk89KWYiq11oU2Sj2sQFDfrAsXx8vKC4Zp+eXl5wbyuZzEDAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Tasks",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Inbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Outbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 14,
+            "label": "Mark Read",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnoCAABXRUJQVlA4TG0CAAAvf8AfEHVIkiRJkpT+/6d1gIhoOoLjFrMEEgEHAABCyjvbtm3bro2jbduaXlu2bdu2bZuHCdh//v9tuQtw1ewzkq5MNTFyzwN8eXFuWR+yAAqQ8wAYnjDSpehMBKppx6GGym+7OzsUpiHWmN2A80xtmK2anBHnAtusw10yN+OUDeNewQgYAiQ1S0mF471IycaQ0HBosNGQ5io7ebOcVxC6pNiNZjaHuPEeHPGCzchBl8XiNQGimfFfb8QvwwkO/Stps4qSIzJEbKQx4xqZQeojJqMwhHbkCSpREMlpJDMjOATWR3BUEscRy0ZaMjRDVl8kOiJ8oX+0fYgCEpsPxBTxkb6IR2TmgWiDx86l8GPoRL5QBKojOQ0g4dDjIc8O3uelIFJjYD+CYxS4iVi+4OereiDGrIFIxg9kL/SPrp8TTIMkRKZ/EByZ3XYuyOwgehEA/e5qjeS2M45vJ8H5Co79A7HQXiJWzSxz3omVNRjB71K/EICukRttEsjuzJKkyMau2MjsNrJJaaeW6EeHc/VHcl+iZCFR4KIn3Uty/kT9AlD4jrh9+YpYvSjEaiK5Q4Yct4YjRYwuBKDrsKhNZfc1T3LkVHpkblssbg/ZiRvHIDrnkbwmy6nwSXcaCt9RyrrLqsrOCdph+177RN8Gi9vskKZJrZnbNsulAKI9jFFNXqPVkZ01mFko/ZRYd8LrNTvhs9ZYBYC+0/IseMc9S1rF/LZa/dmpmcW4Ir8ZQe/ZMRmFym+BTbPlX7ANO2mNZwD03SCNZCd6lPTM/HZbIj4zH/gmMc3k91uh2WmYhNpvwmYAlKnsmHf65//faQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Mark Unread",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkwCAABXRUJQVlA4TD8CAAAvf8AfEHVIkiRJkpT+/6d1BjyysiXJG0uwBBIBBwAAso1t27Zt28a5y7Zt27Zt27Ztb6nbCehf/v9usTuoVctPRMwyqcLRZGmPME1J6yRwpA9M3WeYrsEHuZDcNdpzIQdrkm40GJasXInTCjLwK6laYTZXcrsi5zKe/IbBs2A/ObvFf8OJS4UOKoKpuobgpL3ikCzJuwaF5ANGoSxJugdsf2FIFi4TvXu0kSQw4ZgIhugiQpORxDlZeqFdhGICwA0ak6Sb/PYfhnrwlOjdpI0lcV8RmgiG+CrCksWveCbLfRXKCRxJd+tOku8CBxCGyQutYfpK9O/SxpPsbjITwRHvcPg+mgeJSPa6BSfLvcP++6gfRCUNujaaJG+xXch4hLWichBcoMTxHyDR32KtkPUIe0X+oDaZVFCfCI54i9lC4SO8FfGTRCbXYpOV3qK/UPmIWIX3JKpp3CYpezQUOh5RrTCcBBcolQz2yCrMPWJRwTupTa2BI9nDv/AB8wnvwlcfJXrNSu9hXQz1J5oLO2dRX5OyCV9lEvoaWkCh5Sx4wEsMNsH0WYzQJRi6p+RxVptZAUeyqdVVIwN+hVTz1LgPE7NitXeRWxh34qijhQMXHQ2Jnqc280I77PeK1G2tY2ErrdPggyww3IfOyzvU92lttgJHsq8pAPZZR3ye2Mpqv6Eped1lGkWfR6uS+pbGqHcLkAhY/Q1AAFIwfE83dYPgT3zIxtyXRctOugHbnv2CQfj3Yku3aLqwX2i//P/9cwA=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Delete",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Delete",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Archive",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Backspace",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Follow Up",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Print",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Save Draft",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Check Mail",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Next Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Period",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Previous Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/outlook-shortcuts-waveshare-v4.json
+++ b/decks/profiles/outlook-shortcuts-waveshare-v4.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Outlook Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "outlook.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "outlook.exe"
+          }
+        },
+        "name": "Outlook Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Email",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Send",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqADAABXRUJQVlA4TJQDAAAvf8AfEHVIkiRJkhT+/2k9ZLbX0hFngiUhQgIAAGTb2LZt27Zt27Zt27Zt27ZtG2ccuG0bSXIxMDrX3hunP5ifFwloe9BrJ9J94x5giQHI1kPjOccFH6iN4XiWfEhH3haMG+f4p5lg1x0eAJ8yRwdEy6HpJDnjAbkhnABZ3iQjaQem7RDjwfirHm/LHXBxqvEnTJimAbzV0LygO4NIgtdgHHOB2AjOC7kzMxC5Og7Gi4S/bcC8sDubgNMyHYw/qnF22eERcM6BMx/Cp8HfMGGcKrAWQ8uCTnocSKV6D8Y+B/AN4LKQM1GQeToPxpMY+OXBsrAzFwJBz0IwfivHWhxgv/YdlyKs1b8wYZgi0NJD64L2nceDUqbPYOyyAVsYrgvZc0vQ+LkMxoMIOGXBurA9NwWSkZVg/FKCqeoOz+ecA3tui7hO/8OEfrJASw5tC1rzQGjk+Q7GJgswBeG2kDWPBEOQ22DcCYFVDmwLW/NQoJnbCOafAnQld7zwapLRF4z/uknWGtoXNOcFYVDkJ0xYYwq6ENwXMucVwRbuPhjXAqCXAfv2jXrrMYJlbScYX3JQV9nhZdvxXqVCwVD6AGonWmPo2Ha8+l+t3O8wYYkhyALwWDg18aocniSXBYIzjvNt+ZCB4suA8Afwdfkn5Ltg+LrzXyfxL284fBlfctF8fVrDghWCF4U1/hO7EQSjwGnu9tLzNf2Xm5x1ZqBLtN/uVV7v1EF6SRf53WW/RY93ABXrQD8K0Zf531G/Ra83gMbPVSp/hFUqf7aiCu5zUMpKOcAWq1LlH7o9el/xLAcZJFes/GW3kPcMkPQtpvJfKeapJnULek+AwivlYI8i4Rasu90s4N8HmTTvKf6xAzcFhXbrMMxd8GvyLzijlIrGX7YLBTf/jmmbTfFfJbayuVPtgsEdIHF3GpxnsZXbH64XCK9BIslbcA45QajcdkCzPbO5Ao86f4MzQa14+4vNQlEGOHWTqf2nFtdUl5oFowQEzo6C8yoR0Xyo+h7EnyAU5yW1f7m1aP+i3p7hZ/2tKra/aTVpf7NeKNnSF2Vjqf2vEd90keoFkxnw7O0H510q0umjrZL5B0+0p7T8w7PV8g+qLTYpSzHSPL1my1+srtKTFkLTTapyepSJouG6m8uUnvm2XP5FeT6wzAjktBTLPbbqINZ23VnlFltRN153d3FcC4QxjYXSGlNQP0BaC8y010//6cIA",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reply",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Reply All",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 4,
+            "label": "Forward",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Search",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Address Book",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Close",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Mail",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Calendar",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Contacts",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgQEAABXRUJQVlA4TPcDAAAvf8AfEJVIchtJkqT6/6d58KjMSHTEub33xaZ6IiQAAEC2TTHbtm3btm3btm3btm3b222bdTMB/XxMlLz1ufYL2l/PTIvBtSV06sAB92HNEt0OsDh/chxGG9K9IDaa865x7OTHce5Ceu//nfiCfx/ARjN0IxI3cDc6HlYG8RjlNsSn+sMX9Aa6S9uTErO7QP8oXhPto6islzDYhIYkeRDr40jdFJcgW0ANUfj1WULQSfKzBb5J4h70VGsuuragv4ju82SKd1twW/BMaG+SBPUO/E4CBTzDWiGxA+gk3vdM/YXKDvwBJP5NMV9I7cCzJEEzw23BsgNThcsErEniZ+9QbLEwQUIxswV8JTROofK98NlCWy0eozwBbBiQxA/Ee6BVYg3pIWDFgCqzN2m0xDXBA6iMAKpXiHaBxtsSKPUkBtgl+5n6RaW3ScqvksRrK/rMuQWMYfncQBsl79PoMOT7DbRVMROMIdgJPsuZ6RnDfbADy2R5IOsBJvui1cy3MVV8cR6SBJuxpxqFMKPNmJcSx/9HMYtgMQjFe5n7TrjDvSMnY4Pk+j4ORWCDmH1dyo+3Oe6e9uAnQ7vk+jhWnYPoXQh8XTn9Xz7IDdTkIQaqQG+g09zfS3gvA7n9zNT9++siVeANNJOS38Vf3Iv4NZ+hr1rZksdPjY8ZiEFUiEyVewPNZQKTJAYXoSgVTCbiHuPUP8h7MQ08qSUUWNJLIAxdvCPbR3m9lwqOvWeDuksSXUswmyR+4OvjHO4p6vnMi7+IF0A69V+fVT4CR31BO0+SzwWoLFb7NArfBsb6ykdRvQAPhcG5VjDgfwnB4vjpIUkSP+FOIDcgcwmwv0l+nh7RYrsnwoUtqC5p14Ak8J8c5WJwRvtc4Fxj1MvH44H2yZEvxqf4mcT/3iDe4nAGoiTxdgefEEnekU1gWKzsoO0nCdcJWou8LUgqf3BO4YYoFLeAFSpJJJ0BsZAk7oC30LoLDIsTylJ59x4f/icJlJAjPzpTXfxtogWWxDqF0Scnz1PBiPc2tQ4ST9WI4ydVj++AISy33ieo7tHxNwG9VUMTBPVOMeoFTASTjmAfDP3IXDd4diEBJmNox7oUy1ZuxOM7+aO3B2kZ238g6zFW8V4PAk5nB8Iy9Ih1H0Ygwc8S/yiu7xtqoAVen8XkqMQblKtD5nmSwIroiQgNlhhZnfxUST0V1FIJ/bVh9K/ou4Emo/CoOAVemsIk8QXZrKZawmhlIN4VoT3fVDGwMrpJ4jXcC4gUMKQLk19k95X2k4TewqwVCpdIKlIX5jsggYRzCfVidF2gsEk89KWYiq11oU2Sj2sQFDfrAsXx8vKC4Zp+eXl5wbyuZzEDAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Tasks",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Inbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Outbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 14,
+            "label": "Mark Read",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnoCAABXRUJQVlA4TG0CAAAvf8AfEHVIkiRJkpT+/6d1gIhoOoLjFrMEEgEHAABCyjvbtm3bro2jbduaXlu2bdu2bZuHCdh//v9tuQtw1ewzkq5MNTFyzwN8eXFuWR+yAAqQ8wAYnjDSpehMBKppx6GGym+7OzsUpiHWmN2A80xtmK2anBHnAtusw10yN+OUDeNewQgYAiQ1S0mF471IycaQ0HBosNGQ5io7ebOcVxC6pNiNZjaHuPEeHPGCzchBl8XiNQGimfFfb8QvwwkO/Stps4qSIzJEbKQx4xqZQeojJqMwhHbkCSpREMlpJDMjOATWR3BUEscRy0ZaMjRDVl8kOiJ8oX+0fYgCEpsPxBTxkb6IR2TmgWiDx86l8GPoRL5QBKojOQ0g4dDjIc8O3uelIFJjYD+CYxS4iVi+4OereiDGrIFIxg9kL/SPrp8TTIMkRKZ/EByZ3XYuyOwgehEA/e5qjeS2M45vJ8H5Co79A7HQXiJWzSxz3omVNRjB71K/EICukRttEsjuzJKkyMau2MjsNrJJaaeW6EeHc/VHcl+iZCFR4KIn3Uty/kT9AlD4jrh9+YpYvSjEaiK5Q4Yct4YjRYwuBKDrsKhNZfc1T3LkVHpkblssbg/ZiRvHIDrnkbwmy6nwSXcaCt9RyrrLqsrOCdph+177RN8Gi9vskKZJrZnbNsulAKI9jFFNXqPVkZ01mFko/ZRYd8LrNTvhs9ZYBYC+0/IseMc9S1rF/LZa/dmpmcW4Ir8ZQe/ZMRmFym+BTbPlX7ANO2mNZwD03SCNZCd6lPTM/HZbIj4zH/gmMc3k91uh2WmYhNpvwmYAlKnsmHf65//faQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Mark Unread",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkwCAABXRUJQVlA4TD8CAAAvf8AfEHVIkiRJkpT+/6d1BjyysiXJG0uwBBIBBwAAso1t27Zt28a5y7Zt27Zt27Ztb6nbCehf/v9usTuoVctPRMwyqcLRZGmPME1J6yRwpA9M3WeYrsEHuZDcNdpzIQdrkm40GJasXInTCjLwK6laYTZXcrsi5zKe/IbBs2A/ObvFf8OJS4UOKoKpuobgpL3ikCzJuwaF5ANGoSxJugdsf2FIFi4TvXu0kSQw4ZgIhugiQpORxDlZeqFdhGICwA0ak6Sb/PYfhnrwlOjdpI0lcV8RmgiG+CrCksWveCbLfRXKCRxJd+tOku8CBxCGyQutYfpK9O/SxpPsbjITwRHvcPg+mgeJSPa6BSfLvcP++6gfRCUNujaaJG+xXch4hLWichBcoMTxHyDR32KtkPUIe0X+oDaZVFCfCI54i9lC4SO8FfGTRCbXYpOV3qK/UPmIWIX3JKpp3CYpezQUOh5RrTCcBBcolQz2yCrMPWJRwTupTa2BI9nDv/AB8wnvwlcfJXrNSu9hXQz1J5oLO2dRX5OyCV9lEvoaWkCh5Sx4wEsMNsH0WYzQJRi6p+RxVptZAUeyqdVVIwN+hVTz1LgPE7NitXeRWxh34qijhQMXHQ2Jnqc280I77PeK1G2tY2ErrdPggyww3IfOyzvU92lttgJHsq8pAPZZR3ye2Mpqv6Eped1lGkWfR6uS+pbGqHcLkAhY/Q1AAFIwfE83dYPgT3zIxtyXRctOugHbnv2CQfj3Yku3aLqwX2i//P/9cwA=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Delete",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Delete",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Archive",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Backspace",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Follow Up",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Print",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Save Draft",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Check Mail",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Next Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Period",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Previous Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/outlook-shortcuts.json
+++ b/decks/profiles/outlook-shortcuts.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Outlook Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "outlook.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "outlook.exe"
+          }
+        },
+        "name": "Outlook Shortcuts",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Email",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Send",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqADAABXRUJQVlA4TJQDAAAvf8AfEHVIkiRJkhT+/2k9ZLbX0hFngiUhQgIAAGTb2LZt27Zt27Zt27Zt27ZtG2ccuG0bSXIxMDrX3hunP5ifFwloe9BrJ9J94x5giQHI1kPjOccFH6iN4XiWfEhH3haMG+f4p5lg1x0eAJ8yRwdEy6HpJDnjAbkhnABZ3iQjaQem7RDjwfirHm/LHXBxqvEnTJimAbzV0LygO4NIgtdgHHOB2AjOC7kzMxC5Og7Gi4S/bcC8sDubgNMyHYw/qnF22eERcM6BMx/Cp8HfMGGcKrAWQ8uCTnocSKV6D8Y+B/AN4LKQM1GQeToPxpMY+OXBsrAzFwJBz0IwfivHWhxgv/YdlyKs1b8wYZgi0NJD64L2nceDUqbPYOyyAVsYrgvZc0vQ+LkMxoMIOGXBurA9NwWSkZVg/FKCqeoOz+ecA3tui7hO/8OEfrJASw5tC1rzQGjk+Q7GJgswBeG2kDWPBEOQ22DcCYFVDmwLW/NQoJnbCOafAnQld7zwapLRF4z/uknWGtoXNOcFYVDkJ0xYYwq6ENwXMucVwRbuPhjXAqCXAfv2jXrrMYJlbScYX3JQV9nhZdvxXqVCwVD6AGonWmPo2Ha8+l+t3O8wYYkhyALwWDg18aocniSXBYIzjvNt+ZCB4suA8Afwdfkn5Ltg+LrzXyfxL284fBlfctF8fVrDghWCF4U1/hO7EQSjwGnu9tLzNf2Xm5x1ZqBLtN/uVV7v1EF6SRf53WW/RY93ABXrQD8K0Zf531G/Ra83gMbPVSp/hFUqf7aiCu5zUMpKOcAWq1LlH7o9el/xLAcZJFes/GW3kPcMkPQtpvJfKeapJnULek+AwivlYI8i4Rasu90s4N8HmTTvKf6xAzcFhXbrMMxd8GvyLzijlIrGX7YLBTf/jmmbTfFfJbayuVPtgsEdIHF3GpxnsZXbH64XCK9BIslbcA45QajcdkCzPbO5Ao86f4MzQa14+4vNQlEGOHWTqf2nFtdUl5oFowQEzo6C8yoR0Xyo+h7EnyAU5yW1f7m1aP+i3p7hZ/2tKra/aTVpf7NeKNnSF2Vjqf2vEd90keoFkxnw7O0H510q0umjrZL5B0+0p7T8w7PV8g+qLTYpSzHSPL1my1+srtKTFkLTTapyepSJouG6m8uUnvm2XP5FeT6wzAjktBTLPbbqINZ23VnlFltRN153d3FcC4QxjYXSGlNQP0BaC8y010//6cIA",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reply",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Reply All",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 4,
+            "label": "Forward",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Search",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Address Book",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Close",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Mail",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Calendar",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Contacts",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgQEAABXRUJQVlA4TPcDAAAvf8AfEJVIchtJkqT6/6d58KjMSHTEub33xaZ6IiQAAEC2TTHbtm3btm3btm3btm3b222bdTMB/XxMlLz1ufYL2l/PTIvBtSV06sAB92HNEt0OsDh/chxGG9K9IDaa865x7OTHce5Ceu//nfiCfx/ARjN0IxI3cDc6HlYG8RjlNsSn+sMX9Aa6S9uTErO7QP8oXhPto6islzDYhIYkeRDr40jdFJcgW0ANUfj1WULQSfKzBb5J4h70VGsuuragv4ju82SKd1twW/BMaG+SBPUO/E4CBTzDWiGxA+gk3vdM/YXKDvwBJP5NMV9I7cCzJEEzw23BsgNThcsErEniZ+9QbLEwQUIxswV8JTROofK98NlCWy0eozwBbBiQxA/Ee6BVYg3pIWDFgCqzN2m0xDXBA6iMAKpXiHaBxtsSKPUkBtgl+5n6RaW3ScqvksRrK/rMuQWMYfncQBsl79PoMOT7DbRVMROMIdgJPsuZ6RnDfbADy2R5IOsBJvui1cy3MVV8cR6SBJuxpxqFMKPNmJcSx/9HMYtgMQjFe5n7TrjDvSMnY4Pk+j4ORWCDmH1dyo+3Oe6e9uAnQ7vk+jhWnYPoXQh8XTn9Xz7IDdTkIQaqQG+g09zfS3gvA7n9zNT9++siVeANNJOS38Vf3Iv4NZ+hr1rZksdPjY8ZiEFUiEyVewPNZQKTJAYXoSgVTCbiHuPUP8h7MQ08qSUUWNJLIAxdvCPbR3m9lwqOvWeDuksSXUswmyR+4OvjHO4p6vnMi7+IF0A69V+fVT4CR31BO0+SzwWoLFb7NArfBsb6ykdRvQAPhcG5VjDgfwnB4vjpIUkSP+FOIDcgcwmwv0l+nh7RYrsnwoUtqC5p14Ak8J8c5WJwRvtc4Fxj1MvH44H2yZEvxqf4mcT/3iDe4nAGoiTxdgefEEnekU1gWKzsoO0nCdcJWou8LUgqf3BO4YYoFLeAFSpJJJ0BsZAk7oC30LoLDIsTylJ59x4f/icJlJAjPzpTXfxtogWWxDqF0Scnz1PBiPc2tQ4ST9WI4ydVj++AISy33ieo7tHxNwG9VUMTBPVOMeoFTASTjmAfDP3IXDd4diEBJmNox7oUy1ZuxOM7+aO3B2kZ238g6zFW8V4PAk5nB8Iy9Ih1H0Ygwc8S/yiu7xtqoAVen8XkqMQblKtD5nmSwIroiQgNlhhZnfxUST0V1FIJ/bVh9K/ou4Emo/CoOAVemsIk8QXZrKZawmhlIN4VoT3fVDGwMrpJ4jXcC4gUMKQLk19k95X2k4TewqwVCpdIKlIX5jsggYRzCfVidF2gsEk89KWYiq11oU2Sj2sQFDfrAsXx8vKC4Zp+eXl5wbyuZzEDAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Tasks",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Inbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Outbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 14,
+            "label": "Mark Read",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnoCAABXRUJQVlA4TG0CAAAvf8AfEHVIkiRJkpT+/6d1gIhoOoLjFrMEEgEHAABCyjvbtm3bro2jbduaXlu2bdu2bZuHCdh//v9tuQtw1ewzkq5MNTFyzwN8eXFuWR+yAAqQ8wAYnjDSpehMBKppx6GGym+7OzsUpiHWmN2A80xtmK2anBHnAtusw10yN+OUDeNewQgYAiQ1S0mF471IycaQ0HBosNGQ5io7ebOcVxC6pNiNZjaHuPEeHPGCzchBl8XiNQGimfFfb8QvwwkO/Stps4qSIzJEbKQx4xqZQeojJqMwhHbkCSpREMlpJDMjOATWR3BUEscRy0ZaMjRDVl8kOiJ8oX+0fYgCEpsPxBTxkb6IR2TmgWiDx86l8GPoRL5QBKojOQ0g4dDjIc8O3uelIFJjYD+CYxS4iVi+4OereiDGrIFIxg9kL/SPrp8TTIMkRKZ/EByZ3XYuyOwgehEA/e5qjeS2M45vJ8H5Co79A7HQXiJWzSxz3omVNRjB71K/EICukRttEsjuzJKkyMau2MjsNrJJaaeW6EeHc/VHcl+iZCFR4KIn3Uty/kT9AlD4jrh9+YpYvSjEaiK5Q4Yct4YjRYwuBKDrsKhNZfc1T3LkVHpkblssbg/ZiRvHIDrnkbwmy6nwSXcaCt9RyrrLqsrOCdph+177RN8Gi9vskKZJrZnbNsulAKI9jFFNXqPVkZ01mFko/ZRYd8LrNTvhs9ZYBYC+0/IseMc9S1rF/LZa/dmpmcW4Ir8ZQe/ZMRmFym+BTbPlX7ANO2mNZwD03SCNZCd6lPTM/HZbIj4zH/gmMc3k91uh2WmYhNpvwmYAlKnsmHf65//faQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Mark Unread",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkwCAABXRUJQVlA4TD8CAAAvf8AfEHVIkiRJkpT+/6d1BjyysiXJG0uwBBIBBwAAso1t27Zt28a5y7Zt27Zt27Ztb6nbCehf/v9usTuoVctPRMwyqcLRZGmPME1J6yRwpA9M3WeYrsEHuZDcNdpzIQdrkm40GJasXInTCjLwK6laYTZXcrsi5zKe/IbBs2A/ObvFf8OJS4UOKoKpuobgpL3ikCzJuwaF5ANGoSxJugdsf2FIFi4TvXu0kSQw4ZgIhugiQpORxDlZeqFdhGICwA0ak6Sb/PYfhnrwlOjdpI0lcV8RmgiG+CrCksWveCbLfRXKCRxJd+tOku8CBxCGyQutYfpK9O/SxpPsbjITwRHvcPg+mgeJSPa6BSfLvcP++6gfRCUNujaaJG+xXch4hLWichBcoMTxHyDR32KtkPUIe0X+oDaZVFCfCI54i9lC4SO8FfGTRCbXYpOV3qK/UPmIWIX3JKpp3CYpezQUOh5RrTCcBBcolQz2yCrMPWJRwTupTa2BI9nDv/AB8wnvwlcfJXrNSu9hXQz1J5oLO2dRX5OyCV9lEvoaWkCh5Sx4wEsMNsH0WYzQJRi6p+RxVptZAUeyqdVVIwN+hVTz1LgPE7NitXeRWxh34qijhQMXHQ2Jnqc280I77PeK1G2tY2ErrdPggyww3IfOyzvU92lttgJHsq8pAPZZR3ye2Mpqv6Eped1lGkWfR6uS+pbGqHcLkAhY/Q1AAFIwfE83dYPgT3zIxtyXRctOugHbnv2CQfj3Yku3aLqwX2i//P/9cwA=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Delete",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Delete",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Archive",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Backspace",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Follow Up",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Print",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Save Draft",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Check Mail",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Next Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Period",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Previous Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/teams-controls-waveshare-v3.json
+++ b/decks/profiles/teams-controls-waveshare-v3.json
@@ -1,0 +1,380 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Teams Call Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "ms-teams.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "ms-teams.exe"
+          }
+        },
+        "name": "Teams Call Controls",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Toggle Mic",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsQBAABXRUJQVlA4TLgBAAAvf8AfEHVIciPJkaT6/6d5iOxBZiF6tYgV3h0BBQAAQ9LsGW/b9qezL31zc7Nt27Zt/zfbiLZtzwTMb1cyV2rHB7jTl0P1WE8BRr6/HNSK1B9EO3jWJFx73HNaSncwLhceHO50u/BOujm8JPHN/gJ7CTyCSTg3x7somN0Ci8zmxBRu2/CLmubEFS7bcIu631LDBZP8v9U7Sf7+kE5Y4beNdVHaEs4HOBarsJsghorID3BuBLXoL5RLrPLjspOn8VSUorBwaIResVxGXzlqBVJ0FcJGYP2AiU8ihbbHQ75QLjAzEGeFRiNjKUnYlsHzeMTneypKkri8QKcSi7nF0NZ3wCTLWeoo6luh5z9J2C1mKHMUJm6nCG50LrBGTSVsZbQV93RXx8k5KuanV1q+ksTO6xYULKdiNjOSS9yzuwGBk1TNF+gWykhJzLElcgSe1QtcWkNqZ4jbXiQ+LetXt1uPeS9ZO6V6gYaJG1nd0hKlaRlKsq+b+FOBMF3T0ub/DsaYTef0JFryc8SfLVkspn1Yeqg4uA9dFtyHbzSGCPNsHZZ55l/qZDl87Le8Hmt7Guqy28RXs99OBA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-mute",
+              "settings": {}
+            }
+          },
+          {
+            "index": 1,
+            "label": "Toggle Camera",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-camera",
+              "settings": {}
+            }
+          },
+          {
+            "index": 2,
+            "label": "Raise Hand",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4BAABXRUJQVlA4TFEBAAAvf8AfEHVAkiRJiqP/f9ovJDBm5E1LaSlZBBQBAAg4Z9u2bV9SY7s9YMl2MhqrbSZ71Yq27W0C5sv/75mb93/djzcPjq2Z1CiZHvCKef/HWq558H8s/SlOOpINWW7XPn27dc/abp2gtltt9fxStvibY0BgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7b4BO2PY3qm0DCAaHTSek1utGf5Qt7tf1Brj2wmdygFjOCfV0s4Q71ayJz/kyLowpppmrZewwzvWn0zKA4Ji8Sj2E9SX3Pi1z2cNTHKJYDrsaASsNlNW0f50Gy01ahZ1G7IQfnk6jK60DmE7ILtNq6DQSTvjj6jQm0toE6YTjMa2sTiPxhGesTmMqrZ5SBP9p+TqNpBP2QDsBmk8rr9MQe01ecDuNjLQGSgFZTSv4ZF/+fzcbAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-hand",
+              "settings": {}
+            }
+          },
+          {
+            "index": 3,
+            "label": "Share Screen",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4CAABXRUJQVlA4TIECAAAvf8AfEDVIbiTJkaTWX2nDFq/qzCOv7YqQBUmyaVvr2rZt27Zt27Ztfdm2bdt8tm1jDyS3kRxJzIiZ9Zundk/4fo8ZSoyyo+0no+zAT7IrSa4mtyaptcmsS2J98hokrVES87tLXjq+Lmlpg5szcLCRZ8ZBQeNB+YKVmzqHvoM6rWTBItE+DJQZShUaxv0D904lCg1b4N4VgSK7jOgNmAyD0fjnrg3jWlUpUShPNusHBQoo49E6jt6Bjh+mRZJHMNxrmqDQGOg/sswDWbPaTkLC5QZomSBf195OQGS9BA07pMveRxIOPV9B5btYuA/6TiUYsm1dEyibn0souNvvmkd1ZnW4BtrQDAStm6DSAv/Q6ng9bjhBE0h7tNMP93jj4AYqcwiPNw4sPlRuITveQIw1l5ZkjjcQiqASc7yRmK0cwTndt62805quh4QCDymqjVl34Mp9j8oonzcUY5XR8SYEBOt10//Zdc+0oaD1pyLbg0dPg6dL112zxiIQFPa6JUir9hrcu2TSYKxVPCv4HGyAe1eNGwwW/8G9viMuf5unB2A43tnWIpEVJaI4UNNrDBsNd1CYedDH3s3R93wwLJTQ9L5v1HDUN8c8ghZBPz6qo1JPfzNWB43HUXPC9Qu0YOY4I1587tA3Hji+g9HADJFcuu8eNyBsw4/0E1987jJsRBQHnFNefu4zakjMO75JgP+gZYPGxLFlFdfOc6++QfFo/qYieA/a0TUq3uBeH5hvPndqG5lbuB+0qWlkTjA8aFdtZDZRPWhbaWTEkO7viXtQtKG8MnxkJscHJjuSdwpCeae50YGB5HiD/0y+aTs+tkJ5af4n0X5xcD8o/fz678/qAwA=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "share",
+              "settings": {}
+            }
+          },
+          {
+            "index": 4,
+            "label": "Leave Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "leave-call",
+              "settings": {}
+            }
+          },
+          {
+            "index": 5,
+            "label": "Accept Call",
+            "color": "#237a3b",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvwAAABXRUJQVlA4TO8AAAAvf8AfED+hoG0bxvxJtzsg5n/+FTWSpOaW8e6PRk5sktBshwAygoFAJAgIAwKBQJxx74SPwgS+8FDnsIBAFBzYtm02N1ZtxUn//IcY89aI6D/BJM2Wz+AP9qc6+WaJp5MTIotcnkZO7OU7bf4KcHjQLdIXgOP7zklhtXxGSQa7nW+SEyKrT+cx6qnVdZxgBKJ4YLICzEpWf0YcK8Cq1o+R14eRF7ZtXWfEheXsrijqhiRWgF2tPZoiu42LAlDVDklROacNuprRFTusAKdaPc42deiKRd1dBaDOVQHOarFGDpjEFcyVULfN0P/v/z5MBgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Decline Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Blur Background",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "New Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Commands",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Settings",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Teams",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Calendar",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Calls",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "5",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Attach File",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRswBAABXRUJQVlA4TL8BAAAvf8AfEB65kWS7dpPG5J8q7r53X+EcD+JUYa0PU2sNUwMJaGqadOlpBkCzET2BAwAAwWS2vWy7rk7btm3bNi/btm3rtm1zAmrZ/wuog+eNf4l8HwY9JaMx4GZNRVKsDOD1X0qIeygeKZE3iI2MgHE9yMglhLGHU5zQ1xE8g5mAxooZNn5HGKd0iPZYlrMByK6gQhjJZFBwmytQXAiKkqFWzIoswcNaKhBuBVKFqDC2qay4zVZVsSSYTYVVgX9VvQkjkggSbvMNrarA3wpyEyFf0FVzqRXcAu/UkZ/5B4wbgUEDRWEs0sDEbW52Go/sCybSYEhQUG3ihOFPAnZ+BTICTv4EGUkQ4zY7pd8LLoGm8PggCByApTBGKRy6PYM+ACQPguEuPypa6kXfC7gT+Mj7JCYpATw9LWdA4mN9IqMb3q6npjc8Cid7txXc/++TmdjgMLOEr8YC4lhwdBTbqrip8aQLoxEanO8EQR0QU3SEdur2BRwdig0xgxnYIweCuer5TZiIwFC2xLvLwS/B3mNcNIh3B13qUhilsCDyIRivvlgpmsPCyxLXTqB5EXxCjeqzmEHpVFQLExzVsv8XzAYA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Format Message",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRhwCAABXRUJQVlA4TA8CAAAvf8AfEJdCkG1TjPurLneYiDlh3LaR49xJ3pyetw74NhAANARCVARBAQACdICOAVAQPPAQWAc/CjoGOsCqgArRIA5EBU0xQBOI9EMBKEUBIEqybdpZz4iTh9i2bfNh///X3LPPuTtVb8WI6D8EN5IUSZEZS7l8fE/A/zQpTG+f3NfuDpdKnBRXauLnqErI+LOEs5UhI7EosTlu43JZNM37m4bfDKHHE3kgVVlv6JHPhSR0+i7V86iS+TIZ/BpUPeKy1o9g+tRYolrnEJN1xxLVAx1kY6g4Dkk0NuXO3nFo7o2I1Fisz99aeh9xz+IYegzNNyNOaISlExKxTaOlyWPHNIumLqhvhQUSTZ1UT2GFwVHA1P4Xx3ORQ1PnauIY5zC+oSxy+JouJyg0lVxgnt2x+gfZkQ+Jox9lh7/urQ3BxshXnsM8Dn7lOQAbQ/TW3juxwm6n94/UXlYxI172S5xiXQLZzMUxSCEuJJSLXrutvjw9en0sW235ZSNd3W3q9tps/WUWQOlUjzmLBEsXomR29J0pBmjskIgr7//nuiUqMa0W6GTUuE8l1vTipaTurJdJnOvFz676ERCUZQlQlbj/JZMsmyHSjzGyLHM+XbMbT2Fplm5vu6JbgXaJuEb33KbbCMWU4+FaYrNCI1bFkIv1mU7w5OwVG80S4nxtugN0mbJvVMvZ6lQ7aLPntn9wAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go To",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBgCAAAvf8AfEBZJkiQpkvQN/f9PByIqsyriNszMuCDSiJ5AAQCAYDObt23b0Tbi0m3btm3btm3btg0HbiMpknf3GHoYnnBycPI49h9ypmK12HTp1Y8HR1a0Cf/G3A0wI4N+/eeHPyMsYXMGTqcPCtuiamcoJc6RALtApnI4LfoQesBpayIxVjF1QMLtVGqswdT36WIyOSrKg7KSVnTZ9PCjAEVOnK2pND20qhOVBO6eM1jWDh0kzAEOxMoh8FKhvyHoO7KILo8HpdnkpFKb5pg6Y/BLAaF2GsksDbe/wAOm5ZDoRs5eKpMWE4c0EpO5PbblfWCvfAPkKnAMPILdmRTGaPfCrYxsvOc3Hm51AiPcXWmKnwbsym6g56Qp8DjVkdrVdXxHaFe4Im4pHgMjmpy6iEesuyLS/uY9EtLJwuAeSerqxVugblbhfs98cNGW0pg0ZGNR2WmARUSvK6yRxkmV513WA99ouvoX7+RuZvuex2c8KU8pPe+XHbkgsAhU1O06th/6/8fTDckFhE2s0u+U2HDhtZO8+APi4RJ4lO+8uooaGz56sgR6VMroBjkIMtKcDK7Z71b4isP5FfX9rAKdn91ZCsEnVNlzQ2duSNIemUzN+8ts+oEJ9TPMs5Cdna8phbYdiWq8zcXpAI/f2XVPqY1PQlKdLnEpkyLQ2uuu7WdhpNh/mrxw5/vdrR3d0pnhW3speKDxOPbfCQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Help",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkICAABXRUJQVlA4TDYCAAAvf8AfEBaJkSQpkqSG6y/qVu3dzVrnM3Q9MzOYNaInUAAAINjMuG3btm3btm0r2bZtI9m2bduO3LaRJAae7eSarbr7CftxLYOapQyjdtz6dm/PpHz2WPLA4mHc/9VjWTCiKDBFvJzrx5tkhDlou5ybjScOIaComCvGjzvHbnxfVUMfvATwn0/nVTVrzGB7b2B0jBV7OOtiC+36kNqZxh1/6Fe2geDgbNq4wrY6GBbb8nxLgnNtIajCv7VGjn+sDUh/W9xP0jfqhMth62QRcml829Ks3fTbhdBYayV1ZZi8F6dIblwLutXij8TCtM/JM3wHeqFxMzNjdl14prA/1IxSa0ZzWRra9/rlsWp6islldxsfheI+BoffmRkMi2I1J8YOl1NfRK78nN1h/4vpRTksiA4D9XLiE2zNDa9i8wL12j8zviURLFouQFphsCRK5c8F8Ckcl0THw2mEX8CbImgHD7fCP5no9u+QTH55ncxGwRoMecU9YLDPRWdwIFwVpsGEtnOC77nQeS8ScgNuquIGZi4FUzjnRkSLHsBYvFqcIYqNwBYveLL3u/FJJTYSe6jtUJ9ktvh4Fxs5PZRjI79fCCK3Uyls8Ug0NmJb3OCNDYsW19hyt1rPxQPu2Hwy0a7Dkd6xmLXXeOcGzEExsHMxblfC0AYz3K805kLkb2Z8owxGt13t38EkxZ9k6yiEkhkt35NZK1CT2S87mYN7/uix+vbt236Qb4w8e/bsWf6+exfgcS+zAQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "F1",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Close",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRtgBAABXRUJQVlA4TMwBAAAvf8AfEBpZjiQpknUNu/9VV1ldI1X+7XsvlY+ZmZl+l0FqRE/gAABAoMlutm3b9rXbtm3btm3btm3btiagrvl/P2cIakK0WHPrw48n+wYk0UKQDz4F7/0PH2ilmgs6DT3RIK5EGHvtqT7YZAEkraeLz+Gxot4h/xRE9E4pJkCzBx2KIYsWHA52JgZH3kEuD77zyBvviwopnUTNdnl3OvRAokaRWYkcgSwO6ZvgmHCNo78M+sHieHTIrbZyiOQvzmbg7GLTu8vuPjAj7hDh2rB1KLi23zMs9AFsLZ9dhH9CkkoD94BZPQv0V9bHgeysEHUoMCucEfusTiMWWZGKmGZFMmKdFYGIa1aYovtZvYuUZFUuA+Np6Q68gUygdUgXOgHhQRObcNTtWQH5L6ujEInY9s5d73UoBMvaQD0ELsA3MepQ19pKWtB3t1zYjugvDpe/wPv/DcI6fPN6caUyaLcEh253LL1Wj/Fv0J45AAcQojt+g2J59TjqtiWI2CUogtsCXvSgiErw58BMc/8z+K9nBx4wVIr/NU1zRaSSBHrqZ45tzJXne1MTfDx6V6nS0HEw5kwk+koXKR0Zhhx7Prj/2pJqbmSB65r/928H",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/teams-controls-waveshare-v4.json
+++ b/decks/profiles/teams-controls-waveshare-v4.json
@@ -1,0 +1,380 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Teams Call Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "ms-teams.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "ms-teams.exe"
+          }
+        },
+        "name": "Teams Call Controls",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Toggle Mic",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsQBAABXRUJQVlA4TLgBAAAvf8AfEHVIciPJkaT6/6d5iOxBZiF6tYgV3h0BBQAAQ9LsGW/b9qezL31zc7Nt27Zt/zfbiLZtzwTMb1cyV2rHB7jTl0P1WE8BRr6/HNSK1B9EO3jWJFx73HNaSncwLhceHO50u/BOujm8JPHN/gJ7CTyCSTg3x7somN0Ci8zmxBRu2/CLmubEFS7bcIu631LDBZP8v9U7Sf7+kE5Y4beNdVHaEs4HOBarsJsghorID3BuBLXoL5RLrPLjspOn8VSUorBwaIResVxGXzlqBVJ0FcJGYP2AiU8ihbbHQ75QLjAzEGeFRiNjKUnYlsHzeMTneypKkri8QKcSi7nF0NZ3wCTLWeoo6luh5z9J2C1mKHMUJm6nCG50LrBGTSVsZbQV93RXx8k5KuanV1q+ksTO6xYULKdiNjOSS9yzuwGBk1TNF+gWykhJzLElcgSe1QtcWkNqZ4jbXiQ+LetXt1uPeS9ZO6V6gYaJG1nd0hKlaRlKsq+b+FOBMF3T0ub/DsaYTef0JFryc8SfLVkspn1Yeqg4uA9dFtyHbzSGCPNsHZZ55l/qZDl87Le8Hmt7Guqy28RXs99OBA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-mute",
+              "settings": {}
+            }
+          },
+          {
+            "index": 1,
+            "label": "Toggle Camera",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-camera",
+              "settings": {}
+            }
+          },
+          {
+            "index": 2,
+            "label": "Raise Hand",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4BAABXRUJQVlA4TFEBAAAvf8AfEHVAkiRJiqP/f9ovJDBm5E1LaSlZBBQBAAg4Z9u2bV9SY7s9YMl2MhqrbSZ71Yq27W0C5sv/75mb93/djzcPjq2Z1CiZHvCKef/HWq558H8s/SlOOpINWW7XPn27dc/abp2gtltt9fxStvibY0BgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7b4BO2PY3qm0DCAaHTSek1utGf5Qt7tf1Brj2wmdygFjOCfV0s4Q71ayJz/kyLowpppmrZewwzvWn0zKA4Ji8Sj2E9SX3Pi1z2cNTHKJYDrsaASsNlNW0f50Gy01ahZ1G7IQfnk6jK60DmE7ILtNq6DQSTvjj6jQm0toE6YTjMa2sTiPxhGesTmMqrZ5SBP9p+TqNpBP2QDsBmk8rr9MQe01ecDuNjLQGSgFZTSv4ZF/+fzcbAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-hand",
+              "settings": {}
+            }
+          },
+          {
+            "index": 3,
+            "label": "Share Screen",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4CAABXRUJQVlA4TIECAAAvf8AfEDVIbiTJkaTWX2nDFq/qzCOv7YqQBUmyaVvr2rZt27Zt27Ztfdm2bdt8tm1jDyS3kRxJzIiZ9Zundk/4fo8ZSoyyo+0no+zAT7IrSa4mtyaptcmsS2J98hokrVES87tLXjq+Lmlpg5szcLCRZ8ZBQeNB+YKVmzqHvoM6rWTBItE+DJQZShUaxv0D904lCg1b4N4VgSK7jOgNmAyD0fjnrg3jWlUpUShPNusHBQoo49E6jt6Bjh+mRZJHMNxrmqDQGOg/sswDWbPaTkLC5QZomSBf195OQGS9BA07pMveRxIOPV9B5btYuA/6TiUYsm1dEyibn0souNvvmkd1ZnW4BtrQDAStm6DSAv/Q6ng9bjhBE0h7tNMP93jj4AYqcwiPNw4sPlRuITveQIw1l5ZkjjcQiqASc7yRmK0cwTndt62805quh4QCDymqjVl34Mp9j8oonzcUY5XR8SYEBOt10//Zdc+0oaD1pyLbg0dPg6dL112zxiIQFPa6JUir9hrcu2TSYKxVPCv4HGyAe1eNGwwW/8G9viMuf5unB2A43tnWIpEVJaI4UNNrDBsNd1CYedDH3s3R93wwLJTQ9L5v1HDUN8c8ghZBPz6qo1JPfzNWB43HUXPC9Qu0YOY4I1587tA3Hji+g9HADJFcuu8eNyBsw4/0E1987jJsRBQHnFNefu4zakjMO75JgP+gZYPGxLFlFdfOc6++QfFo/qYieA/a0TUq3uBeH5hvPndqG5lbuB+0qWlkTjA8aFdtZDZRPWhbaWTEkO7viXtQtKG8MnxkJscHJjuSdwpCeae50YGB5HiD/0y+aTs+tkJ5af4n0X5xcD8o/fz678/qAwA=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "share",
+              "settings": {}
+            }
+          },
+          {
+            "index": 4,
+            "label": "Leave Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "leave-call",
+              "settings": {}
+            }
+          },
+          {
+            "index": 5,
+            "label": "Accept Call",
+            "color": "#237a3b",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvwAAABXRUJQVlA4TO8AAAAvf8AfED+hoG0bxvxJtzsg5n/+FTWSpOaW8e6PRk5sktBshwAygoFAJAgIAwKBQJxx74SPwgS+8FDnsIBAFBzYtm02N1ZtxUn//IcY89aI6D/BJM2Wz+AP9qc6+WaJp5MTIotcnkZO7OU7bf4KcHjQLdIXgOP7zklhtXxGSQa7nW+SEyKrT+cx6qnVdZxgBKJ4YLICzEpWf0YcK8Cq1o+R14eRF7ZtXWfEheXsrijqhiRWgF2tPZoiu42LAlDVDklROacNuprRFTusAKdaPc42deiKRd1dBaDOVQHOarFGDpjEFcyVULfN0P/v/z5MBgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Decline Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Blur Background",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "New Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Commands",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Settings",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Teams",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Calendar",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Calls",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "5",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Attach File",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRswBAABXRUJQVlA4TL8BAAAvf8AfEB65kWS7dpPG5J8q7r53X+EcD+JUYa0PU2sNUwMJaGqadOlpBkCzET2BAwAAwWS2vWy7rk7btm3bNi/btm3rtm1zAmrZ/wuog+eNf4l8HwY9JaMx4GZNRVKsDOD1X0qIeygeKZE3iI2MgHE9yMglhLGHU5zQ1xE8g5mAxooZNn5HGKd0iPZYlrMByK6gQhjJZFBwmytQXAiKkqFWzIoswcNaKhBuBVKFqDC2qay4zVZVsSSYTYVVgX9VvQkjkggSbvMNrarA3wpyEyFf0FVzqRXcAu/UkZ/5B4wbgUEDRWEs0sDEbW52Go/sCybSYEhQUG3ihOFPAnZ+BTICTv4EGUkQ4zY7pd8LLoGm8PggCByApTBGKRy6PYM+ACQPguEuPypa6kXfC7gT+Mj7JCYpATw9LWdA4mN9IqMb3q6npjc8Cid7txXc/++TmdjgMLOEr8YC4lhwdBTbqrip8aQLoxEanO8EQR0QU3SEdur2BRwdig0xgxnYIweCuer5TZiIwFC2xLvLwS/B3mNcNIh3B13qUhilsCDyIRivvlgpmsPCyxLXTqB5EXxCjeqzmEHpVFQLExzVsv8XzAYA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Format Message",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRhwCAABXRUJQVlA4TA8CAAAvf8AfEJdCkG1TjPurLneYiDlh3LaR49xJ3pyetw74NhAANARCVARBAQACdICOAVAQPPAQWAc/CjoGOsCqgArRIA5EBU0xQBOI9EMBKEUBIEqybdpZz4iTh9i2bfNh///X3LPPuTtVb8WI6D8EN5IUSZEZS7l8fE/A/zQpTG+f3NfuDpdKnBRXauLnqErI+LOEs5UhI7EosTlu43JZNM37m4bfDKHHE3kgVVlv6JHPhSR0+i7V86iS+TIZ/BpUPeKy1o9g+tRYolrnEJN1xxLVAx1kY6g4Dkk0NuXO3nFo7o2I1Fisz99aeh9xz+IYegzNNyNOaISlExKxTaOlyWPHNIumLqhvhQUSTZ1UT2GFwVHA1P4Xx3ORQ1PnauIY5zC+oSxy+JouJyg0lVxgnt2x+gfZkQ+Jox9lh7/urQ3BxshXnsM8Dn7lOQAbQ/TW3juxwm6n94/UXlYxI172S5xiXQLZzMUxSCEuJJSLXrutvjw9en0sW235ZSNd3W3q9tps/WUWQOlUjzmLBEsXomR29J0pBmjskIgr7//nuiUqMa0W6GTUuE8l1vTipaTurJdJnOvFz676ERCUZQlQlbj/JZMsmyHSjzGyLHM+XbMbT2Fplm5vu6JbgXaJuEb33KbbCMWU4+FaYrNCI1bFkIv1mU7w5OwVG80S4nxtugN0mbJvVMvZ6lQ7aLPntn9wAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go To",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBgCAAAvf8AfEBZJkiQpkvQN/f9PByIqsyriNszMuCDSiJ5AAQCAYDObt23b0Tbi0m3btm3btm3btg0HbiMpknf3GHoYnnBycPI49h9ypmK12HTp1Y8HR1a0Cf/G3A0wI4N+/eeHPyMsYXMGTqcPCtuiamcoJc6RALtApnI4LfoQesBpayIxVjF1QMLtVGqswdT36WIyOSrKg7KSVnTZ9PCjAEVOnK2pND20qhOVBO6eM1jWDh0kzAEOxMoh8FKhvyHoO7KILo8HpdnkpFKb5pg6Y/BLAaF2GsksDbe/wAOm5ZDoRs5eKpMWE4c0EpO5PbblfWCvfAPkKnAMPILdmRTGaPfCrYxsvOc3Hm51AiPcXWmKnwbsym6g56Qp8DjVkdrVdXxHaFe4Im4pHgMjmpy6iEesuyLS/uY9EtLJwuAeSerqxVugblbhfs98cNGW0pg0ZGNR2WmARUSvK6yRxkmV513WA99ouvoX7+RuZvuex2c8KU8pPe+XHbkgsAhU1O06th/6/8fTDckFhE2s0u+U2HDhtZO8+APi4RJ4lO+8uooaGz56sgR6VMroBjkIMtKcDK7Z71b4isP5FfX9rAKdn91ZCsEnVNlzQ2duSNIemUzN+8ts+oEJ9TPMs5Cdna8phbYdiWq8zcXpAI/f2XVPqY1PQlKdLnEpkyLQ2uuu7WdhpNh/mrxw5/vdrR3d0pnhW3speKDxOPbfCQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Help",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkICAABXRUJQVlA4TDYCAAAvf8AfEBaJkSQpkqSG6y/qVu3dzVrnM3Q9MzOYNaInUAAAINjMuG3btm3btm0r2bZtI9m2bduO3LaRJAae7eSarbr7CftxLYOapQyjdtz6dm/PpHz2WPLA4mHc/9VjWTCiKDBFvJzrx5tkhDlou5ybjScOIaComCvGjzvHbnxfVUMfvATwn0/nVTVrzGB7b2B0jBV7OOtiC+36kNqZxh1/6Fe2geDgbNq4wrY6GBbb8nxLgnNtIajCv7VGjn+sDUh/W9xP0jfqhMth62QRcml829Ks3fTbhdBYayV1ZZi8F6dIblwLutXij8TCtM/JM3wHeqFxMzNjdl14prA/1IxSa0ZzWRra9/rlsWp6islldxsfheI+BoffmRkMi2I1J8YOl1NfRK78nN1h/4vpRTksiA4D9XLiE2zNDa9i8wL12j8zviURLFouQFphsCRK5c8F8Ckcl0THw2mEX8CbImgHD7fCP5no9u+QTH55ncxGwRoMecU9YLDPRWdwIFwVpsGEtnOC77nQeS8ScgNuquIGZi4FUzjnRkSLHsBYvFqcIYqNwBYveLL3u/FJJTYSe6jtUJ9ktvh4Fxs5PZRjI79fCCK3Uyls8Ug0NmJb3OCNDYsW19hyt1rPxQPu2Hwy0a7Dkd6xmLXXeOcGzEExsHMxblfC0AYz3K805kLkb2Z8owxGt13t38EkxZ9k6yiEkhkt35NZK1CT2S87mYN7/uix+vbt236Qb4w8e/bsWf6+exfgcS+zAQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "F1",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Close",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRtgBAABXRUJQVlA4TMwBAAAvf8AfEBpZjiQpknUNu/9VV1ldI1X+7XsvlY+ZmZl+l0FqRE/gAABAoMlutm3b9rXbtm3btm3btm3btiagrvl/P2cIakK0WHPrw48n+wYk0UKQDz4F7/0PH2ilmgs6DT3RIK5EGHvtqT7YZAEkraeLz+Gxot4h/xRE9E4pJkCzBx2KIYsWHA52JgZH3kEuD77zyBvviwopnUTNdnl3OvRAokaRWYkcgSwO6ZvgmHCNo78M+sHieHTIrbZyiOQvzmbg7GLTu8vuPjAj7hDh2rB1KLi23zMs9AFsLZ9dhH9CkkoD94BZPQv0V9bHgeysEHUoMCucEfusTiMWWZGKmGZFMmKdFYGIa1aYovtZvYuUZFUuA+Np6Q68gUygdUgXOgHhQRObcNTtWQH5L6ujEInY9s5d73UoBMvaQD0ELsA3MepQ19pKWtB3t1zYjugvDpe/wPv/DcI6fPN6caUyaLcEh253LL1Wj/Fv0J45AAcQojt+g2J59TjqtiWI2CUogtsCXvSgiErw58BMc/8z+K9nBx4wVIr/NU1zRaSSBHrqZ45tzJXne1MTfDx6V6nS0HEw5kwk+koXKR0Zhhx7Prj/2pJqbmSB65r/928H",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/teams-controls.json
+++ b/decks/profiles/teams-controls.json
@@ -1,0 +1,380 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Teams Call Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "ms-teams.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "ms-teams.exe"
+          }
+        },
+        "name": "Teams Call Controls",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Toggle Mic",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsQBAABXRUJQVlA4TLgBAAAvf8AfEHVIciPJkaT6/6d5iOxBZiF6tYgV3h0BBQAAQ9LsGW/b9qezL31zc7Nt27Zt/zfbiLZtzwTMb1cyV2rHB7jTl0P1WE8BRr6/HNSK1B9EO3jWJFx73HNaSncwLhceHO50u/BOujm8JPHN/gJ7CTyCSTg3x7somN0Ci8zmxBRu2/CLmubEFS7bcIu631LDBZP8v9U7Sf7+kE5Y4beNdVHaEs4HOBarsJsghorID3BuBLXoL5RLrPLjspOn8VSUorBwaIResVxGXzlqBVJ0FcJGYP2AiU8ihbbHQ75QLjAzEGeFRiNjKUnYlsHzeMTneypKkri8QKcSi7nF0NZ3wCTLWeoo6luh5z9J2C1mKHMUJm6nCG50LrBGTSVsZbQV93RXx8k5KuanV1q+ksTO6xYULKdiNjOSS9yzuwGBk1TNF+gWykhJzLElcgSe1QtcWkNqZ4jbXiQ+LetXt1uPeS9ZO6V6gYaJG1nd0hKlaRlKsq+b+FOBMF3T0ub/DsaYTef0JFryc8SfLVkspn1Yeqg4uA9dFtyHbzSGCPNsHZZ55l/qZDl87Le8Hmt7Guqy28RXs99OBA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-mute",
+              "settings": {}
+            }
+          },
+          {
+            "index": 1,
+            "label": "Toggle Camera",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-camera",
+              "settings": {}
+            }
+          },
+          {
+            "index": 2,
+            "label": "Raise Hand",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4BAABXRUJQVlA4TFEBAAAvf8AfEHVAkiRJiqP/f9ovJDBm5E1LaSlZBBQBAAg4Z9u2bV9SY7s9YMl2MhqrbSZ71Yq27W0C5sv/75mb93/djzcPjq2Z1CiZHvCKef/HWq558H8s/SlOOpINWW7XPn27dc/abp2gtltt9fxStvibY0BgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7b4BO2PY3qm0DCAaHTSek1utGf5Qt7tf1Brj2wmdygFjOCfV0s4Q71ayJz/kyLowpppmrZewwzvWn0zKA4Ji8Sj2E9SX3Pi1z2cNTHKJYDrsaASsNlNW0f50Gy01ahZ1G7IQfnk6jK60DmE7ILtNq6DQSTvjj6jQm0toE6YTjMa2sTiPxhGesTmMqrZ5SBP9p+TqNpBP2QDsBmk8rr9MQe01ecDuNjLQGSgFZTSv4ZF/+fzcbAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-hand",
+              "settings": {}
+            }
+          },
+          {
+            "index": 3,
+            "label": "Share Screen",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4CAABXRUJQVlA4TIECAAAvf8AfEDVIbiTJkaTWX2nDFq/qzCOv7YqQBUmyaVvr2rZt27Zt27Ztfdm2bdt8tm1jDyS3kRxJzIiZ9Zundk/4fo8ZSoyyo+0no+zAT7IrSa4mtyaptcmsS2J98hokrVES87tLXjq+Lmlpg5szcLCRZ8ZBQeNB+YKVmzqHvoM6rWTBItE+DJQZShUaxv0D904lCg1b4N4VgSK7jOgNmAyD0fjnrg3jWlUpUShPNusHBQoo49E6jt6Bjh+mRZJHMNxrmqDQGOg/sswDWbPaTkLC5QZomSBf195OQGS9BA07pMveRxIOPV9B5btYuA/6TiUYsm1dEyibn0souNvvmkd1ZnW4BtrQDAStm6DSAv/Q6ng9bjhBE0h7tNMP93jj4AYqcwiPNw4sPlRuITveQIw1l5ZkjjcQiqASc7yRmK0cwTndt62805quh4QCDymqjVl34Mp9j8oonzcUY5XR8SYEBOt10//Zdc+0oaD1pyLbg0dPg6dL112zxiIQFPa6JUir9hrcu2TSYKxVPCv4HGyAe1eNGwwW/8G9viMuf5unB2A43tnWIpEVJaI4UNNrDBsNd1CYedDH3s3R93wwLJTQ9L5v1HDUN8c8ghZBPz6qo1JPfzNWB43HUXPC9Qu0YOY4I1587tA3Hji+g9HADJFcuu8eNyBsw4/0E1987jJsRBQHnFNefu4zakjMO75JgP+gZYPGxLFlFdfOc6++QfFo/qYieA/a0TUq3uBeH5hvPndqG5lbuB+0qWlkTjA8aFdtZDZRPWhbaWTEkO7viXtQtKG8MnxkJscHJjuSdwpCeae50YGB5HiD/0y+aTs+tkJ5af4n0X5xcD8o/fz678/qAwA=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "share",
+              "settings": {}
+            }
+          },
+          {
+            "index": 4,
+            "label": "Leave Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "leave-call",
+              "settings": {}
+            }
+          },
+          {
+            "index": 5,
+            "label": "Accept Call",
+            "color": "#237a3b",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvwAAABXRUJQVlA4TO8AAAAvf8AfED+hoG0bxvxJtzsg5n/+FTWSpOaW8e6PRk5sktBshwAygoFAJAgIAwKBQJxx74SPwgS+8FDnsIBAFBzYtm02N1ZtxUn//IcY89aI6D/BJM2Wz+AP9qc6+WaJp5MTIotcnkZO7OU7bf4KcHjQLdIXgOP7zklhtXxGSQa7nW+SEyKrT+cx6qnVdZxgBKJ4YLICzEpWf0YcK8Cq1o+R14eRF7ZtXWfEheXsrijqhiRWgF2tPZoiu42LAlDVDklROacNuprRFTusAKdaPc42deiKRd1dBaDOVQHOarFGDpjEFcyVULfN0P/v/z5MBgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Decline Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Blur Background",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "New Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Commands",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Settings",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Teams",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Calendar",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Calls",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "5",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Attach File",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRswBAABXRUJQVlA4TL8BAAAvf8AfEB65kWS7dpPG5J8q7r53X+EcD+JUYa0PU2sNUwMJaGqadOlpBkCzET2BAwAAwWS2vWy7rk7btm3bNi/btm3rtm1zAmrZ/wuog+eNf4l8HwY9JaMx4GZNRVKsDOD1X0qIeygeKZE3iI2MgHE9yMglhLGHU5zQ1xE8g5mAxooZNn5HGKd0iPZYlrMByK6gQhjJZFBwmytQXAiKkqFWzIoswcNaKhBuBVKFqDC2qay4zVZVsSSYTYVVgX9VvQkjkggSbvMNrarA3wpyEyFf0FVzqRXcAu/UkZ/5B4wbgUEDRWEs0sDEbW52Go/sCybSYEhQUG3ihOFPAnZ+BTICTv4EGUkQ4zY7pd8LLoGm8PggCByApTBGKRy6PYM+ACQPguEuPypa6kXfC7gT+Mj7JCYpATw9LWdA4mN9IqMb3q6npjc8Cid7txXc/++TmdjgMLOEr8YC4lhwdBTbqrip8aQLoxEanO8EQR0QU3SEdur2BRwdig0xgxnYIweCuer5TZiIwFC2xLvLwS/B3mNcNIh3B13qUhilsCDyIRivvlgpmsPCyxLXTqB5EXxCjeqzmEHpVFQLExzVsv8XzAYA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Format Message",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRhwCAABXRUJQVlA4TA8CAAAvf8AfEJdCkG1TjPurLneYiDlh3LaR49xJ3pyetw74NhAANARCVARBAQACdICOAVAQPPAQWAc/CjoGOsCqgArRIA5EBU0xQBOI9EMBKEUBIEqybdpZz4iTh9i2bfNh///X3LPPuTtVb8WI6D8EN5IUSZEZS7l8fE/A/zQpTG+f3NfuDpdKnBRXauLnqErI+LOEs5UhI7EosTlu43JZNM37m4bfDKHHE3kgVVlv6JHPhSR0+i7V86iS+TIZ/BpUPeKy1o9g+tRYolrnEJN1xxLVAx1kY6g4Dkk0NuXO3nFo7o2I1Fisz99aeh9xz+IYegzNNyNOaISlExKxTaOlyWPHNIumLqhvhQUSTZ1UT2GFwVHA1P4Xx3ORQ1PnauIY5zC+oSxy+JouJyg0lVxgnt2x+gfZkQ+Jox9lh7/urQ3BxshXnsM8Dn7lOQAbQ/TW3juxwm6n94/UXlYxI172S5xiXQLZzMUxSCEuJJSLXrutvjw9en0sW235ZSNd3W3q9tps/WUWQOlUjzmLBEsXomR29J0pBmjskIgr7//nuiUqMa0W6GTUuE8l1vTipaTurJdJnOvFz676ERCUZQlQlbj/JZMsmyHSjzGyLHM+XbMbT2Fplm5vu6JbgXaJuEb33KbbCMWU4+FaYrNCI1bFkIv1mU7w5OwVG80S4nxtugN0mbJvVMvZ6lQ7aLPntn9wAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go To",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBgCAAAvf8AfEBZJkiQpkvQN/f9PByIqsyriNszMuCDSiJ5AAQCAYDObt23b0Tbi0m3btm3btm3btg0HbiMpknf3GHoYnnBycPI49h9ypmK12HTp1Y8HR1a0Cf/G3A0wI4N+/eeHPyMsYXMGTqcPCtuiamcoJc6RALtApnI4LfoQesBpayIxVjF1QMLtVGqswdT36WIyOSrKg7KSVnTZ9PCjAEVOnK2pND20qhOVBO6eM1jWDh0kzAEOxMoh8FKhvyHoO7KILo8HpdnkpFKb5pg6Y/BLAaF2GsksDbe/wAOm5ZDoRs5eKpMWE4c0EpO5PbblfWCvfAPkKnAMPILdmRTGaPfCrYxsvOc3Hm51AiPcXWmKnwbsym6g56Qp8DjVkdrVdXxHaFe4Im4pHgMjmpy6iEesuyLS/uY9EtLJwuAeSerqxVugblbhfs98cNGW0pg0ZGNR2WmARUSvK6yRxkmV513WA99ouvoX7+RuZvuex2c8KU8pPe+XHbkgsAhU1O06th/6/8fTDckFhE2s0u+U2HDhtZO8+APi4RJ4lO+8uooaGz56sgR6VMroBjkIMtKcDK7Z71b4isP5FfX9rAKdn91ZCsEnVNlzQ2duSNIemUzN+8ts+oEJ9TPMs5Cdna8phbYdiWq8zcXpAI/f2XVPqY1PQlKdLnEpkyLQ2uuu7WdhpNh/mrxw5/vdrR3d0pnhW3speKDxOPbfCQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Help",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkICAABXRUJQVlA4TDYCAAAvf8AfEBaJkSQpkqSG6y/qVu3dzVrnM3Q9MzOYNaInUAAAINjMuG3btm3btm0r2bZtI9m2bduO3LaRJAae7eSarbr7CftxLYOapQyjdtz6dm/PpHz2WPLA4mHc/9VjWTCiKDBFvJzrx5tkhDlou5ybjScOIaComCvGjzvHbnxfVUMfvATwn0/nVTVrzGB7b2B0jBV7OOtiC+36kNqZxh1/6Fe2geDgbNq4wrY6GBbb8nxLgnNtIajCv7VGjn+sDUh/W9xP0jfqhMth62QRcml829Ks3fTbhdBYayV1ZZi8F6dIblwLutXij8TCtM/JM3wHeqFxMzNjdl14prA/1IxSa0ZzWRra9/rlsWp6islldxsfheI+BoffmRkMi2I1J8YOl1NfRK78nN1h/4vpRTksiA4D9XLiE2zNDa9i8wL12j8zviURLFouQFphsCRK5c8F8Ckcl0THw2mEX8CbImgHD7fCP5no9u+QTH55ncxGwRoMecU9YLDPRWdwIFwVpsGEtnOC77nQeS8ScgNuquIGZi4FUzjnRkSLHsBYvFqcIYqNwBYveLL3u/FJJTYSe6jtUJ9ktvh4Fxs5PZRjI79fCCK3Uyls8Ug0NmJb3OCNDYsW19hyt1rPxQPu2Hwy0a7Dkd6xmLXXeOcGzEExsHMxblfC0AYz3K805kLkb2Z8owxGt13t38EkxZ9k6yiEkhkt35NZK1CT2S87mYN7/uix+vbt236Qb4w8e/bsWf6+exfgcS+zAQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "F1",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Close",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRtgBAABXRUJQVlA4TMwBAAAvf8AfEBpZjiQpknUNu/9VV1ldI1X+7XsvlY+ZmZl+l0FqRE/gAABAoMlutm3b9rXbtm3btm3btm3btiagrvl/P2cIakK0WHPrw48n+wYk0UKQDz4F7/0PH2ilmgs6DT3RIK5EGHvtqT7YZAEkraeLz+Gxot4h/xRE9E4pJkCzBx2KIYsWHA52JgZH3kEuD77zyBvviwopnUTNdnl3OvRAokaRWYkcgSwO6ZvgmHCNo78M+sHieHTIrbZyiOQvzmbg7GLTu8vuPjAj7hDh2rB1KLi23zMs9AFsLZ9dhH9CkkoD94BZPQv0V9bHgeysEHUoMCucEfusTiMWWZGKmGZFMmKdFYGIa1aYovtZvYuUZFUuA+Np6Q68gUygdUgXOgHhQRObcNTtWQH5L6ujEInY9s5d73UoBMvaQD0ELsA3MepQ19pKWtB3t1zYjugvDpe/wPv/DcI6fPN6caUyaLcEh253LL1Wj/Fv0J45AAcQojt+g2J59TjqtiWI2CUogtsCXvSgiErw58BMc/8z+K9nBx4wVIr/NU1zRaSSBHrqZ45tzJXne1MTfDx6V6nS0HEw5kwk+koXKR0Zhhx7Prj/2pJqbmSB65r/928H",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/vlc-controls-waveshare-v3.json
+++ b/decks/profiles/vlc-controls-waveshare-v3.json
@@ -1,0 +1,489 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "VLC Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "vlc.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "name": "VLC Controls",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Play / Pause",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Stop",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4TFMAAAAvf8AfEC8w//M//4ratoF6/UugIAZ5UAN4MDwOharYViKWAkRwSODWgAz2zwNuX44R/Z8AeMyKBkSfNALS9fTmahEYXPMPU2+uFsH/ckQDos+LHQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Previous",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Mute",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Volume +",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Volume -",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Full Screen",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8w//M//4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Ahead 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Back 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Ahead 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Faster",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4TEIAAAAvf8AfEC8w//M//woCEEDUAJPMNTOAH0UwGIoiSXFIFvhjAin4dwMXXrki+j8B8K9tkfdFozDzHpKUVaMw8/3hmxo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Slower",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Normal Speed",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Record",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "Open File",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Open Folder",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Open Network",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Playlist",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Subtitles",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "V",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Audio Track",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfELXIkiRbtZU3/0kncvpIxF5/yMLdYeEQAQUCAALO2/ZsG2m3ZNu2bdtmsm3btrJtmxPQD/1/D3V4b/4juWMm53LyS+A2WUVRVnZ4/VgSsdnLoyR5u2xUBOZ615AtiPHsV1yQwQOeYQ7s5xe89Fqx+j0wnMoRPUctVwNoN6gIQ6IYCrPtCspFUFSM2vCjZQUPv0pBeBxINpEwbEvh4X/bVndbCmZLsRr4dze3MIQLIT7bvtG6G/5xkFuI/KCr71Yb3IKXAeYmMNigGIZFGUxm+xvYBqD9YKIMQ0HBDWBbXBh8RWDzG0gHHP6CjCLEzLadzkaDS9ASnj0OAnewDMOohL+z7Rt9B6SHYLgE9eHc/7gKeOn9kpFUAM+51hnI+qxfNHSXR3Ku1rs8hZf5/b24L24vG7GLYzYR7w3gKJDj4Ojv2gwHq31cehgaS8PxIgg6gWjSsbR/s+0P+wltI/jGtLBnDoK5PvNNGBELozyR9ymY/AR7z9alIbz4c0obCkNpWYg+gvE+l1XSvCxeE7meBO0l+ERdlY3wA+WkVh1G8Koe+v+e2QA=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Snapshot",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Quit VLC",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 24,
+            "label": "More",
+            "color": "#2b3a46",
+            "labelColor": "#ffffff",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          }
+        ]
+      },
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "name": "VLC Controls 2",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Global Previous",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "media",
+              "command": "previous"
+            }
+          },
+          {
+            "index": 1,
+            "label": "Global Play",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "media",
+              "command": "play-pause"
+            }
+          },
+          {
+            "index": 2,
+            "label": "Global Next",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "media",
+              "command": "next"
+            }
+          },
+          {
+            "index": 3,
+            "label": "Global Mute",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "media",
+              "command": "mute"
+            }
+          },
+          {
+            "index": 4,
+            "label": "System Vol -",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnIBAABXRUJQVlA4TGUBAAAvf8AfEDVAbCRJkXT+O53SNSzc5DP0RLittu14gtLW99dRa9sYIENkl5wMkPPVsblATjrbLo3udeS2kSOx7Nm8t8k/mH9YByGOvWGbQbAE9sbhblA3MTcTt/C20rZhbUfcoZOICwFOxH2QMnELbyttVcDdsK11AbqpPQ0/kTWd6Wn4+fPFsKQTPdAX2Bzhrei4p6F8dm/Sq+KGowyCOQ8yeSAGz6LYNevjBQONQaArNljSAzaxoRpImaEN3KGKDVNg743OjEQgbkYskDRDF8iZIQu0zJAn/hf+r7znf8TEvt1DDTzxgCpGJYDHC3M+ExYf99AP9MTHfeTSI77lj3tB56HiH8gIjvtB518Q4A9sjvAN5z2go6/04YvRcd4HOv9HBIiuf97bxH7eD9IaUE1HFxYlWoO0phKGeUkhDm3vdV8kzPrrvtK0rLEbxEwb3lTeMLEbREwycxjbDbx031c///77RjIA",
+            "action": {
+              "type": "media",
+              "command": "volume-down"
+            }
+          },
+          {
+            "index": 5,
+            "label": "System Vol +",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-up"
+            }
+          },
+          {
+            "index": 24,
+            "label": "Back",
+            "color": "#2b3a46",
+            "labelColor": "#ffffff",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/vlc-controls-waveshare-v4.json
+++ b/decks/profiles/vlc-controls-waveshare-v4.json
@@ -1,0 +1,489 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "VLC Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "vlc.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "name": "VLC Controls",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Play / Pause",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Stop",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4TFMAAAAvf8AfEC8w//M//4ratoF6/UugIAZ5UAN4MDwOharYViKWAkRwSODWgAz2zwNuX44R/Z8AeMyKBkSfNALS9fTmahEYXPMPU2+uFsH/ckQDos+LHQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Previous",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Mute",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Volume +",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Volume -",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Full Screen",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8w//M//4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Ahead 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Back 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Ahead 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Faster",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4TEIAAAAvf8AfEC8w//M//woCEEDUAJPMNTOAH0UwGIoiSXFIFvhjAin4dwMXXrki+j8B8K9tkfdFozDzHpKUVaMw8/3hmxo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Slower",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Normal Speed",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Record",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "Open File",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Open Folder",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Open Network",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Playlist",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Subtitles",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "V",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Audio Track",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfELXIkiRbtZU3/0kncvpIxF5/yMLdYeEQAQUCAALO2/ZsG2m3ZNu2bdtmsm3btrJtmxPQD/1/D3V4b/4juWMm53LyS+A2WUVRVnZ4/VgSsdnLoyR5u2xUBOZ615AtiPHsV1yQwQOeYQ7s5xe89Fqx+j0wnMoRPUctVwNoN6gIQ6IYCrPtCspFUFSM2vCjZQUPv0pBeBxINpEwbEvh4X/bVndbCmZLsRr4dze3MIQLIT7bvtG6G/5xkFuI/KCr71Yb3IKXAeYmMNigGIZFGUxm+xvYBqD9YKIMQ0HBDWBbXBh8RWDzG0gHHP6CjCLEzLadzkaDS9ASnj0OAnewDMOohL+z7Rt9B6SHYLgE9eHc/7gKeOn9kpFUAM+51hnI+qxfNHSXR3Ku1rs8hZf5/b24L24vG7GLYzYR7w3gKJDj4Ojv2gwHq31cehgaS8PxIgg6gWjSsbR/s+0P+wltI/jGtLBnDoK5PvNNGBELozyR9ymY/AR7z9alIbz4c0obCkNpWYg+gvE+l1XSvCxeE7meBO0l+ERdlY3wA+WkVh1G8Koe+v+e2QA=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Snapshot",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Quit VLC",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 24,
+            "label": "More",
+            "color": "#2b3a46",
+            "labelColor": "#ffffff",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          }
+        ]
+      },
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "name": "VLC Controls 2",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Global Previous",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "media",
+              "command": "previous"
+            }
+          },
+          {
+            "index": 1,
+            "label": "Global Play",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "media",
+              "command": "play-pause"
+            }
+          },
+          {
+            "index": 2,
+            "label": "Global Next",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "media",
+              "command": "next"
+            }
+          },
+          {
+            "index": 3,
+            "label": "Global Mute",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "media",
+              "command": "mute"
+            }
+          },
+          {
+            "index": 4,
+            "label": "System Vol -",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnIBAABXRUJQVlA4TGUBAAAvf8AfEDVAbCRJkXT+O53SNSzc5DP0RLittu14gtLW99dRa9sYIENkl5wMkPPVsblATjrbLo3udeS2kSOx7Nm8t8k/mH9YByGOvWGbQbAE9sbhblA3MTcTt/C20rZhbUfcoZOICwFOxH2QMnELbyttVcDdsK11AbqpPQ0/kTWd6Wn4+fPFsKQTPdAX2Bzhrei4p6F8dm/Sq+KGowyCOQ8yeSAGz6LYNevjBQONQaArNljSAzaxoRpImaEN3KGKDVNg743OjEQgbkYskDRDF8iZIQu0zJAn/hf+r7znf8TEvt1DDTzxgCpGJYDHC3M+ExYf99AP9MTHfeTSI77lj3tB56HiH8gIjvtB518Q4A9sjvAN5z2go6/04YvRcd4HOv9HBIiuf97bxH7eD9IaUE1HFxYlWoO0phKGeUkhDm3vdV8kzPrrvtK0rLEbxEwb3lTeMLEbREwycxjbDbx031c///77RjIA",
+            "action": {
+              "type": "media",
+              "command": "volume-down"
+            }
+          },
+          {
+            "index": 5,
+            "label": "System Vol +",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-up"
+            }
+          },
+          {
+            "index": 24,
+            "label": "Back",
+            "color": "#2b3a46",
+            "labelColor": "#ffffff",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/vlc-controls.json
+++ b/decks/profiles/vlc-controls.json
@@ -1,0 +1,456 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "VLC Controls",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "vlc.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "name": "VLC Controls",
+        "rows": 4,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Play / Pause",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Stop",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4TFMAAAAvf8AfEC8w//M//4ratoF6/UugIAZ5UAN4MDwOharYViKWAkRwSODWgAz2zwNuX44R/Z8AeMyKBkSfNALS9fTmahEYXPMPU2+uFsH/ckQDos+LHQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Previous",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Mute",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Volume +",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Volume -",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Full Screen",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8w//M//4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Ahead 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Back 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Ahead 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Faster",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4TEIAAAAvf8AfEC8w//M//woCEEDUAJPMNTOAH0UwGIoiSXFIFvhjAin4dwMXXrki+j8B8K9tkfdFozDzHpKUVaMw8/3hmxo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Slower",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Normal Speed",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Record",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "Open File",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Open Folder",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Open Network",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Playlist",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Subtitles",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "V",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Audio Track",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfELXIkiRbtZU3/0kncvpIxF5/yMLdYeEQAQUCAALO2/ZsG2m3ZNu2bdtmsm3btrJtmxPQD/1/D3V4b/4juWMm53LyS+A2WUVRVnZ4/VgSsdnLoyR5u2xUBOZ615AtiPHsV1yQwQOeYQ7s5xe89Fqx+j0wnMoRPUctVwNoN6gIQ6IYCrPtCspFUFSM2vCjZQUPv0pBeBxINpEwbEvh4X/bVndbCmZLsRr4dze3MIQLIT7bvtG6G/5xkFuI/KCr71Yb3IKXAeYmMNigGIZFGUxm+xvYBqD9YKIMQ0HBDWBbXBh8RWDzG0gHHP6CjCLEzLadzkaDS9ASnj0OAnewDMOohL+z7Rt9B6SHYLgE9eHc/7gKeOn9kpFUAM+51hnI+qxfNHSXR3Ku1rs8hZf5/b24L24vG7GLYzYR7w3gKJDj4Ojv2gwHq31cehgaS8PxIgg6gWjSsbR/s+0P+wltI/jGtLBnDoK5PvNNGBELozyR9ymY/AR7z9alIbz4c0obCkNpWYg+gvE+l1XSvCxeE7meBO0l+ERdlY3wA+WkVh1G8Koe+v+e2QA=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Snapshot",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Quit VLC",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 24,
+            "label": "Global Previous",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "media",
+              "command": "previous"
+            }
+          },
+          {
+            "index": 25,
+            "label": "Global Play",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "media",
+              "command": "play-pause"
+            }
+          },
+          {
+            "index": 26,
+            "label": "Global Next",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "media",
+              "command": "next"
+            }
+          },
+          {
+            "index": 27,
+            "label": "Global Mute",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "media",
+              "command": "mute"
+            }
+          },
+          {
+            "index": 28,
+            "label": "System Vol -",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnIBAABXRUJQVlA4TGUBAAAvf8AfEDVAbCRJkXT+O53SNSzc5DP0RLittu14gtLW99dRa9sYIENkl5wMkPPVsblATjrbLo3udeS2kSOx7Nm8t8k/mH9YByGOvWGbQbAE9sbhblA3MTcTt/C20rZhbUfcoZOICwFOxH2QMnELbyttVcDdsK11AbqpPQ0/kTWd6Wn4+fPFsKQTPdAX2Bzhrei4p6F8dm/Sq+KGowyCOQ8yeSAGz6LYNevjBQONQaArNljSAzaxoRpImaEN3KGKDVNg743OjEQgbkYskDRDF8iZIQu0zJAn/hf+r7znf8TEvt1DDTzxgCpGJYDHC3M+ExYf99AP9MTHfeTSI77lj3tB56HiH8gIjvtB518Q4A9sjvAN5z2go6/04YvRcd4HOv9HBIiuf97bxH7eD9IaUE1HFxYlWoO0phKGeUkhDm3vdV8kzPrrvtK0rLEbxEwb3lTeMLEbREwycxjbDbx031c///77RjIA",
+            "action": {
+              "type": "media",
+              "command": "volume-down"
+            }
+          },
+          {
+            "index": 29,
+            "label": "System Vol +",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-up"
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/windows-workspace.json
+++ b/decks/profiles/windows-workspace.json
@@ -1,0 +1,3821 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "name": "Windows Workspace",
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "appMatches": {},
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "name": "Main Hub",
+        "appMatches": {},
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Chrome Menu",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 1,
+            "label": "Cursor Menu",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 2,
+            "label": "Outlook Menu",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 3,
+            "label": "Excel Menu",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 4,
+            "label": "Word Menu",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 5,
+            "label": "Teams Menu",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 6,
+            "label": "VLC Menu",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          },
+          {
+            "index": 7,
+            "label": "Switch App",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmoDAABXRUJQVlA4TF0DAAAvf8AfEDVIcttIkKT5/6d5SWdEdmTfZnarIiRAkmTalm3btm3btm3btm3btu33bdvmOQPBjSRFkqv3GHKo6QnP19d///2SQkyoHvte+Oq/7567bk0Je2xfB6FIN0FRVtnAOYDcz0xH6RpsvHwb5TrxPgEgab8ETJWgV/4IbnO84QfyO6gF7eLZRHSbTNAVuIA+/2n2qNhyfgNk3h143YDTAa/ISeYCEkGAmuNJDCUcJDiZa/f77LqyBXuaLuBOcIfsJgpet5LjDgsF35CMw5aPENZtGMw+gyisNSwQUBSfcUyCySKNhMStJhVUHI3jEfQV0EOD1LqP8iC7vGzEp3EKXiEs4rgZtJRogZW3iLwOaqbRBFH64X0mpp6g4lESfEY0/SO7ToYdnA9A4Wcg8YNBOPNyn37nEmzKKxVUYZ8SBFYun+dxGOxMkwT25aMh/riOOAki98MvoWFIvQJleaiefvseJAZW/qHbTz+UT7/jDDrls2ZKPSqLTkpP8AH+dFMIeuWIWWfI8z6wWtDOiJzG5z3qQbPMYiixAyvv4a15PQrW58c+Hr42m+fEKhaDqsghIwPinW9olPnVa17j2sMKCaQCdmhQdMP0B6UwV70/AWdLGli5tkliJXgD9475Jz7R1v2t2zr3rW4z0Z1Hls01CwAkTFW5W/AM1gbt7HTQ75YrPgdLV62BcIuwt23UNvS9JwXFedkyjLiFDZmbIc+vI6+c6xaCKpKxJBic8RLO2I1GmLEghQYdeM21hMCz4DA5O/Qyn+IiYmuuA+kObgYS4JSZKdr6PYeq4CKoPgbBOkRI5uZYshYsr+D7cOyVPoRI8gRxgSAkKF1xyHx4yuCwPAuewvpwa9zOJvdPDjKn5f1sKTg5mTUwGiIMZFnHvvt48/IB3jrCQYKYkytnfOpPeb7b6NDLATdS2CgIcTXqL0iyqxEeiu1plPMcDzBO7fmAo/IW2TrkeRzstoKLzpCSpv6wgaPhhPEajW4GEdqC0f+cL8McAs/cAfERTX92Ls1LazFj0hnb9Gt/6K+wnBP5HaydbhwZmhvl2HnX4pxso3Pk34TY93xw0A7Od/g5Kbe8LLGG2Xmy0HRT68q0YkdHerxcVNp000s//PfdW9dMK2aF9gfj6+u//36ZeQAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Open Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" chrome"
+            }
+          },
+          {
+            "index": 11,
+            "label": "Open Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" excel"
+            }
+          },
+          {
+            "index": 12,
+            "label": "Open Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" winword"
+            }
+          },
+          {
+            "index": 13,
+            "label": "Open Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" ms-teams"
+            }
+          },
+          {
+            "index": 14,
+            "label": "Open VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" vlc"
+            }
+          },
+          {
+            "index": 15,
+            "label": "File Explorer",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": false,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Previous",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "media",
+              "command": "previous"
+            }
+          },
+          {
+            "index": 17,
+            "label": "Play / Pause",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "media",
+              "command": "play-pause"
+            }
+          },
+          {
+            "index": 18,
+            "label": "Next",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "media",
+              "command": "next"
+            }
+          },
+          {
+            "index": 19,
+            "label": "Mute",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "media",
+              "command": "mute"
+            }
+          },
+          {
+            "index": 20,
+            "label": "Volume -",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-down"
+            }
+          },
+          {
+            "index": 21,
+            "label": "Volume +",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-up"
+            }
+          },
+          {
+            "index": 22,
+            "label": "Screenshot",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": true,
+              "shift": true
+            }
+          },
+          {
+            "index": 24,
+            "label": "Copy",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOEAAAAvf8AfEFU4cNvGkf7/al1LNuuzr/eLYFpr25IFkO4MwAg6ypeorPAPgo3ACG6N5Bq9cv72m2nbxg2AXQPxeW8yFMjqcaPaU+ROkjlN9sAc8/GV3BGvOAuWpmRPkTtJ5jR5E2VNlTNZxnT5EpYBDZgMh/8wbGA3OHeEkNVjhrenyJ0kc5rsEYKmI2pyh/WZDoA0xepK1ZYLl6UUC4RQi/VpitWVqi1UXyIO4v3ofqXYv/P7laDS/VAualAoC6N2Jhrxa2h/0MJow4x2VfsCk5Efg9kIH4NwcogGNiXdteCtyT4A",
+            "action": {
+              "type": "hotkey",
+              "key": "C",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 25,
+            "label": "Cut",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRloDAABXRUJQVlA4TE4DAAAvf8AfEAUkt20ESf3/TxNblaRqgPJ5I+RAtm3a1r58tm2bkW3bfpFt29a3rcy2bdu89oTkSJIiyfLgy5uz1LA/+Mg/LMPmp5UyeEjrHhcnIvAFw/ccIKGdwARgXYczGShP4C2AoVv2Azge8TwAFs3rAjHNhOdh5boASt5nCK7DiWyT9z5aWLDG4A37YPECLeAVhjf/adxW/kc+khIDZ/b2poYjaWtO9P/SkA/iH/W7hqBZom9mT29WrpoVvVdNDYfetOjp7G5NGoObv9SOjYr/sEZ3ZVdvatj3JkbXoYnxh+rUODR67OxNDbve1OjsTRwD5fyjNze9uWlNzdTUDI0N1uYVWi6WxJtflHPZVJ/RFovFanZshDZaY9v5GRobYPEOB9ZoicScaFNsvIRSIuvL3xx0OiWaY6voIx8xtvkRGOtq/9Au0RSHWesaozWxXcFODNNShR/5yBDfKWaxBouX7YBLq0RjVglr2xjJi9Xa050oDUGYlCo43orzLShW+tnmKeqDenG2aaiEQgrLNyfbNEvUhWBce3UV6iuFoHqOdr4PUZJRgvb/hdhYqr29CFP7PKqi1NZeXYSVqBRN+WVs7MSDMngMbrAjazvZw+5ZWgihjz9izyT7MyxFpP3Zg804pHJPlJHNW1l5klo4DDGfGT+S01aqXvxjT1C4ql2FEW/LBh6gTtA9L6t4Y0SFdlfrh2D46Mvw5ewVME2XxyZ5IrcsYhKj7FC+QOafg+ZXucppW9ixOTRxdLOt/wiWYyDqa3jC4glK/9tLtviN0qH4DwCkDPoW5YeA22skbBaGNTzea9DoaMPi4ekvs7jXyNqMDFzb6HX0y2/EwOgm8zWCNgcPP4UkaMMapADgJ2rnyCbwNfT2Q8Nj1EiDxaNpK4/n30PG+ABASu+5d3QZ1jhNvt7x8O34v3dDmy/MCgrOweLSRz7y5CvAHWFoH6Go2A9YCJiNV6EE5cpDMcWPoAlzF8pr3oPiSjus+kJcFzA8b2WkHfF8aQdmV1Be/MPvK8zjLMYMw9nDUr4yfvLAx9nbkRPUT0tRd3LkDedHD/y0bSFt/Nd2cd6Hrh2rIbGR1rsnXhwNuOkHoY9Oqrp8YHTVOO0ToR9u6GP3kX+V5iM=",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 26,
+            "label": "Paste",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjABAABXRUJQVlA4TCMBAAAvf8AfEFW4kSQ3bvT/T3cAUZeJgJFgKAKqAIAGo9lbtB3XbCOZaW1xv2BlJsWtLa55dxdt2zbfBNRbSyZ1ax682dUVgkyK1BgYftwp8XsDjiqC5sPmt4/LpIPsAdj15Nr/TrNmowJ096eEXgUv7jlYAssF3nuQ2CC7ZH66u5ly4QO62yboXmkE5Vwkg3wNOYPBvGAYrtQLoiPs4JDhStQ54AKXc42QwrVik6MbgfpLimJUvpOiOeA3AZfa3W0aLGqPSQ5o9VA/2NXubouzMdwgVfUPknUrQ9CuqvrWleF3q3YGT1xYhP+H0szr2etMx/Bqh8FmjVHn5bAfiru4cO+1kEHda/j6bxIeDS/3mcXdiwsC916nweG9Pn/u7i88cWG9RAQA",
+            "action": {
+              "type": "hotkey",
+              "key": "V",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 27,
+            "label": "Undo",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 28,
+            "label": "Redo",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 29,
+            "label": "Save",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 30,
+            "label": "Find",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 31,
+            "label": "Select All",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmQBAABXRUJQVlA4TFcBAAAvf8AfEP8gFkzmL92Vw/zPv4JGktrcA9+7ABLQCBwSCoUikVgoFAlEAqFQLBAfCUTiGRw4stU2Tu9x74X7nxOLL4GR0sNG9J+R27aR6HvRzj6eeUH0vyQK6LWrAiotU0CstQo4Wpves6YHOu3SA7mW9MBdqwEO9qb3oskVuDh3vgJrpwM5ZbruPGsqIDc4xTZzNkgrYBctIrGymSyS8qzJQgiJpM2EjAqQptJIYj2XrdOBJJn4ZKKJu2dGvO48a+IQwt25m578xulANtiYXnjWtEDtXNECe/+ve88agINk7IVMCpCmMkj2R2Dl/3Pf48//686zpgc6p0y9n//PXc+aK3BxRez9/L/uPWsqIJc0sZABQJpKOfOS6v3Omc1cxd7P/+8Oz5o4hHB3Re79nu8srfc7A6SzU6EFbqZCz9r0/P/v5FG3oN5vfQR22hZgYyr07E3vr2kCAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "A",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 32,
+            "label": "Task Manager",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 33,
+            "label": "Lock PC",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlABAABXRUJQVlA4TEMBAAAvf8AfEFXAkiTJacX9L50fg9FKw/NmaSKgCgBg0LlnJtv/YDcmG3O0bdtbeutKW7Ptddv2bgLm/y0hKRUadeDO1+UuRhVSQJ4PhkrH4O5rYpwLklpv4OFLHdKJMDgCH+qI8TRk+QW3vblw7m0rfmWfhKasu9HJhrWAOSdWbrcriaZTUJZV9zJgF7DzjvuVKDkBrqyKoSzgYAyuhLM9Ag/Fv7wFPFDBXTzgd2c4VcICHiqlxFBztKm654MNlND0ZrzYgn3UbbsYa400lWk+nLXk6kxJMb+AgZaK4s6sFfYR3MVKY8h+k3iDG4HgA0z8IPdFkSQm5lBTSULWl0DROkZ74e9LepE2RkaR2peiImGMxKKwL2VFdMxV7t9mKBxueyxu76EpHu9tih4YwBdm+EQSm0+ff/+9O7w6fPp086qfRP9dBAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": false,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 34,
+            "label": "Run",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": false,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 35,
+            "label": "Settings",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": false,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 36,
+            "label": "New Desktop",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8w//M//4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 37,
+            "label": "Desktop Left",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": false,
+              "ctrl": true,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 38,
+            "label": "Desktop Right",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": false,
+              "ctrl": true,
+              "meta": true,
+              "shift": false
+            }
+          },
+          {
+            "index": 39,
+            "label": "Close Window",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkAEAABXRUJQVlA4TDMEAAAvf8AfEHXIkiTJkar7n9oRndW9hfH3RCEaIiRAtm06VsUa27Zt27Zt27Zt2/Nt27ZtxE4uBDeSFEnOY6we6K6eJ8y7z3///fkEmocWRzzzFx0b0XsXDIki9P4wsIAIlPlylHvJXlTj84amokrHN7yJagx0ouDAPYiLdAqKshZSNVcLiOAlIjcIbiQZBTgKupzENAkq4cWqSmRW4p2ItQE1BhxHf/hCDjpLfG5FWUlz8KLv1dJ9IOqjNmfzWijpLzlacjqYbqPjPhTOKw0BBazicQkBrAACH8R2EXALPuphTx4KH00pLla8h1lwyToYFIjfOkwKtG6g0ISg7wlV9XcWw8VHICN3AYcVpBdEbSgpSCzmiCZ6boBnNVVIeJJ8Wm9pt4P5gtkNhwsmg9UmxFHzJme6qYdiXj2X++Yi96zgwwY8aPIwyGiiorpzd1GQzC8EBVz8gcpd5YzAKMBhB1pNvAy+QW3BvL7DdkefAMILYnkYuAbpQVtQFDgAK39AetAAgubZ58dlrdzxVmV4FdQG2yt/ieCsHNyeSPtN7+UlhvNwzAZHYnbxZ2Vn3Fn5B7qyn+ehidXgP8jjJAa/VwzvSubo3M1IvuVE1MST4Pw8YHudX8oLpYHacA0KFuTuCgm8CXrnGuF7EL1wopjcYL7rC01YcGp6ELlBYwc7wdArSJSVhZlxLu4AkFf6gpomtJP8Dl/BzVfs70rMC9VRA726F2LfhGmS0YFxwIAqWz5SL5gHeS8g0KI46CZsktQOYEhRI4sXrpWrABj8yu4LJnflyjRhnWS3FOlU3mBVy2d4KciBmBFAZuTkbNyFUVLaQl2wPsMXWAlYyI0q6M5YCTy7UEk6WnDMVuiZgRUOgQXNIGfG6ygIfxeYZKUFLGbRT3u8cmvW+JprAOG7cm/a4mdwfVriZuCXLZ/2YGnlV9HyG+zjdPZ84AdEfYuFO23RtP7umuIRH3XQ1tS/49Gen7I4YOVeJAscQY46ZGfNRasGHUgHWU4F4n04PfCDMP6trbgWagerBKJP8V+KirxY2fY/dzx9IOCDH1BbkoCTFczzu4mqgpE4EcWOpzHGjmceKK+T+MrvDvOCwF1B4jrRwQ1ojDa0FbsRvBVxGwhgBQLYGxRanzfYzGL9Zbz5WjI+FUobDpYVubUodjytKBdbfiQFeSChdQPF+82TBl9r8urTVLM6vZFbFeyVJhakIAj9aPAdKOjYnaQarRLnmoxpzud9JO5Bnx+j6/vmNkGrD0i3T2ceAE9p+3CqZGXqfFT8AZn2F4eO+cVs/4gEoSJxt3+sOPAGz9x+NWCf8Zrq7ONEhdyug6womjfIMHbrALoWmJP6VFcHZXvo/CswnbcJLye+ar7ppHhWHfuCidnFHlDteN4qxMWYcMnnH+yf8ci2MvZgx5coRhK6Jatap959/vvvD0YDAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F4",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Sleep",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqgOAABXRUJQVlA4WAoAAAAwAAAAvwAAvwAASUNDUMgBAAAAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AAABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAAApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADZBTFBIygoAAA3whv3/46Tatn2HHiSCCPEAg71SDhsgCrqw94a9HocdEXHhsvdeV9PDYI/bIfbeWXbsOQ7sSiyxG3vNMZYcgTAvnP9/JpP/sB3HqxURE4A//f9/xbi/xXpf3ZXjuoS0mKKLC63FDn1GdyeAOp21E00uGp8MeDToZ9hYvOiSVg7inkl9lppdklEC3+sz843FiLQRTtBGN/mHKzJKQ1yXaTEWF9J+FEDvkXiNly81DGRdpsVYLGg1X4Dk0Khc2VLLg1aXaTGqX8KcQsio8f0kV2p50OsyLUa1m9AQik6NgFRdpsWoagmLBCg6NQLSdZkWo4qNaAllDyoPOXWZFqNaaX93QNmDqkJeXabFqE6RiwRI/eCtdUm/6pBbl2kxqlFyOqTa9+5dFeiKps0hvy7tzEn16dQNEoWrs4H6JV3RvcgF0LdeqzqDEiDRZtgF4HUZAudVIK06XMlVu6s2qZVBL1ydje95LcEn/LE0X5eo76DyoLdvyoboqzKcGDyKpD0px7lAuKcybRJA/2YhD/HnoT5iPsGvpGU3D3PB21x1adMF1IJ5Nsj39X5iiHgmLefG8CDZbGuhqpEDQC2cXQ7KZ0FaQsBnaVj2PjNIJpsBqqqdK1A5960H7dnoUgRd0D1pWPYlLVAWmwHqOrMAtIU7joL+UUVCybC7MmBx4chAGWwGqGuqA7SF2/6AREtFLzGt/rYcWOw9RCvJZoC6RrYGrXPbUUg1V/IT8yv7QBbMChimlWAzQGUXCjTOHecg+WZYiBhXxSIPZgUN01DZDFDZmXZQCrnbIT2vbLgYKobkyYNpQWkaCpsBKptQDbQ310LOW1GcWHBYvkyYFjzCj2AzQG0zBRrrcsh6s7K/WECNS3JhSuk0PxGbAWo79BMoPxkg778qhYp51L8oG6bohmkAfFwBtdWmgLIg2yFTXnBlMejrHJANE++OqOv893qobrqdQjhzCnJfquUtFhxzWj4c+fUKVLhaPVBasyH7+chSYl5xF13g+ri+AWd388zp56D4th7yH6hZRQw162x2F/3qICCp9i8bGVMtEmTh3HkX4GKcl1hQ0kE3iZwqAOAqpeUb2dLVTvFyG1x5onZpMa5BkcktIjMEiOoyLUaWaBuD7NwPl+ZUriaG8Pi97hCZIYCoy7QYGdL/M8XDP1yDnCZ+Yt5NLvLKi8wQQKnLtBjZ0Rhkx264+FRkGTHUaGZQ3kIB1Lq0MydZkQDKu3muMhU14MQ0bY/ySuvzERL1rdeyoq2DVHAMLj+YFCSGqGSD0mo4pHDV7rKiIciPz7hu81+jCZoul+4pzKNICjubviAVnYICd7YpIYYaP6xS2H29nwThHitiv5FsN5SwPrEawTvl7Ull7YqI4+je5rIiEeTbV5XA/9HBTwzhPX5XFj91SAyVbS0YqdWRCvOgyOXJ0QSuWexCRcG8ND2GwmYAK1t/IH24qQx+b0oJMWj63zApCibjqBiCzQBmxjhI1qvKwLL4BAIqDF7MKwom46gYEZsB7KwGonAdSl2bEkzgGiUuUBZMxsHxHPAuCwyNINmfKGZrYCsPMfgMFlYqC6YfayX53NsNhsY9J316pBjM71mZgKCRV3KUBaw56wBTK3wgvbuqHPPJgSUI0KdvMCuMuWW+kF5Cwcsqt+UIiBkylVc1nYMgPFESZqXEkLjkHuN5NQsHseCDosynewcR4Nk9KV3NvEiOF4rCyqJBfgR49mz5dxXTk5wFysKU5OYcAV69Wo/gVYvy82eFYWLfGBI8u7fK4NVKR1K+eWl6DAmenQZOMKuUJ6nArjSY9ozSk8A1Ss/KVSfKr/mKQ45ppI4ELnJ67gp1c0vjk9HBJEA3wXcSX8zCygfjdBTQDOwyzaRi/lF5bgBj/k/hFODip55bpDp2P4K3H+8O2Jg7oSoFEPJTkx9NKvOxFMFtc7aMiuUowMXPejHdqiqUGv/37gHT4mEtPCmAwJT0PUt5FXlcgeDtaXcTWIe1H6ihAXTpXbcs5VXD6cGJ+ZazuAuQYZ+upwKnH9rn8GKrSrwO9hbzKvnBfbAxe1yyFw3AhfZMf5q1RxUs5XzFPILfuRHMo+tn6KgA+DccEXd8RR77XgUEiCHimTsBiy6MSvaiAzh989QK53duZpypZiAhvGyeW8E0rfK4ShwdAC40sVvXZ9fOHzWzi/8cRigVYnEvYN3ynoN0Ur73jaid2LLif14++nzbCtzJ0yd5F5yzsgOWKpyYpqLZ3cAvODKoTylpopqSYRUDauqBGnEAvBO9t8zgWfGgrJ+YT/WbbgdYF54Z2jtEFslcmV7tM8yMuFoxSAyRhffcD7AuPthjaCXOZQAX23UiI45FhxF0VS6wAOCz1tQaXj/QZeASy21mA67V4sS0tc+yAcCelea+vWv6uAiBURcYcbW6vxgXb+ZZAfBZW/hePar7ucQj8CMjjsaEiaF842x2ALBu2P6iW+faoZxs+AZG3uPrEQISjzAFAL9x77XQDs1iSnvJ4njHCpypGyCGWhoTY7437z9x832rFlGVyvhzEt7mMyO7cXlCRNN/Mkj00LH8h6+/to2IDU4KJV37wAz+WqKHmEeTl2ZGiR96dqlrRxC/5YGd+xuEiqFCs3VMA7S9QX56hSE5obEE79YPzGybWUAqOg2Wbm5TSgyVWmcxrU0gyC/PsaVGXYJnR3sOw7TDQRbOFjIF21oFiSGs5+8Mm1lA8TYXbF1Ttx6BS0pcyKxBAsjC6Y+MwdqUYDFoBt45yajIFqB8ewKs3RrSjBODvv9ynknauQJF0RE7c7CqQziBa9xkJpOWO0H5JAfsPfk2xVsM3v19VjJonh2Ujt1g8cwutQgIGnklhzmpHqDNO84kfvXAYAL06RvMjOkUDdo32WDzVntfbwJixiwxM6VNO9AWbAOrZzZpzBG42AGLrAxp0wW0wplTzOLX9CxLAJc8IINnRqd2oH6+DezOuTIyiACu6ah0KyMGJYD6kwEsX1k0yI8ALjl9mpkJ43WgthvB9im1unoSwMWNX57LgGXfQO3cdZ1xSO+azBGAmjNzV7ibfrUT1ELuLrCen9o9kSNBN8E7w71ajRFALVzaCPabl6XFcCRoBnefYHKjqVGgF27+BjU0z82M5UjgGv10YZG7JMxzgl649BvU0bxkcCJHAnQZ9aeZ3GJCQ0gUzq+DWprnDm7KUcAreeyL6VbFtZovQKLz2AaopzWja08vCiAwJePUDF5RCXMckOrYchhqyqdFp2lpgJD+o07MsiomebwGkvmVd6CyUz+MrUQFhHQe9zRrjyKGjnBC+sOfob4bt41u4kkF+Dcc0fhs9h4X9en5A2R0nloKNTaPThxdig7gSjfq3+KuafdJmeI6N42GrLYVJ6DScy+MSfai+z6gekJK4tvnD249uWYmtStTr1qlvwiQV/j3DKi3aVr9DJ2k731Dy1aOLl87EoXfwGk84dI3v52Cqi9aM3pAoAyUXhq42L53CdSen3JpdAd/+VztODMPxUHz7LeprbXuYD/1exGKiaZfb43pGMopzHY0C8VJ66z9nYfU8lGO8+6GTSh2rlnzfkjH6l5KKHxwYqUTxVJr1v4vHdrXCvF0hfDxzr7tKM5a9xy87tc8OSpC6yvtv/yz/NyjX1AMth7JzX/G+7T0rxcMQPMNwIfLX486UMzmj369/AHAN/zp/z/9/79vVlA4IOgBAAAQGQCdASrAAMAAPikQhkIhoQuaAAwBQlpbuFtrgAZeiZucq+rfoj/APwA/QD+Afv73+ELVK6QjXwqlEi6mzHXJII5+PgfSAAc8+E31eVabSAFLnfYUbhhYbdtOmy1rDZ72r7j4Hx0YbpW8hE/rmA8u9YkFx2DLEJbbad+xI/XgJzeMCj1KizTzDXWpgTAPPDgaRyLnCYBzDqU+vpu1xq+8kge2i4le7K4SQbTJEVhbCNHxgEs5audsM7DmwnhW6c64x6pXSEa+FUrpCNfCqV0gMAD++0UoAKL9GZw9f0Zngwd9///u+ND74kgRADf0ZvZ+jLYdFT+jM50vvLcgXH7eYjwxUpoMvKaFbE1SD/889tsVgyuQIYGvCY/wGGiNpduf+i6//+JOf/8U5f//isQDIG/0/f//7vFt5GilgQKb+pSURP+5EiEsQqz9Hs/0Zvkt+jLZfRFLCqKwTXyX//gWjsHHiL6K/ATKVHErBj59wDaNNTErICGBvJqJefk8Km5ps2cORjM5gGRkDzgutz6TFeJYdFzdA/wKpCOaCcrRYNbA/oxrxp6Zf0dS/JEhEL2DP1R9tTITCpBtn/Re4PpzAQ7+6h+jjRwQT+9PaCXbJAgD8cD9ABv2xw/o69FNwwA1pAAVMgAAAA==",
+            "action": {
+              "type": "sleep"
+            }
+          },
+          {
+            "index": 10,
+            "label": "Open Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" outlook"
+            }
+          },
+          {
+            "index": 9,
+            "label": "Open Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "launch",
+              "command": "start \"\" cursor"
+            }
+          }
+        ]
+      },
+      {
+        "name": "Google Chrome",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "chrome.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Close Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reopen Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Previous Tab",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Tab",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 5,
+            "label": "Address Bar",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Hard Refresh",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQDAABXRUJQVlA4TNcDAAAvf8AfEHVIchtJkqT8/6d58KgtPXqu44lq64yQRduWIUkRFW3rz2Z0to2xbdu2bdu2bbRt+2/MspERbwLmPyj1BO/U85/ESAk/nZ/AV8dF/GQoqAqNhvcjzZcnsY9YvUg0GradJ4V6n4/49CBRJHxPiC2M4DOynPHjQX7tYL0hwSrz9FtmYIO8wRaJKv7bMYQiy8t9uR+YGaHu44uQG7IZ6+8sFRPGzc/MiFGyCGbpTmAnsqQw40DzubnMpyyJI/u4XM5SCb85xYxANYs4tQ2ns3QSmbMMG+cXcWgTNqcSzTvQ+hQz1uIlVm7BaLwwG3egc40pWPnqvwGhNEnyNXrONmbiIAmFwHZsNaSaP+cbK0qUId3sBdXR6TAul9jcDGUuCpEerFUWJqG9FCcJBe952kg77/sWcIoRTJMk3rUyPNW0A7U1r8SQRrC2onD6XiqL2kaGJwlRTKORhIEkBvZRVtyZ1h4XRW3QJMGE9yLgSXJ1caJ4daDm3hVHmpD4W367GVG+dw/ZSeIH3I2VX0kio4cjxckDtXe6ONBDQ5HTT9+iqQVXLAkd634XdRKMUwd9ksSnA21QfpLo0cHKYu8OHCjWdHC5GL8DY4vzHXwuhB1ILN530FZ47IBX0d7BP5AwzhaZk/jZgTYJ2R4oQULZgQgSP/bgZxLmLr7vg6UDbRLSPZCBhLrDlYRxD79J/O2gHSThvgMeIInWDvIKuoO7+NzBtWLsDowrrnawpti5g7tY1cGA4sMOfCz6deCBg4Qa6RdqkGDcOozWJNGjn8wk0XSglk4Wl/o5WpzooXchY90N9qXo2YMVGUhiSDf9koQU6THOFc+7eVacmaYSC07oJRQr4ruMmiTxrJcbSaJ62hpX7m8nFCvG9EF0gyRyG8EKQBJdJH3GuBKL+liaasx0VlVoBXURQldUHqi1BGKSKEF6RBlI8hXfaxwvca6HC6mOTnP22kps7GBTqlZ23QZlKLgp58td/tDpb0oJsylnCzOoJh9ohw6U4Daey8Y71b4DbRF2vSRf5DxxASxdu/YwiEeLKBF0FsFKwdJDZHYZ1xehtegUsCW/WbqGzD4vBxaJXMLnxMnP2v5rtmrK3yK4Z4TPiPMCB8s/k2e3qLZFgntuMOt3XYZ4gYO1VnT2y95x4iIJqYtykNeip0tk4CHRMXazZQmqHiSh8t4OY0RzW3FHjbXTB2rwpErxB9q2cbofrRlIffcjjOBF3d8D7ZzkUv3cO/+ue3Yv0TnS95F+50A/IqKXE1rw1+7v6IUc6Aflrr/VrsrV7h8t8ft7Ra6rVut/z/9aAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Forward",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Home",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Home",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Find",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Downloads",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4BAABXRUJQVlA4TEIBAAAvf8AfEAXkSJIUSam/0v7IHlrrOoYIyLFtm7bWfW1HcDN6Ldvv27ZtMyGncF8eB3MCov9cGgLAv/++0MiYfRld4Z5k/MPVi5iGSLgjGf8AXLyESQAi4X7EfKGdvYBxtEh8O5ECW3DymDEszUUbVmQLjh4ywi8sRFtWZgsOH9Hn0ZaiTatyBfsP6PFoK9G21biCvdt0eLS1aOMaXMHOTdo82ka0dS2uYOsWTQ5tK9q8Nl+wcYMGh7YTbV+XL1i/pMah7UUD6vMFqxdUObSDaEQjfMHyKWUW7Sga0hhfsHhCiUU7icY0voD5AwUW7Swa1OQC5hbyDNpFNKrpBdhi0K6iYc0uzrqJxjV/wW00sMVT7qORLZ/wGA1t9cBzNLb1hVfBXJFNAN4F0eS24VMQzS4riH7MlDN8ZbNb0sIr2/2U+sci",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "History",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4EAABXRUJQVlA4TAIEAAAvf8AfEDVAkiQ3bJP/f7qrLECiCPAcIUISbdumHeUhNnq2bdu2rbLt2HZaZduxbbdtO48HgttGjiS5Djdx15s6VNcLvv9aRJidm+r8N2PVPhJhy5wp9cpd5kz4JODs5JrAgkehDcrjDD8DeoqtgWVZV8aoPRDeOsFLGRUIaQ1P0+BBCDuWLdlGPHkxI7wvtLWAGznSIEsIXRLRDzHaQqRpcABupJNmT3B6hgQJy8rY4Hy2BWOt2Hz2hZKPuyGUjYMojD88oKvWhotvmPwclNrB137a8oH6O3tUvUwb9gXXw25mmGXcS+2MLnrv7dLRng66X87MjLn0a1eS3kwJe5oG1xxHl4ohfVCXfk9ktn1F9USfXkC6oBAElG1s1mFq02YT3I7P5vxe0x6mG1rADXOBFLTbtShkCMENoGA39KpC9tsWFX8plMqB6Qv+JUXfFSeN4q7Gs+BeYY3x+GDyi6GCuNAKrQEWnhRFsxb14IdtkqvOXJc6M+/aH8ehtSoldiIilp2ZAzPzzrprwbbwMrK0fHVAQh9kBlIMhmYhH53wwQksxuuvks/L8AzFaPLiRvwKoBr+MSo6vCKpBXy+hR7zZLiE+Qj8YKBhMMz5YD7FF/Jqxp0rIlcC6wuDbeZBJcAcgBk04YP5NIQTJyPtwuWTEXKh/GRoX6g/GWIXpk7mQ8yMuaOx/cPW0VgCM4ijsdwcWsfv2NgQzvpeogmEoHnuAxHWvydoxXavdVh/GYJju99UhLaE1NjvtQ19MWi8QX3s9/tHz3EPTTfUs9oQekNYWw+WheM+/pbCF3ZfUF9FYWHygRH4YRGywR/BdwExd8GlaN9CtLwvrK4F5zjvKULJhZ9/HFtCTwxqK/ga531FUL9AU6wNymneW6WQtvDqj2NP6A7h5TOex3l/GfxD3oP6xlCP+7nPiXmPOiDGQuJhk0cCulf+IFpT3qdOvMOnKXpXyF1Icbqc8l6V0nphi2SVaUop71cKVWfBOqyGCb8FFK3ifk1qZfJWTcz7lq/2xZGFcxV4kPPe1SJnL7R+/PcjEhvz/h1W/IrWPUTmdY8OchOETQl7cR+b1v56SNkEKYJufKL4aKOkzWK/6pQAJ7kLirpu1v3aSHl8IXb2NKEQlxyl7VYVCO5i0sENrRi9XBzgQbd1b4epvMRLqi+3fMemJWIh/db9DeZ1CF+4QpfbSJ6+Y/uu+38fTplIkGReIVv4wm+NnTrbN3UPCnD3nONQ1wxuZE+DTAH0iUaGliCp/t/XfdDqO8viZ+yx7sWupbHlbKHupbV463pd9yMI0r70iPqruifljM+ovIKykGsC/QzGsAKu8JNqz/CzdUu1/2at2Ech7Vgwo1GFK7+6t39a9AE=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Bookmarks",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRs4DAABXRUJQVlA4TMEDAAAvf8AfEHXQkiTJbiPt/S/ttuhqCAC7v6fwKCACDgCAZaTj27Ztezrf9LZt27b9v9m2bVuTbfs/kNxGciQx9mZ7XHZk9w/yXy8hRnR2QgXPzrzZyWH3/2GfG1egOM9Nf5XeqaHxVXW9M2NaVcV4ZuobtRND4qm5vnkhVgj8vJRGiqcF6jxyds6KenWhOiupPcmzstezO2vlqIX7s6qK6KSVo1GpqhE8aeVo6DNozE5aORY+UD7v4sM+aeWo0pmpq2rS8qG/Yf8/Do3eSStH+cOcieVcXO+klcNEZqbJScuH+oZfwz+Uj0krB4GGYCwfU1YOGxlic8ryobQRF4kP5WPKykEhojho+WBnbFfMAAtH2cVxVZWZfcf5/uSLs09gb+T15NfePL8ayxQd7AXVg97LAcWffRO9rn3cQfRu9/tc3y/f3sL97aFi7fhU7nFeP/5AQLuKbFLC93dWTzXvhoOiaD1y/f38P+IwFR+AE2rHHi0VRxWYxpm/D4SsCvHF40jcLiCQDTnGBKLvOT4KNSiP8qiuEM8MhhmBRGxWiG1iB/VxW91b9clxgkJF90wyPAIjLxWoRJHb89MhLBdyr/PuRi2X3JEfD2GzuPd5zVXgkNKAp1r0OivELcIeTwGBbgxjnuuF+Q0Pyr94sK2+038ctSKGvRAA1Q1hQ1i2KcNHjNphhrAzWlvUszJqRw6EzApRsIVCIJADmYOHvt8GeguY8J5kmDk6In9Vjsy/ygeJ8QlulOWmqGiEjc9sQ3sbuo2F4WH7Fl6Rbzw5ea+qD+foONdCU26M1nZM3Eant2G2AlyCRLAVrBsDM1xt8I12fdQawtzD4Ccc1NiY1EJfdmg4rap6r+xiOLwoY1PXcO3w9l0heXd4NeonuNqAM0CtoVbyZYA3dDMkI0OohaVwCCTt1WrsxnlrtaoKcWRKGpENc69dF88KeZg1Yhqlw19tIJOJRGG3i3DPvK8KUfhlkm9cnOOiFrbo/yCJx3wFjqis71gvnsxwCNTHJSUUi4Tv2qVejBly6+sa6ZvyGqmD32iAERN38VMU6ErhvLtDEQPb2B8WUWDhp2uXbu5cDdxXIYbfqirioxICrMUMrj8XDrOrByV0VOaa7evXea8xP+yNhp5nRrsWzoFvQ3Cpji2iexfuKi5j0lf7F2qUqjrXuJWjyifXnTdjrqphb0MwOWihpuwwHN49ZOU4aqEu3c09ZOU4bKE+P39j3oZAOHKhhjmBegasHIcu1PdXSsarHM6OvYZ4yn5AR0Pi8GuIDEnkP1KSAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Incognito",
+            "color": "#34a853",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYAAABXRUJQVlA4TCoAAAAvf8AfEB8w//M//0ICQjTPSzcDXIRBJm1Tpmz+TdVEj4j+TwCxfV07FTU=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "DevTools",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkwBAABXRUJQVlA4TD8BAAAvf8AfEBa4kSQptp4Z6b+v/T629mFG+vxFpomYEzi3rR1zxlPZ8xNs22od2+6yUk4Zq7JT2rZttbaNdwLm1v9XrnvT4KT+9puvfOAxVznFzF7Zq442vNyu9yxtt/52artd59Vbh9fzp5k9XDkz82+UcWaYZ5eDPjlivWBol2y7z9I60GlM9HzygaGdxmRfhrWx1DgqubHVv0+Drw0tNc4Pa2ErW5PjW5mYXNFqfBPcV8s7weu1PBF8Xsv9wU+13Bn8WcvtwX+1noPfa3k8+L6Wt8JrLV8GT7UyxiC6oZVVyTmtnJusaeWl4EcjSplnEN02pd6SzaWcbhB9ZGglY11jkB0yZQwz2mSz7f7xq0H26l2N0/42Z8o5aco5ON387czp5jnzppl/3GXrlDyZ//zha+950CX2m3wAcuv/K9wBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "View Source",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRngDAABXRUJQVlA4TGwDAAAvf8AfEBemoI2kqDLw7/RewMFEzAmCtm2bWpL+BJI2PMBdDdwZMAbvB5OAGgJCiIcAgBDDNtZY5wVwMWAdhiB+GCehKws3w674TLuUbBUoPD8DkHbbliFJt9y2bYxt27Zt27Zt27aq+/21iRsRNZHzTRH9nwD89/8fpmtHrj316H3048PrR+Z0L3TurtBmVkYLHacRP/amGB7uGnRrOltg5ThpyGNdH4vF63VOVbDHfgs5DeQw1L4FYvfbcJdwnkhLC8OFDiKLxPpAl8ayRRaOkq8pqj5iP9rKodwG8ixglBklW6FMfhEDuRF0B4eItDYaKrSzapLQxj0Da9OCicUdV31lMsyhQWyJ0UHyNqK6Q+40BS+/xc45lPKFvAwapP8gK6AsFPWnAujmvyVS4A62EmljMFhoa1U7sgP6E1k/hzqzlQZ7ySO/agBZb5DdSKY6FHlLXoe0Ur+TeVD3Ik/i9XCTLHcIK4i01eovtAlpRWRDWM8TW7PVWrvIbdBCJje6BT3G/4i8i2gkfSXTGK4wkSfzmwe8BPOIdNToLbRMY7KOiLzePLTEO5qw9RrbyRloJj3R+/ne4jZhb8Bt8iGeJHwmo3TQ20xE3i5r5gnTiHQh3UUdzdbCTBsicraDB5SxzWQL2Q9932I7IrtznMNZ8ilBEf+R9DMABry3Iw9rnRtNpLuii6g/JxkhY94XK/K0xLXsKNmm2EA2wWbaqKs25GzQMRwgX5IARN6TjlYAVIw/+t1Ihrs2gEgfAB1F/TpsC0Bi+4V3DR74HUv+QnYCWEOWIsalY07qSAvHsIV8S0X4LWkZKwB1+zSmu9aJyAC0FfUD3y8AzGfbXAu/IXuwisyCdmJ122EzN51+2tco7gE54xqWke/Zr0id3mVRLzPCGnLTuVZEtoj6BvRXkmcho4XksnP+h4RPNhhBpKfREXLQOcwxKjaoYfcTDCobyFz36k1OwPQikR1BreQLQju6h5sGw4xGMTlapFF5QeirsAdM0fuRYZT4kMm3dT1KkwKpVX23fhc+Ax5Yorcb5l01rD5P9gKc0uptARtj0dgWnjhS51OCjfCeGEyAN2b90FgPq/EbbX0fBa/cp9HWDtDthZVLTeGZfdnLkC0kDjlvEj3QxYffbHmfBcduPv4U/fj82q7ZnTPx3/9/RgY=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Full Screen",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8wGBMxJ4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F11",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Print",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRvoAAABXRUJQVlA4TO4AAAAvf8AfEBq3sW2rShu7/1axp8FHLwd9Ee4e/hI+USN64rYBAKQJq39AOMGZ7QFGl5kroD73gl7gvuncdGSsu7t3AmyiSnz+ge4qLjYMvFoOcM1rPV4eBHEqNHssLYQ/r5uW8uvxRgw8EgweSiZ31CjgeSuhC9gYKCqpZGNgnxZ2MUgSE4gkLiUplmJJLNUPMiFbUgA5A+MgCTtnMJJEOmeAzCWh5MwgadDDs6xFXyXdEAK9pWunQHcVF10yXt85qM1rPWyCS9Mj/VBOTY//mNyG4LaKmbpsQmmmLmNwugtlZ8muCNgUr5aDECusyRQB",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Save Page",
+            "color": "#f9ab00",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRg4BAABXRUJQVlA4TAIBAAAvf8AfEBYItu2mjbbx9r9VtUOyhkH/nHIDGmafRvTEbQAAZBNNtu2ckVNySnbdkDM62t462e4HnYB8+iwQMrbjeesPjJw3f9efA6izPyZyz2jli0oNHFwB823BJ5AnFEniR7OqWBt2dUFXZltV1SVp9oRtKjOT1JDlBd2Zt8zMMsMj8vrqgvZ2XewbJ6/3Tgwk50/cuJ3On/omjO7fWdMI4y3PmuRm7W232+2gIytJGq7L2MNHJ1ZwcUGwMWIJG1ZisjViDhtWYo1GzGDCymFlxPQlrBzYG41VtTLbqqpuGNbJWRpudcrehMT5M579JS6H6BKPY3T5eowuoQbPIE14yjo=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      },
+      {
+        "name": "Cursor",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "cursor.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Command Palette",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 1,
+            "label": "Quick Open",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "New File",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Save",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Close Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "W",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Reopen Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Split Editor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backslash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Toggle Terminal",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Explorer",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 10,
+            "label": "Source Control",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 11,
+            "label": "Run / Debug",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 12,
+            "label": "Extensions",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlIAAABXRUJQVlA4TEYAAAAvf8AfEC8w//M//4raNmI6Dsz8HbXjrwD+SCwCB7WRpDa4Vshphv67cVLkJ6L/EwDf2ubZNaMw8x4QxjWjMPMeFpfl8k8N",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Toggle Sidebar",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwCAABXRUJQVlA4TAACAAAvf8AfEHVIciPJkaT6/6c5KyIzC5txW+ErYhEBBwDAMlJ797Zt+yf7J9u2bfsn27Zt27Zt28oE5Jf/vyeNj7NSE848+/Xq1Kp+sXTR3cEg8DrxBZjcrQOb+mhBaYWWc+CgVfx9gCUBZ31xbEMacJx5E4yA837JtADPzQtjDUoH/IHSv3bm+BBCgYORqgKf1XD4tta5FV6zb6uwRSA1VhuVmQbQzde9oc0qao/F/L8fpULTA63zq5jcj1mhfAO5/0Lw/RgULmCuxXoh935kilEBbe2+L6CrxhodKC3FUjXjQiIJyIYErMyMe9VsMXUD18Xal/ZlkIXWSRjuzYxHOUQbiagTM2OaSh9gGWdmtKHoImHm+cw4xddGkIj3cWRcYmojQcjF8okxDaWPJNh4GvC9NRxbSQKHsmTbG04gmvkS82/jK0OyoST4dS4I7ymRWKm/HRzcFDmIUmXSJeMtGE4KU7ezOF+XsxUlhfXbyS9cQd2SXFi8Hadi6G/pL/TcDk/lCPYGTn+FuNvFfDGaoCzBMzcl1etxqcYA+gWc5oDSHbTrwXFajS9l9DDDhUSAi7E630At8oGuF1oLR13DayAq3/BPMR1A0/4C37QQmH9P+ebyQE0kdNwcsUAgfQQOG7M7fnXTBD9Qs1gZSTJk3bk3v/9cW9EihgbSB/rl/+8mAw==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Problems",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 15,
+            "label": "Settings",
+            "color": "#0369a1",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Format Document",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 17,
+            "label": "Rename Symbol",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvICAABXRUJQVlA4TOUCAAAvf8AfEHVIciPJkaT6/6e5ojwzazvmtiJGxCJCAgCAZSM1Z9u2bdu2bdu2bVtv27b/bNu+Kyag//n/d9MkhOvzybIDsCNL/nupjCOO1/Matv/pxJ5FvzxVL4wkcASxaCOwTS/YwStn0YI4xHvsrMxB/0mWNWOM5Aages46F1rX2CW/pn6O865rLKFf4TbnwbTrGj0LKGw+MIbh1QUhnCTDItRD3iRQw0OGm6VOZ2mEvJ6uvgfgIkCKnqIcK2mUJOPBOPnO+I0m3+qIGLxJhgMO2L1j7L2K1V6Y/9U0WvsBgvSOWXDngtYlJR7ltI4weO94BQMbGKFBej2SEsk7LsEq4rU2ErTVIz/huqMdxiCCtdd/wO2E9A5HGsMc4L0F+MDB8AVFf9KMVVXU4VaH1dhE1UnKyszYcVUgnpoABCiwkmCu2vFEKOGE3Oraz2Y0MkRQx3kDF7TIdW9m7GmlUpw51Cut+MTM+MqiMktEexnQeGbGA0xleYe9d3k5ODOWSNTkF6c+iE6F0yNjDU851tyVRqwPoxbh74nxFV41hkn3kwTEeuVia4S+nK4GEGKmLtdeGBcSnuhuZMzVmNiwCOf1btF5H2bUA4/8jFeUjytDo4hG4mOar8e6m6THC7KraCy20kj5BbpVJTfLaNYLYGoryIgyFaLYFZ+tcd9CZDH4UkcbSGMO2YLfc691q/UGI4WgtZ5G3YKO8Al/S03wu5DmvAClkoSF4bzlZfCsknY/jb/wArFkHukGYUhQXgo2+2nEhvYzjDufSyj8mMiylOa/4BBLEJHGK5wLhP2ARdsIamnP0hgKyCylca6fE17kcFER4e6GC1iWe0HF4HKYhu5ds1s4agNFNS10wSj8uzb0BJRplwN4nUZiQODhAx9dT+N1nBxhv2vEn6dciLigilp0GtdDNwebR/wi3zXB8TENg9TIBPi+A/aULXBBbyx+bqq9MWLFMdiRDf/cU8oG/QX98/9vkQEA",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go to Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Peek Definition",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F12",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Line Comment",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQDAABXRUJQVlA4TDgDAAAvf8AfEHVIkmxbNCXzn3Q2NhGcf6pdj2d7EZIAACwjKWvbtm3btm3btm3bto2XvXu27RtnAo7/ryQr27qX/tF5xuXf93eS3Y+pEzDpPqNgOvnuhs9e77+gvX6L0fUFnFCf6a7FERp86DfVZ/z8flCocylqkE044xzQHE9Gy8kUXBSC6koovWw6Inu8lILjqBcoNlLcNIr0ePHnjCpYCJWfYQvhDbz8vML37z7c2/aD6Rh4fdqW0z7GQ/oxUkYY2cc3sIXFPKNvsPVlHVxgW4fH0HfbYtuGWeiaojsYbSMgFE1p8N5GUiiYojDEbSM/lE5RFnJWUjVFdcjeRm6on/IOmdvICo1TNIXUbaTEOUVzSNhGXLynaAnR24iMa5SwbQSHsinKQ+A2gkLsFAkryQouU3iEzG0MBO0p9EP/Mgh9bQuHbgrG8AXBLlzAtu6Ose7blssqSDwNBXMUxhfJJvraFpbQnN+7bfXuAV9108Ax2GBU1bUEQWtN33BOwuV71CqBBVAw1wvVhON4A6O53imkLqbI/xZOP8DHom9guNg76TvOv4S3D/0XcAPjBUI8KN4V2NzAH2S7iy+M5zHpLoVhP40jTFc40JEQYfdOIenMog/Vu7aEEUd7A3+erquo1+gmofcWTBe0bmBH5Cai6idpaJr4HVsisBYQOOac37CG4Ab2/PgEtpUyR1rb+oj22FREOJnjLM5jVWT+tIVBMQU1bFt/kO1ymGxbalNota3JY1l5wXEK15C7jZAQNUVsnNsICkVTlISAbUSE5ilaQug24uaJ2kZKaJryDgnbyAqNU86Quo3cUD9FQ8jcRn6omqI6ZK+kbIrykLONlFA4RVFI2EZQKJhyBb9tWIe2KdqD+TYEw8aUb+DZBp7fbSFQzUAN2dbPY11LbStkxtm25vYRFN6hmPD9BN99MEG0raEJhtvWf/T7HFqjKt6veqtoarqBhS9fo+awvQaH+aavGDc6WMNF/VFO/nkUVfnXvFjdwM5i77T1zRXZZ1yufe9DMcfWvPy/19J9RsGHP57H3pQ9nfD9HJsjEuH9q67zfSyPlJM+j2Gedb4/nJAe/0TEWJE84/u+jv+yBg==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Duplicate Line",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOEAAAAvf8AfEFU4cNvGkf7/al1LNuuzr/eLYFpr25IFkO4MwAg6ypeorPAPgo3ACG6N5Bq9cv72m2nbxg2AXQPxeW8yFMjqcaPaU+ROkjlN9sAc8/GV3BGvOAuWpmRPkTtJ5jR5E2VNlTNZxnT5EpYBDZgMh/8wbGA3OHeEkNVjhrenyJ0kc5rsEYKmI2pyh/WZDoA0xepK1ZYLl6UUC4RQi/VpitWVqi1UXyIO4v3ofqXYv/P7laDS/VAualAoC6N2Jhrxa2h/0MJow4x2VfsCk5Efg9kIH4NwcogGNiXdteCtyT4A",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 22,
+            "label": "Move Line Up",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Move Line Down",
+            "color": "#0f766e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      },
+      {
+        "name": "Microsoft Outlook",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "outlook.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Email",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Send",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqADAABXRUJQVlA4TJQDAAAvf8AfEHVIkiRJkhT+/2k9ZLbX0hFngiUhQgIAAGTb2LZt27Zt27Zt27Zt27ZtG2ccuG0bSXIxMDrX3hunP5ifFwloe9BrJ9J94x5giQHI1kPjOccFH6iN4XiWfEhH3haMG+f4p5lg1x0eAJ8yRwdEy6HpJDnjAbkhnABZ3iQjaQem7RDjwfirHm/LHXBxqvEnTJimAbzV0LygO4NIgtdgHHOB2AjOC7kzMxC5Og7Gi4S/bcC8sDubgNMyHYw/qnF22eERcM6BMx/Cp8HfMGGcKrAWQ8uCTnocSKV6D8Y+B/AN4LKQM1GQeToPxpMY+OXBsrAzFwJBz0IwfivHWhxgv/YdlyKs1b8wYZgi0NJD64L2nceDUqbPYOyyAVsYrgvZc0vQ+LkMxoMIOGXBurA9NwWSkZVg/FKCqeoOz+ecA3tui7hO/8OEfrJASw5tC1rzQGjk+Q7GJgswBeG2kDWPBEOQ22DcCYFVDmwLW/NQoJnbCOafAnQld7zwapLRF4z/uknWGtoXNOcFYVDkJ0xYYwq6ENwXMucVwRbuPhjXAqCXAfv2jXrrMYJlbScYX3JQV9nhZdvxXqVCwVD6AGonWmPo2Ha8+l+t3O8wYYkhyALwWDg18aocniSXBYIzjvNt+ZCB4suA8Afwdfkn5Ltg+LrzXyfxL284fBlfctF8fVrDghWCF4U1/hO7EQSjwGnu9tLzNf2Xm5x1ZqBLtN/uVV7v1EF6SRf53WW/RY93ABXrQD8K0Zf531G/Ra83gMbPVSp/hFUqf7aiCu5zUMpKOcAWq1LlH7o9el/xLAcZJFes/GW3kPcMkPQtpvJfKeapJnULek+AwivlYI8i4Rasu90s4N8HmTTvKf6xAzcFhXbrMMxd8GvyLzijlIrGX7YLBTf/jmmbTfFfJbayuVPtgsEdIHF3GpxnsZXbH64XCK9BIslbcA45QajcdkCzPbO5Ao86f4MzQa14+4vNQlEGOHWTqf2nFtdUl5oFowQEzo6C8yoR0Xyo+h7EnyAU5yW1f7m1aP+i3p7hZ/2tKra/aTVpf7NeKNnSF2Vjqf2vEd90keoFkxnw7O0H510q0umjrZL5B0+0p7T8w7PV8g+qLTYpSzHSPL1my1+srtKTFkLTTapyepSJouG6m8uUnvm2XP5FeT6wzAjktBTLPbbqINZ23VnlFltRN153d3FcC4QxjYXSGlNQP0BaC8y010//6cIA",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Reply",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Reply All",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRv4BAABXRUJQVlA4TPEBAAAvf8AfEHVAUiNJktT//7ToiuhhskiHvk3MkkwEFAAADEln22+bybZt1G+2WW3btpVs27bNgeQ2kiNJIY2f2T2N/cF80TYc1PRsmPsPDzhPwyvDO9844dmMDdt6D9dbn634cL/12X7Tw7LWsoPnre8YUPbpKZUrURgH8uA7d9M86uKJuiWIz26cL7UUdlQScO+0EY7XhwiwbZVP5/NjwlGAPCv+X08Ywt5Vv9xW35Dyt/KiA2LbynUWB8ractc1+f2UfJMDIcBH+wedE9xWLrM8inb7O1PEXLHMtX9QzQOyrZxneSj9Ib6Dxe2ycIa4oVK6nGZ59PydaxImWLmFB8R99bMuqvtzjd9sLMdZnbj2zcQEi+7rXCO+p1K7HFb/O00FrwmWR6Fp9pb04nNPYW+2Vuzq/+a6niCg9vWGxui5Rnj2db3RVlCc4KkqqCejoaCUjN6CdDI2CqxgIH1deJpgqNexqWTEFVKSsVOwCIZ+5RkuGCOFkuCYnIJKLnB228fvyUVJO6aeC6+W8tx4+Gsf/bFi4eu/+mc0oSCoPm0iUmPvpCcr8xIINqaBPumgiT8MsJHp8uWUX6EzYeCYsOIR+GDO6UwcBIGP5k8OygOSjH/N1xfPwTiXSPIBmVR82dAmlBJ47FPtwYUI+oDE78t2BgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 4,
+            "label": "Forward",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Search",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Address Book",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqIDAABXRUJQVlA4TJYDAAAvf8AfEJVIciPJkaT+/6d5iNwskTnHxcTo2fUVERIAACDbJkndbbdt28Zs27Zt27Zt27Zt21baZgL62f93hfUCK2FSpE8kic9/N58CF2mocAS50KIYTKC9OcPBYS43iHNn5Kzmlmo93xWMEMhd7WDZExrVGaNol8yT9ZlsBcu1MAoyjR2B5GVojoYbD+B8oO9CwCUo+DbEBVL/MEfoiz1VVuLAu+2gTbXx2tdD8SgxCrMZoI5iz5u+JdsSapshniQouPuerzKKFTR70VckPoC7umwnSWhtxfskceL+bZpp0bEVJkV639d5cJK4uhO5heiNWlnBsxOjxfWrEDEyEyNPpSpJhUlhXEh9fSmWyoWk26vZTQIGXeOnZMcZmiokC+/CKmNtlGCXQkpisa/0TFZ+PHgtwucSEwSBCzlKYuUK5uAcwVoEHElUu7zOexInoNMQJGd6QKKwPxbT3iyjNkk8PAteQ8bIGvlTQO+zB4V9IV2c99YfAuzk2hrF3q9V+BSyZ4nP0BBN13pSffG2jGFxSB/EopuL4CpKTmKYaps2dM+6g5TEKnCmu/3QXqINbg3430ni2ynuOi7mPH8A84IgSQT0URhJJfTWaF7FEPwZ4pLEjDs97z9KEmSvDzVIZLHp/Bou2UkSEcBj3qIk+Y+25399J4mYPhHBSJJwWaOZlEiEOSQoSYT0vGfmksSRO2e0H8U67Brwukq0+XYA9DsJkrtT0LRsp9Lvc5UnCbY1+peVEhSpWKFnvE8StT3pKnWDGYrrk8kXXou0nw5LEmsyWePz2xvnC9nCvrjvI1pyfH4jZawB/iyPiupV+sXcaMy6cCzEi+lMS0Hos6GcJjG/TLum/pjAgvnQF4u+0CokcbBOA4mbOSK8YDwi1/O+0iIk+VqoG46G7jk+hcSUE+l+96UgcBLbS3W3+6S5fypV/fZRmBbGRfKbSgViWWBB/QAudh2SxPBq83iLknJXokXOTlwvTp270WdhuJPWmySM7uOu4+LNVuiX3y7dRkKS6OmtOmcDkkQ68Ca4UArhvTTtEjb38MZekmgHbgbWeAk30A3Q2kj1v3frk8MSpZ5chcACDKmcer9EBvkjyBfgBW7QNJ+hXNCGmv7/kuSPbEFsWZ3ImockbSiQsWo0D2DLuOyNbigEpjftlcZ7WCPfG8dv7DqHHJ3prUNjl2j5CsdvtFx+AE+g22i/SJI6kwh2L+H62f8/SwY=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 7,
+            "label": "Close",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Mail",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Calendar",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Contacts",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgQEAABXRUJQVlA4TPcDAAAvf8AfEJVIchtJkqT6/6d58KjMSHTEub33xaZ6IiQAAEC2TTHbtm3btm3btm3btm3b222bdTMB/XxMlLz1ufYL2l/PTIvBtSV06sAB92HNEt0OsDh/chxGG9K9IDaa865x7OTHce5Ceu//nfiCfx/ARjN0IxI3cDc6HlYG8RjlNsSn+sMX9Aa6S9uTErO7QP8oXhPto6islzDYhIYkeRDr40jdFJcgW0ANUfj1WULQSfKzBb5J4h70VGsuuragv4ju82SKd1twW/BMaG+SBPUO/E4CBTzDWiGxA+gk3vdM/YXKDvwBJP5NMV9I7cCzJEEzw23BsgNThcsErEniZ+9QbLEwQUIxswV8JTROofK98NlCWy0eozwBbBiQxA/Ee6BVYg3pIWDFgCqzN2m0xDXBA6iMAKpXiHaBxtsSKPUkBtgl+5n6RaW3ScqvksRrK/rMuQWMYfncQBsl79PoMOT7DbRVMROMIdgJPsuZ6RnDfbADy2R5IOsBJvui1cy3MVV8cR6SBJuxpxqFMKPNmJcSx/9HMYtgMQjFe5n7TrjDvSMnY4Pk+j4ORWCDmH1dyo+3Oe6e9uAnQ7vk+jhWnYPoXQh8XTn9Xz7IDdTkIQaqQG+g09zfS3gvA7n9zNT9++siVeANNJOS38Vf3Iv4NZ+hr1rZksdPjY8ZiEFUiEyVewPNZQKTJAYXoSgVTCbiHuPUP8h7MQ08qSUUWNJLIAxdvCPbR3m9lwqOvWeDuksSXUswmyR+4OvjHO4p6vnMi7+IF0A69V+fVT4CR31BO0+SzwWoLFb7NArfBsb6ykdRvQAPhcG5VjDgfwnB4vjpIUkSP+FOIDcgcwmwv0l+nh7RYrsnwoUtqC5p14Ak8J8c5WJwRvtc4Fxj1MvH44H2yZEvxqf4mcT/3iDe4nAGoiTxdgefEEnekU1gWKzsoO0nCdcJWou8LUgqf3BO4YYoFLeAFSpJJJ0BsZAk7oC30LoLDIsTylJ59x4f/icJlJAjPzpTXfxtogWWxDqF0Scnz1PBiPc2tQ4ST9WI4ydVj++AISy33ieo7tHxNwG9VUMTBPVOMeoFTASTjmAfDP3IXDd4diEBJmNox7oUy1ZuxOM7+aO3B2kZ238g6zFW8V4PAk5nB8Iy9Ih1H0Ygwc8S/yiu7xtqoAVen8XkqMQblKtD5nmSwIroiQgNlhhZnfxUST0V1FIJ/bVh9K/ou4Emo/CoOAVemsIk8QXZrKZawmhlIN4VoT3fVDGwMrpJ4jXcC4gUMKQLk19k95X2k4TewqwVCpdIKlIX5jsggYRzCfVidF2gsEk89KWYiq11oU2Sj2sQFDfrAsXx8vKC4Zp+eXl5wbyuZzEDAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Tasks",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBcCAAAvf8AfEHVIkiRJkaT6/6f1EAUNGcsQAz4dAQcAwDJS7m3bNrbfbNu2Ndq2bZujbdu2rbZ3mYD5v1kkBJb48UwEwCXOTx9vxp44a3jbwBO//QhDxFEWk95kJuHfGXLfSex3RgWsOBsTv8O6MVM7ivtCDdmx3Red7CJgaUv6Xpi1ZelAXlcY4A+sdsUkh/AYmpJfEJKEYVO2iq4ioydsYBLPlIqFntgU3cj8JIGhaUl5ETCGk4R2S44KqRFVJHeEN0nczlAsPuxV2+pxdMKlaN7AIPOTsyY6UV94bmDGyKl8NeKyEN7AjJBzHPsgliTOZ2Ze6v2fUd0Hn6KmzCBCUckXJ31oLxz3Dt2BSfB3Aeeh4L6gtXDpglySOJiLvIvaLoQUpVeIFedd6C+srozrJCHUA2JvYIKA9ZKmwm1hiDCeoJAkNuYyj6KDwLG51dBzHxO4DoQWedcIl8sLYQJJYh/XnoHC+Nq4WNkXJNUB7oLMdxJ4DDdQtzBGkOw7/NjADKUksTg3pIawIGtUKg//4LFDPBsYsUXaLYaZfmNnva3hvJcSR3g2YKLQvslFY8uRi81miWPi70kgqNuRt4HBarPEe5KYmm7kb2BmXrbKrvgu3KndVcp8A7tYbR1R6eJtA1exvfb8Iu9qsL12DE9bg812EdrYYLMBxg2OzgYFN4FYp7WH/UOEt7cnzhqe/6cOEgJL/Him/2IHAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Inbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 13,
+            "label": "Outbox",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 14,
+            "label": "Mark Read",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnoCAABXRUJQVlA4TG0CAAAvf8AfEHVIkiRJkpT+/6d1gIhoOoLjFrMEEgEHAABCyjvbtm3bro2jbduaXlu2bdu2bZuHCdh//v9tuQtw1ewzkq5MNTFyzwN8eXFuWR+yAAqQ8wAYnjDSpehMBKppx6GGym+7OzsUpiHWmN2A80xtmK2anBHnAtusw10yN+OUDeNewQgYAiQ1S0mF471IycaQ0HBosNGQ5io7ebOcVxC6pNiNZjaHuPEeHPGCzchBl8XiNQGimfFfb8QvwwkO/Stps4qSIzJEbKQx4xqZQeojJqMwhHbkCSpREMlpJDMjOATWR3BUEscRy0ZaMjRDVl8kOiJ8oX+0fYgCEpsPxBTxkb6IR2TmgWiDx86l8GPoRL5QBKojOQ0g4dDjIc8O3uelIFJjYD+CYxS4iVi+4OereiDGrIFIxg9kL/SPrp8TTIMkRKZ/EByZ3XYuyOwgehEA/e5qjeS2M45vJ8H5Co79A7HQXiJWzSxz3omVNRjB71K/EICukRttEsjuzJKkyMau2MjsNrJJaaeW6EeHc/VHcl+iZCFR4KIn3Uty/kT9AlD4jrh9+YpYvSjEaiK5Q4Yct4YjRYwuBKDrsKhNZfc1T3LkVHpkblssbg/ZiRvHIDrnkbwmy6nwSXcaCt9RyrrLqsrOCdph+177RN8Gi9vskKZJrZnbNsulAKI9jFFNXqPVkZ01mFko/ZRYd8LrNTvhs9ZYBYC+0/IseMc9S1rF/LZa/dmpmcW4Ir8ZQe/ZMRmFym+BTbPlX7ANO2mNZwD03SCNZCd6lPTM/HZbIj4zH/gmMc3k91uh2WmYhNpvwmYAlKnsmHf65//faQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Mark Unread",
+            "color": "#0f5aa6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkwCAABXRUJQVlA4TD8CAAAvf8AfEHVIkiRJkpT+/6d1BjyysiXJG0uwBBIBBwAAso1t27Zt28a5y7Zt27Zt27Ztb6nbCehf/v9usTuoVctPRMwyqcLRZGmPME1J6yRwpA9M3WeYrsEHuZDcNdpzIQdrkm40GJasXInTCjLwK6laYTZXcrsi5zKe/IbBs2A/ObvFf8OJS4UOKoKpuobgpL3ikCzJuwaF5ANGoSxJugdsf2FIFi4TvXu0kSQw4ZgIhugiQpORxDlZeqFdhGICwA0ak6Sb/PYfhnrwlOjdpI0lcV8RmgiG+CrCksWveCbLfRXKCRxJd+tOku8CBxCGyQutYfpK9O/SxpPsbjITwRHvcPg+mgeJSPa6BSfLvcP++6gfRCUNujaaJG+xXch4hLWichBcoMTxHyDR32KtkPUIe0X+oDaZVFCfCI54i9lC4SO8FfGTRCbXYpOV3qK/UPmIWIX3JKpp3CYpezQUOh5RrTCcBBcolQz2yCrMPWJRwTupTa2BI9nDv/AB8wnvwlcfJXrNSu9hXQz1J5oLO2dRX5OyCV9lEvoaWkCh5Sx4wEsMNsH0WYzQJRi6p+RxVptZAUeyqdVVIwN+hVTz1LgPE7NitXeRWxh34qijhQMXHQ2Jnqc280I77PeK1G2tY2ErrdPggyww3IfOyzvU92lttgJHsq8pAPZZR3ye2Mpqv6Eped1lGkWfR6uS+pbGqHcLkAhY/Q1AAFIwfE83dYPgT3zIxtyXRctOugHbnv2CQfj3Yku3aLqwX2i//P/9cwA=",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Delete",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Delete",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Archive",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Backspace",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Follow Up",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgwBAABXRUJQVlA4TP8AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBCgiOJDmKBu/t8v+/rumerp0q4PwNRPQfbdu2cUR07R3pr5eb/6u7XubibrVNXJ+0YcJssrxE+UmSbjF06ncefOF/rmi37bfdmwSl4ZJNj52TGmdeWry5KXHnp8NfJg3vFFk9mDTklmuhILt8/PILxC6wSNwiC8UstFis3im2YKzG2MTGKTr+llZ44V584gNiAwyJCzIoJtCwWBwn2IL9m2hgQyMBDo4COt5WjQEPrXkVfDbNAD6wZp1q0TojDKuwWmetMYY1TcWv9Gr983+fY/vT5SoA",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Print",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Save Draft",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Check Mail",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfENegoG0bxvxJd5fD/M+/okZS2By9P1FG2AZALiAQCMRhgQ8Eg0duAIYhAUG27bTNk2Rmpv2vlL4s/e+k3Ij+M3IbSVGWvHDl/QEeP/xjXiRs4GgTNnzamtqGfWgn5tlUGLAOppg4VwiwSsbmKWeCySc5h4y5YRJ/60zCt8btMswrZ11YU8i0R2WU6qBjDQgYoC0CuNtR0fCrahd/VgypI3Q6EGfrIQldUE4k/KjcJaN7SG5CJ6QMIC3AFDRuyXKllpMDlJvk5HQ9G2ICKh4s10dZOaGP1Vm95eosPcBkNGhlBpCWh2tbT2g4rony8nCFsVyNZOYEq2TneJ3rj+vgEwNU0h9SgOTcEe8SnZfhV3tLI2JYnv/d93PQC/jv8fjh3/9+MQUA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Next Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Period",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Previous Item",
+            "color": "#475569",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      },
+      {
+        "name": "Microsoft Excel",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "excel.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Workbook",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Format Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Edit Cell",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F2",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "AutoSum",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsIBAABXRUJQVlA4TLUBAAAvf8AfEDVAjiRJkbT6K+1H2WBW+TuYi4ADybZp61nftm1GP7Rt27ZtM7Jt27Zi27Y2I7dtHHFm2y2ZLd43PN+5x5//UHkHMSiU4v6fVJayuuANVSUSYDV4VpK/ZLMRnBuwHOQLMQFrSgoZ2vCCvA52f2AzONcRA3astIG0l5+8nKTKUIxuXSO5DIrLqAvyH9nBI1IV1Bl5pF8IYnnJrgrP6NX28zyWg7kq1oKAdfwSLUIyOvWDcf37Ia+IgqB78w64g++JPLeB4ReU8pJlDabRp1u4r99AB8FkDcNBYdQhPg8ESuDIyCMbcPkPMkuIjS7tLioxFlzBTo+83WMmaIFVXjKe7utrlh8dTAuIHoORChrAzfCPpyHyfICrIbkAL3DHOcx8NsDloDceaXBL33iKrvnDMRy8O3A9xA3HPNvDvy0IyklwDDWbkWDtoCIZuSI0Z8qEy8gTfIB40jlTJnx+X3Ge1GQz8wDL5MhzGMwfFSUoDyIHo5Kt8TmCxW+wDzmXxvy4YDn8HctVoTwWGp/BxGFZrJOWsXhnY9wOIfMafGGY4erNQn9al5pcFyFTfVMdf/57AAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Toggle Formulas",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "Backquote",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Insert Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Delete Cells",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiYBAABXRUJQVlA4TBoBAAAvf8AfEFVAjiRJkbT6K+2PPBhrOIbptAgotG2b2j7b/pKN+DVb1b9txX/8yTazox2t9tpv2zbuBNz/saQw6Bp4rQdj9Dth9wpc6Ud0H2hueq1Pwm3IBq5WvQ3d4dLhy52GqW3oCZb75YRh7lMKjuVKs6GI5eUiAWK5Em06QmB2lk8fLD1tzYZdPSODwpKetpTTPckSeu6RlYake50/DkhrW8rQ2LaB1baKt1GgLUs4BNoGYdua+/ff1zmGc87BCwFJ55xAknTO4dnGiF/OmELfUMpDwkJoAzSUieBfCLyPtlUDPQyEAiAJFnIbivpwOKqXpvUHbKV0fmJ07qXc8idQfy9WirfBfCt5wJaLrxrkZRhvNrSRPmD/qQQ=",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Fill Down",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgIBAABXRUJQVlA4TPYAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA3DgNpIi9THj/P+xS91dO1XHENF/BQEBIOKM/XdxW1q3f/95cTOd1GYyrczmepjUZXK8ritfShMOdilVW7V3wYC3reqxvJR+KOjlsjCCQMaYIYwRpggDn6TxOTjThIBOFAA4VXmwyUrDv9liUJb0czPCkgAzts+RnzScvTNtGbITlyA5dTG5yQtJTV+E0GbzQQGJFdpl2DmL5BIuk0e0UA7BUg3xF2uAu1x9vPU6dZwVN5tdSuBlZiZXvGDRkvmL5i3bcOH6S9etXfOfFw0=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Fill Right",
+            "color": "#185c37",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Create Table",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "T",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Toggle Filter",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4AAABXRUJQVlA4TFEAAAAvf8AfEE8w//M//2oCAE2DOJyEkWkA/lHYSAgEhQCDbSRJjRYdAyHjajZeeOnpiuj/BOBvduVWD2SuN1fHPJJ0WBwUTn5DWQ6XjcLJ3x9+VQMA",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Bold",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Italic",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Underline",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Repeat Action",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F4",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Current Date",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRr4CAABXRUJQVlA4TLICAAAvf8AfEIXkRpIcSUr9lbbdu4tiMfdjEbJo2zYdacdJ2bZt21XdX7Zt27Zt27Zt27ZiJ3sCBv/9/4dkcnWmOOKZv4ys1N67YJFWPH4/0mygxmVWR9VueYC7zHR+eu6sVXqK/xDCHMCDLkq6lN3RgegD6EyHRxn1eQPRU9lthJbhcfMfQWa9ughtwovGP4JoVJUZeFXlK6hNkQa46KM5SoWScRGvi4sr3lO8wii+hrvvid5oskFU5WNCffcsGQwGAyJSrvylqG+S1wvoOkGLORgpFQxW+XmSfCI+k9X6mlCLEr70gVH2YF04ZUC1dwY8XEueE3QYgdGwwa4ByfpLA15+BFTe4WXwjWyLghIRWd0xTwOetwbaJxsrxGE0ebBvvcumquU8WD1H5Evwi6BBvyT9wP65gVkBpTfYGvwnaFKddGnwJDg/aOKRLG5gDFZXDfwOjhbwwmhil8fBvQKJSf8u54NvBbKTHl2OBaoCRUnXLgcCY4HCpHeXfYGtQEYytMvRQF8gKpnR5Vzwr4Ai2dLlYfC6YOBncL3Lj+Big9OBnviAVk5ry/ERzhhtaDA9oLwDtiDS2KCc4AUFycAGFcmMPQr/8GcfTRFzz4ikqIGEMvhBtqUTRqfuuRkoiRsGlgU0dIfM66T9NSkYbRtUSmIPDDI2TMNIz/maA0llx8DOgP7KXNIJs+WDW/pg9JKgRCRdQBoDiAK52ZjpBVziYg1mLQet+iZEr0ySJ4CEhzwTfMdFMwbHCMl4SdTYBlrM7hDWDGxdOOke+YHTjJIGveTOXKAUMXhG90EzuUPH/JIzeMakQTehCaxnvBY9eIVZv0G9TLcOMJpCMXjFVSmDT6i+E6xrvpkpfLB7jMVB1YNPyVcbK1zymYaVxmeP7DZMKdFgf4+NwS9PnTBfc16D//7/Mzo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Current Time",
+            "color": "#107c41",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4BAABXRUJQVlA4TOIBAAAvf8AfEHVIciPJkaT6/6c5KzyzCptxWxEjojcCEgCAZaOebdu2bd9r77Nt27Zt27Zt2+a2MzMB/c//v1GGTVuEDlseffqFdGxEGj2k9RBWAgksf+qktWZkHif/q2HWAtxoFH8hzL0Bt/rkUAVUWcDtkmv4rwx4UHAJYoBHqRUABiw6lUAJEyyEeFgYXXEM53hIXCfv/L8uKFJ3mobjT9a5BK99RgkTwcn2KmobyRn0w6HyHnySuKB1LOBhaB2Oz0ReF7T7nhQfzm5wBWsLDjgw49eCJDBkZ8M9UXjvv4yLpIXggm49C6dE5IYHz6IyeIZSlY1guKvyGeRXhXyi0KrwJc5VkUhsqiKfWFZFLrGvimjiWRX2JKYqOElFVe02mC5Lf/AO/QZ6XwzhFSA6DOkbVMx4UUIFyumoJjF7cDzNj05F4DwbDPDgBtYWMyDqO1vLCsNzB5b9xPhw+P0HH0Q3RE30juBwrTaMR2JLzCbL7tNh8xbGyzu0AFs8kL2jPV5zTDP2hJFGCwPpS4hrYFFMn69VLtxpCXYFHwYeAMfaFfSHttvckewaGqoQv/fYx9FVdBMzd4NPEXAuqJBuuno+11yJxXJBt5+qGxUDOcace/H7amvqeVGCdkEPnuuf/39fDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Semicolon",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      },
+      {
+        "name": "Microsoft Word",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "winword.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Document",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Bold",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Italic",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Underline",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Align Left",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Center",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Align Right",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Justify",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoAAABXRUJQVlA4TM0AAAAvf8AfEIXbNpIcafJPms72nmzvRQSUbduOSc/Y6NPtyY5GnuRJNvLa+wO8ybZt23W/tDbeCRj4+/8jtG1orf7vD3X1VNVyHJSUwKXkEtdo0KG7HVdBsYRvaOkPccNjECrhfgURJCwocpZwGngTYyIuoSdYSeqCD+QSYgFSXJF6DWYGSpIlSCcNDiq+jAco8rQYsJCOwtBqMJ3FPdBT0zk6BoqiWjvDMHKTAVSth/ypRBgoy2Z1y59xqoHC1NKGnMF8+4A50C6MN/D3/2d3AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Clear Format",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Heading 1",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4TJwAAAAvf8AfEJW4jSRJkfy3Op+5n2HkbyXCaQQASHSQqBwLcFStTmIMdxJHZw/e/bfw7j6B+zeXCZif/9+e6/pvVt7PrZtFh7HsunkucsMB9dIJGw7vGQ7u0GwY52ZjuzcaWL075wFQbJsMRDPuvmkE3T+XdjoJLJuPeKDRrEgTzVcWMpfqiLtpoGc9FV0BNZtT7fqcojx7/7/l+Pn/HTY=",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Heading 2",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRoABAABXRUJQVlA4THMBAAAvf8AfEHXAbSTJkXT+Ox3K1PHSnvSTBiLgAABYRjr73vZPtv8n27an32zbtm3btm3bNjMB8+3/D88NAmeFt3kEzhxvQctejjnHXn25sKaRC5FGxNT4Bq41zRC0DIJkf3urVpRVkJjYOzrCUgTS5N7VGrIePPfOimpg9HYv/0Rb8NrohiduWDh8Aj2H/W9hNdjBOEecroMb8A7YN5KcSD8sjg50gqnJoK4DmQ78grArRmeg3wEfax7ileu35o7VNaoCtQ531RPwtwLzcPIF04r6ng1MK6OBw5t44P3Y79kjYinSPgK/6YTf/Z4dwHXC63rP/ilMJQJuNoqaSsTdb9QFUYmsl40mES+Q96FwbvZ4P5o+NppBNo2Y+tloHOk0YuNvo064acTa/0aVUNOIib+N0sCmEVXfG4VeIG/zuQh73chjKqFzupHbVAI3BESZ0+l3o3XoThi9p9uZlJCz5dD5bsdn21luhwFoR7fe7/v69v9H2AA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Normal Style",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Insert Link",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "K",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Page Break",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvABAABXRUJQVlA4TOQBAAAvf8AfEJVAkiTJkbL//7SjakRv9Q1RKxEFWAQcAQAIKGfbRq7JWrsPZNu2bXOyMdm2bdu23QTUh/9fNzfhf7k/Pz48ubRrVrsc9qhrDPRqv768uv42oVoYJcBclvpWTWKnhQ5YAOXU7YvzIN1GUZPqljhK2ybIqrmO0qZAs/JOYpQWl1VrHOYX8/gUVlUBnaFRSBKJdrLAL+4qpfUcEAgEHBqZBP2vqAUkEUIri5rfRgt5RnpyqbOGSM1e9RU4S6bw/QR2d2MceMumTAYed6MUuEtHVeAPeC9qgcV01EeAe3EM5KVjJbjVTiAWAprZUOnQwk6gSvpl04DJgBuOVGz2DwaDTomXrX7ZD43KBUNrx8xXbc27sgAEhcYmT0+2p449wg7h568y2FpcjWDqq/KyBz2EQwmYaXmlVEN030QC5+SJqEbp1nPNyAzZA2Cg1gWSjg12P7WJ0nr5DIGAR4GWeGdRC0zCn2/v7hxZ0Cn/j/IBsHZdeJMSeUU6NoW182ZVcoLmMyv030DnrMpU4GpaqoNPwFlpD/zOCsR14Komxb5DfZNi4i0SMhugOzQaOZY6/Md+iU1iR7U1OZ+kZsejJiej5uaDZ03NpyoSB8B8/Pn+8uLepSMbprXJZIR0AHz4/xV0",
+            "action": {
+              "type": "hotkey",
+              "key": "Enter",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Spelling",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "F7",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Track Changes",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQBAABXRUJQVlA4TNcBAAAvf8AfELXIkiRbtZX5jzqx3ucc2OsPWbg7LJyIgAMAAIEmu9m2bdvXbtu2bdu2bdu2bduagH7k//tLQ1ATosWaWx9+PNk3IIkWgg288H85qQP4FDyd5Y9aqdaCTsOcaBBXIYy9zqk+2FQBJG1OF1/DP0VzIf8SRMylFAugOYsOxZBFCw4HOxODK/Yh7511DsFLnwjfefLG+2tHSp/TsN2emIkeSPQqMivJEcjmkD4JPgj3OvpvYahujsdEbn30WZK/OZvB2ddDkB5m5qMZcZ8Q7g3bRMF9/LdhoX9ge5cXsEv4T9jrBUqDe8Cq/gf9XdXnILsqRBMFVoUzsa+KcGJR1Y/EtCqSiXVVBBLXqjAlEVU9SUqqapfBeFm6gzeQE2h9ogtdgPAwxE5QMuNZAfnnu6OQRByDdDe3OxSCZW+gHoIL8EOMJuraW0sL8/vIV9uJ/uZw+QveCRwQNtHb4821yjBuCS4xmiy9d4fRaxjPz4ADhOjJ3lBsr9mmGVuCiH0DRfBLgPNZFNH761cLZ5p7W8FbPRd4wNAV9FtNp7ki0jU00H8/59jG3FV0PzV1go+/kF1INw0dH9eciUTfO70rupHSkWHIseePfx5bUs2NLHA/8v/90gEA",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Word Count",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQEAABXRUJQVlA4TBgEAAAvf8AfEJVQkm1btlK9/nd6FNhr38vhFX+yzZWNGiEBAACybVK3s23btm3btm3btm3bNm/bn711AuZ///9TNSQ1SYY889eNB2fem1PAAsFZeqBrny9I2Gz0gjdby7uAT52zbf8wTPUkAWFR9Cw3nIG2EG1k2EKnD/pG87jOIZwYtGC7byyRFs2EpMPRJfStbngdA+oiSG/R2q6QlsTgxWRgJXu73FPGdDDfktsy3DIZVCZgDfuKYk8RF76BdBy2nL43gJwE1knavirFQyiFxddAun1CDRwb0QV62/RRFlm0EHCwczLf8R7qDJjuA9cGiwuCGuyDzw+ghu97ciUSYuL7z7S8zxibQW1D9QWDDeVBc5C10QmJ6SJzlHwCPUNu8Kzhw4V34GQ/cKuQfgpuCE8f/XtYqmcwCJ7gBkxbu6iWQIDpIeCohG0U8gCu8ktqz0ASlnLgGqQEAYEcdO0PUOVl8A3iEpST3fVgSw49hGeMV0F00Fn5i8hjpT8IC3ofQIlto8S5/tuiZKqwH8C5qoOhCsifStfYqvz7U+kNAio+Cf8Np7MPfle/tuY+0qvFV/kWCFWag/9Abw5TWIyF4IBlKAd+BZqtnYNWjoLZefu+B5aFscrnBzBQbiq9BZNgYuqfQeUT0BUUvAB3WambGTOVv0Av5ARRFaKN4p8A32D9BdmtWc2MyGrxvLAc/lY4E98nQDC4hZgZCQHFzBANfB7ADJjr6itkRThxewIgzqslNjNWKs9mZkCcVLpnhtDWlqYmlTg/gTER+M3Adl8pfDH6Kr+BZngFKYFk4vkMxAStM7Sha3oF72pxz2gK1AOBJPgZkA/ez8irPMIrsIfPM15XX+AGTEnaM4DhrlokD8BhZWNqXytdg3BrOxOhkqZnMNYDHaRbSw0aKr8eAM0gP42fwepTkBUkswgUA9tqcUoIDBsmgyvQG1j8ZA3zMHrBtJrKDWRAGXiYCEgbUsMSu0HTrnN15IFOQhSc+VT9nexFpdP/yotpUkjSrkH5ty99lITlnPG8yiIaiio3W6vsgDkJfkBc4gAdTRz05wrRBv0qs+mMkrCCr/zyOrE9iM0FpyANeB4uoGvh8hRcE7ggZaMr2AdhuKB/ujZ6Pj+Avvaw/hJscdisdE72tcenJaWn+QJGl2Gd8wMJkDI3u0Jx1JcejhbFHrcLwzvteiWB2DsYgg9xvkM3pc3Rf1p/pw3huvXjymhu3Gnn21n4Wpp6Y6rjD9Clb19ewQmGORvYaYf9BWEdfQ/gOqSB2/wiMqcb66C5QLgj4Ib5I87DPV5jnuNFNj7PxT/+NQjfMUPQxg1uJEHN+WQbyq6MnuQc9J4ZGsZ+9HyTjn7eIqTbxPgSj2Ri7kfK6t2Cz79//B4HOoX8BXkA//v/n80B",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      },
+      {
+        "name": "Microsoft Teams",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "ms-teams.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Toggle Mic",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsQBAABXRUJQVlA4TLgBAAAvf8AfEHVIciPJkaT6/6d5iOxBZiF6tYgV3h0BBQAAQ9LsGW/b9qezL31zc7Nt27Zt/zfbiLZtzwTMb1cyV2rHB7jTl0P1WE8BRr6/HNSK1B9EO3jWJFx73HNaSncwLhceHO50u/BOujm8JPHN/gJ7CTyCSTg3x7somN0Ci8zmxBRu2/CLmubEFS7bcIu631LDBZP8v9U7Sf7+kE5Y4beNdVHaEs4HOBarsJsghorID3BuBLXoL5RLrPLjspOn8VSUorBwaIResVxGXzlqBVJ0FcJGYP2AiU8ihbbHQ75QLjAzEGeFRiNjKUnYlsHzeMTneypKkri8QKcSi7nF0NZ3wCTLWeoo6luh5z9J2C1mKHMUJm6nCG50LrBGTSVsZbQV93RXx8k5KuanV1q+ksTO6xYULKdiNjOSS9yzuwGBk1TNF+gWykhJzLElcgSe1QtcWkNqZ4jbXiQ+LetXt1uPeS9ZO6V6gYaJG1nd0hKlaRlKsq+b+FOBMF3T0ub/DsaYTef0JFryc8SfLVkspn1Yeqg4uA9dFtyHbzSGCPNsHZZ55l/qZDl87Le8Hmt7Guqy28RXs99OBA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-mute",
+              "settings": {}
+            }
+          },
+          {
+            "index": 1,
+            "label": "Toggle Camera",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-camera",
+              "settings": {}
+            }
+          },
+          {
+            "index": 3,
+            "label": "Share Screen",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4CAABXRUJQVlA4TIECAAAvf8AfEDVIbiTJkaTWX2nDFq/qzCOv7YqQBUmyaVvr2rZt27Zt27Ztfdm2bdt8tm1jDyS3kRxJzIiZ9Zundk/4fo8ZSoyyo+0no+zAT7IrSa4mtyaptcmsS2J98hokrVES87tLXjq+Lmlpg5szcLCRZ8ZBQeNB+YKVmzqHvoM6rWTBItE+DJQZShUaxv0D904lCg1b4N4VgSK7jOgNmAyD0fjnrg3jWlUpUShPNusHBQoo49E6jt6Bjh+mRZJHMNxrmqDQGOg/sswDWbPaTkLC5QZomSBf195OQGS9BA07pMveRxIOPV9B5btYuA/6TiUYsm1dEyibn0souNvvmkd1ZnW4BtrQDAStm6DSAv/Q6ng9bjhBE0h7tNMP93jj4AYqcwiPNw4sPlRuITveQIw1l5ZkjjcQiqASc7yRmK0cwTndt62805quh4QCDymqjVl34Mp9j8oonzcUY5XR8SYEBOt10//Zdc+0oaD1pyLbg0dPg6dL112zxiIQFPa6JUir9hrcu2TSYKxVPCv4HGyAe1eNGwwW/8G9viMuf5unB2A43tnWIpEVJaI4UNNrDBsNd1CYedDH3s3R93wwLJTQ9L5v1HDUN8c8ghZBPz6qo1JPfzNWB43HUXPC9Qu0YOY4I1587tA3Hji+g9HADJFcuu8eNyBsw4/0E1987jJsRBQHnFNefu4zakjMO75JgP+gZYPGxLFlFdfOc6++QfFo/qYieA/a0TUq3uBeH5hvPndqG5lbuB+0qWlkTjA8aFdtZDZRPWhbaWTEkO7viXtQtKG8MnxkJscHJjuSdwpCeae50YGB5HiD/0y+aTs+tkJ5af4n0X5xcD8o/fz678/qAwA=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "share",
+              "settings": {}
+            }
+          },
+          {
+            "index": 4,
+            "label": "Leave Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "leave-call",
+              "settings": {}
+            }
+          },
+          {
+            "index": 5,
+            "label": "Accept Call",
+            "color": "#237a3b",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvwAAABXRUJQVlA4TO8AAAAvf8AfED+hoG0bxvxJtzsg5n/+FTWSpOaW8e6PRk5sktBshwAygoFAJAgIAwKBQJxx74SPwgS+8FDnsIBAFBzYtm02N1ZtxUn//IcY89aI6D/BJM2Wz+AP9qc6+WaJp5MTIotcnkZO7OU7bf4KcHjQLdIXgOP7zklhtXxGSQa7nW+SEyKrT+cx6qnVdZxgBKJ4YLICzEpWf0YcK8Cq1o+R14eRF7ZtXWfEheXsrijqhiRWgF2tPZoiu42LAlDVDklROacNuprRFTusAKdaPc42deiKRd1dBaDOVQHOarFGDpjEFcyVULfN0P/v/z5MBgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 6,
+            "label": "Decline Call",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "D",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 8,
+            "label": "New Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Search",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Commands",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRsoBAABXRUJQVlA4TL0BAAAvf8AfEFVIbiTJkaTVX2nbY01m8nM84R0BBdu2Y8+PT+k/lmzbNpON5LU121Zatrdu2662bb3vPQH7/7I0h30HGPZnjW/TI/ZOjnfE52eOe/Ej9k6T/qzxrHjE3snxjvj8cYIyW34CedEkvoCz6V0a8zHRaL/vetBG/RTePaR8Ogq6kA7SOLUaIJeY2dg5gzIrmy8LRlwk67H8ITrPAEroaEy8lVX2H6Ifkl6wpiDDk5HZL/34Pe34eR7zPxADITQHU1q2CHu+6vkBzm2pmIucl+K6N63acoUdS2xZ3NvooiV8LN0l7741XkbGsle8LjkrslDaU3kthi+AdVOqhsJWFF9gVZdr7Ezrt+i+Am0UEjGUq+JyCc3dpXpkjZaxoSyV1Eugeg4Jh1A6MykrYy+BcVWqZ+IExewVVgXkBjfSmoXMYV6BJlKiZuKKQJow50zvrt5jawgyMdPKrkwy/RH+e1cKgVB6M63qCjEmXQCHTYYB+9dhXEBqh1ohTuAo3ctWWbnFDbVYiYa8fwe1q4b8ddQRSMxUu4ulw5EvV0aED9GtCrQmZbA3/KODd60jen+nSX/G8Bz2Hf77/+c5AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Slash",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Settings",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRhQGAABXRUJQVlA4TAgGAAAvf8AfEAeFoG3bmD/p/W93DPM//wrbtkHxSiNFbts26bi1oL6BmgGsBQEwAOYOAgTgvCsQ+pkW7mlKhflgPz9F/VzbEQQeWu4kdAUSQiHaggFgACnMwyavu27nXgCkXdteSFJ6Gjs1Wtu2bdu2bdvesae3pzH3b91O3kpV0p83ov8O3LZxJGWv7hVvy3gy8wL1n5bIrD8dxpn1mUpi1NlWWCqzDFrPjqoQEkseFwF+BxLBb4Di4yUJ/6k/+AMjzkmcN7X8OFjvN9OvZ8EkP8lkUl5Sk70+3VuCrZ8xovAK4GPCOBM+ArwqmKo+bw28JN0GOs2nhqvbANt1dgDcUMNPNZvK2tJeLt903q5KKaUGdwKdg5UpoaNBKZVa9Vbnq/KSy0D/hfFK3Nm3/qEfgs2GnAkX+oFLfrIRyAdKySfbQqUWaQdDOjvzwAY/GQMwX5AxMQ9ku7qyQG6cwAKA0crPaAGOSTLOIcQJJXAcaFae8hB4LuaBXybfMxIvgAe+sh/oqZJ0LDEYmKsEqnqAfb4yA2CqKGTvoa1r1mw9tFNJTAOY7ivpLLA7qrY9QF/Kq22VRbwH7kTlLvAuRLjrtqbt66UNo02uA41RaQKum4zecOlrW+CWbXpD82Df9JRSuwcARkRjhHYd7FIqNX3fA70Z2uoWoaWl79117fYlorGo/6It19/1CYI/O77SwuN1TVSlta8tpE53yQ0gnxd5FIO7zTwSyfcD112avL/AxWD+sRc9xvNYzHXGeNrz4viC4AKQrXfHIYCJWjqduuduI1+MtZFXfqHp7p5pVZoNADjozmH/CEsiIy124LC5K1fOHWZxuMRL8y3wI+GKpQCrI8iaea0JLZquzYwgbhXAElc8AVrS1kx6ihhPJ1qTagYeu+pdFYFTypYjRUKieNha4KmyqFFuOAcUhltSfVfoAQhZ4fYgS4YXgLNuuratwEtlyT3K9F5ZMjiRGLzkSq++2Gp8BbRmXLABrTvRYMUxTdKVwaaOwVc0IXYrB9/SJK13wRm06Nhs82tFILdJlrIpBxQtfiyxvRONM05eLvuNFm/GhvIM4N8tZNH+J5SJH9Hi9zJXpuO8flLnTmRC8o22NlyktnJmiOyzuuz8eYfWY9Inw1jPEbkK9A62OMF6gWsiiw1b/nGS2yLHjk7dWu+QaNQf7R6aRE+MFp07nJdCBt/W9B8SGAKwzCS0FzBM4KCeCwYrD2JRNsS9zSoz1GoHlZkrsAXILlJ+RHnlOoHlQClpdYrkgZUCq4Eu5RFrBVYARTsKIawx8ObFFoHZcb3YWn6xMHaiJO4D8X/kkCb3VuwfiZC498b/QzsH9B/annDKJCNx/5Kd07W48t7c7+7zXnDOSNznAjd5P3MyJ8l22u59nGjX7m2Mpd0b99Zo95Y64UyExD25BOQ22rT7Nkd4SwdanHbie6Ik7uO2vueIlcSGm7rv8c333Td837KhyeTQZYbvuxvN9/nme4P7gt8umQruVfvme9WoUiTff7wU6vuPRfT9Lvs99jWkyc9knk2K2O/xtt/XqNN41dd+X+JnWL93RF24siGzVyyfNSSOfq8P/f4pu+/8ia3fX/OFxju7p1aVGa/1+53XPeYdfd7tpO7x/Nh8o+7huu7T777uU1l1rxqrupcvdb/3Rt2vLp663/usVPfzou75cP+MtFJ74qh7jtRuu5VKz9j/sMWHumfQ/u3yxjFy3fdPVKGN8ok2ZuPlb21Bxde9varB9/lR93d+FU4R2Xlw69p1Ww/uEZnq9bjHfqC7SnS2A+ixOHzcp0LGvTLfMfhZXSHjXs3AUYmTCHE2rCbVrDwe95wnmeockO3szAL5iQLzPR733Aj0ByEtOouMcd8PiUoY970M5C+ae3hL2Lj3drPUdbHMJeXzuP+71amyn+8Qx/1NCenV73we90+3Y0TLqeHqZvi8h1tq+KkWz+c9BNukeR8vQ+Z9aNW5l9K8j22B8jbz3vgbfd7L3xszPJ/3c+hnxHk/h+orYN7T0icl63lPT5YmKmXe17lWWBY+7+vcqIqa97YhtJJ+ZkNG/Z8lFA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Comma",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Chat",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Teams",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "hotkey",
+              "key": "3",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Calendar",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkQBAABXRUJQVlA4TDgBAAAvf8AfEFVAjiRJkXT6Kx1LPdgL9bqpyAi3tbWnjZkZwmAaQAOESpehATRCOCk1gkdQmTH+MVxqgFCpLmzctpFE1bvd3D+4/ksJzF+FHCWqXT9kK3F5oiE7qDxxIVvpDE5W1cCBMdon2HVQeaK9xuBngs3xI1gNMYOqrI8iVGU2izOrIX6QKfL9193K4dVT5PvPeyVFAzyiN6IHPMrSHgV4RD05QJVs4YimCqzue4qLHtkjlFGTPaK3gIDsEc77z3vVBFaFHPtZNbFPEg4LeCYJoxGjJOkFHJKE/fvPO9VEj5VKtgCkijFq1SwgU6X3/vPeD+697v14QFWSEYkqj49z71dNIEgSVkvDMEkIFg4aSQJ+/31ncVF1d4MWUHd344wa3N2+/7xXUnBginz/d4eqIZusP+Hf0i4=",
+            "action": {
+              "type": "hotkey",
+              "key": "4",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Calls",
+            "color": "#464775",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "5",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Attach File",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRswBAABXRUJQVlA4TL8BAAAvf8AfEB65kWS7dpPG5J8q7r53X+EcD+JUYa0PU2sNUwMJaGqadOlpBkCzET2BAwAAwWS2vWy7rk7btm3bNi/btm3rtm1zAmrZ/wuog+eNf4l8HwY9JaMx4GZNRVKsDOD1X0qIeygeKZE3iI2MgHE9yMglhLGHU5zQ1xE8g5mAxooZNn5HGKd0iPZYlrMByK6gQhjJZFBwmytQXAiKkqFWzIoswcNaKhBuBVKFqDC2qay4zVZVsSSYTYVVgX9VvQkjkggSbvMNrarA3wpyEyFf0FVzqRXcAu/UkZ/5B4wbgUEDRWEs0sDEbW52Go/sCybSYEhQUG3ihOFPAnZ+BTICTv4EGUkQ4zY7pd8LLoGm8PggCByApTBGKRy6PYM+ACQPguEuPypa6kXfC7gT+Mj7JCYpATw9LWdA4mN9IqMb3q6npjc8Cid7txXc/++TmdjgMLOEr8YC4lhwdBTbqrip8aQLoxEanO8EQR0QU3SEdur2BRwdig0xgxnYIweCuer5TZiIwFC2xLvLwS/B3mNcNIh3B13qUhilsCDyIRivvlgpmsPCyxLXTqB5EXxCjeqzmEHpVFQLExzVsv8XzAYA",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Format Message",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRhwCAABXRUJQVlA4TA8CAAAvf8AfEJdCkG1TjPurLneYiDlh3LaR49xJ3pyetw74NhAANARCVARBAQACdICOAVAQPPAQWAc/CjoGOsCqgArRIA5EBU0xQBOI9EMBKEUBIEqybdpZz4iTh9i2bfNh///X3LPPuTtVb8WI6D8EN5IUSZEZS7l8fE/A/zQpTG+f3NfuDpdKnBRXauLnqErI+LOEs5UhI7EosTlu43JZNM37m4bfDKHHE3kgVVlv6JHPhSR0+i7V86iS+TIZ/BpUPeKy1o9g+tRYolrnEJN1xxLVAx1kY6g4Dkk0NuXO3nFo7o2I1Fisz99aeh9xz+IYegzNNyNOaISlExKxTaOlyWPHNIumLqhvhQUSTZ1UT2GFwVHA1P4Xx3ORQ1PnauIY5zC+oSxy+JouJyg0lVxgnt2x+gfZkQ+Jox9lh7/urQ3BxshXnsM8Dn7lOQAbQ/TW3juxwm6n94/UXlYxI172S5xiXQLZzMUxSCEuJJSLXrutvjw9en0sW235ZSNd3W3q9tps/WUWQOlUjzmLBEsXomR29J0pBmjskIgr7//nuiUqMa0W6GTUuE8l1vTipaTurJdJnOvFz676ERCUZQlQlbj/JZMsmyHSjzGyLHM+XbMbT2Fplm5vu6JbgXaJuEb33KbbCMWU4+FaYrNCI1bFkIv1mU7w5OwVG80S4nxtugN0mbJvVMvZ6lQ7aLPntn9wAgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "X",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 18,
+            "label": "Go To",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRiQCAABXRUJQVlA4TBgCAAAvf8AfEBZJkiQpkvQN/f9PByIqsyriNszMuCDSiJ5AAQCAYDObt23b0Tbi0m3btm3btm3btg0HbiMpknf3GHoYnnBycPI49h9ypmK12HTp1Y8HR1a0Cf/G3A0wI4N+/eeHPyMsYXMGTqcPCtuiamcoJc6RALtApnI4LfoQesBpayIxVjF1QMLtVGqswdT36WIyOSrKg7KSVnTZ9PCjAEVOnK2pND20qhOVBO6eM1jWDh0kzAEOxMoh8FKhvyHoO7KILo8HpdnkpFKb5pg6Y/BLAaF2GsksDbe/wAOm5ZDoRs5eKpMWE4c0EpO5PbblfWCvfAPkKnAMPILdmRTGaPfCrYxsvOc3Hm51AiPcXWmKnwbsym6g56Qp8DjVkdrVdXxHaFe4Im4pHgMjmpy6iEesuyLS/uY9EtLJwuAeSerqxVugblbhfs98cNGW0pg0ZGNR2WmARUSvK6yRxkmV513WA99ouvoX7+RuZvuex2c8KU8pPe+XHbkgsAhU1O06th/6/8fTDckFhE2s0u+U2HDhtZO8+APi4RJ4lO+8uooaGz56sgR6VMroBjkIMtKcDK7Z71b4isP5FfX9rAKdn91ZCsEnVNlzQ2duSNIemUzN+8ts+oEJ9TPMs5Cdna8phbYdiWq8zcXpAI/f2XVPqY1PQlKdLnEpkyLQ2uuu7WdhpNh/mrxw5/vdrR3d0pnhW3speKDxOPbfCQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Zoom +",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8wGBMxJ0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Zoom -",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkQAAABXRUJQVlA4TDcAAAAvf8AfEBcwGBMxJwKBJORNVg54GKpq27CUUEIeOlqCvvmbNSui/xMAj2yWRPSpJdItLIno+9kFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Zoom Reset",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRi4CAABXRUJQVlA4TCECAAAvf8AfEB45tm2btlWNUf+y3rXfOfusnT3M1u58L3rRt23bthnZTO3fGtETOBAAEFDubWbbtm1jsmuybduttm3btm3b/QRoxv+TnHMJqV8CRzDoifPLO4+csEA3ebgiBKBVhRzjC6JxNpunWmcekGidOYWidaa4efzBM6QuN3JUwB2sE6BQo88DAgpqI1JEcx6Z5FSAMOT4I+rqKIRyfcRaKm9ciKd6EmQ8BVdBJYKTCylUbyI/MGx5IMNXAZPAKtgTnUoD2uuOr/9RBcRFMGfx84hjPpFWDTRGoLKgwIXYqQbYPwZjJYm7C8lSDdCtcfgpCVT4KaAPcD/nl4N9jCAGn3hzyP9sDjBx45j99+qme8qVIkgWHPOKgOriEEIOVDrejKnqmodPKe5xIVGqixEYlCI6VwtoPF/VLcyUIxyrHI/BqJo5mgmFX0nuZd0x93dUzxgRZXmeJscf0VAfn3X+JzQoEPM7MN/4Z/HChXirp5GQMxrYb86nsHVzAcWqQgsZj/w5g3W8OGYaeCWCltvIBA9vO7uOuYBOtQiTgo/ID+0/XY5vI6t6RHnkBaAHRqoLcVRNkHEVmdxhYQmpkBxVJcwLNt8cEmL7C+h/Wplojczy0+FAybFjDi6pNugfRcZnOA8cf32m6oRzwZI/CXSPVR+iJzKVjTqwJDJqbRIuBWycbNP5C5EJaJPuPIy+wtAm4RWZ2kYB/BUZzUHM+H/SbAA=",
+            "action": {
+              "type": "hotkey",
+              "key": "0",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Help",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRkICAABXRUJQVlA4TDYCAAAvf8AfEBaJkSQpkqSG6y/qVu3dzVrnM3Q9MzOYNaInUAAAINjMuG3btm3btm0r2bZtI9m2bduO3LaRJAae7eSarbr7CftxLYOapQyjdtz6dm/PpHz2WPLA4mHc/9VjWTCiKDBFvJzrx5tkhDlou5ybjScOIaComCvGjzvHbnxfVUMfvATwn0/nVTVrzGB7b2B0jBV7OOtiC+36kNqZxh1/6Fe2geDgbNq4wrY6GBbb8nxLgnNtIajCv7VGjn+sDUh/W9xP0jfqhMth62QRcml829Ks3fTbhdBYayV1ZZi8F6dIblwLutXij8TCtM/JM3wHeqFxMzNjdl14prA/1IxSa0ZzWRra9/rlsWp6islldxsfheI+BoffmRkMi2I1J8YOl1NfRK78nN1h/4vpRTksiA4D9XLiE2zNDa9i8wL12j8zviURLFouQFphsCRK5c8F8Ckcl0THw2mEX8CbImgHD7fCP5no9u+QTH55ncxGwRoMecU9YLDPRWdwIFwVpsGEtnOC77nQeS8ScgNuquIGZi4FUzjnRkSLHsBYvFqcIYqNwBYveLL3u/FJJTYSe6jtUJ9ktvh4Fxs5PZRjI79fCCK3Uyls8Ug0NmJb3OCNDYsW19hyt1rPxQPu2Hwy0a7Dkd6xmLXXeOcGzEExsHMxblfC0AYz3K805kLkb2Z8owxGt13t38EkxZ9k6yiEkhkt35NZK1CT2S87mYN7/uix+vbt236Qb4w8e/bsWf6+exfgcS+zAQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "F1",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 23,
+            "label": "Close",
+            "color": "#7b83eb",
+            "labelColor": "#111827",
+            "image": "data:image/webp;base64,UklGRtgBAABXRUJQVlA4TMwBAAAvf8AfEBpZjiQpknUNu/9VV1ldI1X+7XsvlY+ZmZl+l0FqRE/gAABAoMlutm3b9rXbtm3btm3btm3btiagrvl/P2cIakK0WHPrw48n+wYk0UKQDz4F7/0PH2ilmgs6DT3RIK5EGHvtqT7YZAEkraeLz+Gxot4h/xRE9E4pJkCzBx2KIYsWHA52JgZH3kEuD77zyBvviwopnUTNdnl3OvRAokaRWYkcgSwO6ZvgmHCNo78M+sHieHTIrbZyiOQvzmbg7GLTu8vuPjAj7hDh2rB1KLi23zMs9AFsLZ9dhH9CkkoD94BZPQv0V9bHgeysEHUoMCucEfusTiMWWZGKmGZFMmKdFYGIa1aYovtZvYuUZFUuA+Np6Q68gUygdUgXOgHhQRObcNTtWQH5L6ujEInY9s5d73UoBMvaQD0ELsA3MepQ19pKWtB3t1zYjugvDpe/wPv/DcI6fPN6caUyaLcEh253LL1Wj/Fv0J45AAcQojt+g2J59TjqtiWI2CUogtsCXvSgiErw58BMc/8z+K9nBx4wVIr/NU1zRaSSBHrqZ45tzJXne1MTfDx6V6nS0HEw5kwk+koXKR0Zhhx7Prj/2pJqbmSB65r/928H",
+            "action": {
+              "type": "hotkey",
+              "key": "Escape",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          },
+          {
+            "index": 7,
+            "label": "Blur Background",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 2,
+            "label": "Raise Hand",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRl4BAABXRUJQVlA4TFEBAAAvf8AfEHVAkiRJiqP/f9ovJDBm5E1LaSlZBBQBAAg4Z9u2bV9SY7s9YMl2MhqrbSZ71Yq27W0C5sv/75mb93/djzcPjq2Z1CiZHvCKef/HWq558H8s/SlOOpINWW7XPn27dc/abp2gtltt9fxStvibY0BgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7b4BO2PY3qm0DCAaHTSek1utGf5Qt7tf1Brj2wmdygFjOCfV0s4Q71ayJz/kyLowpppmrZewwzvWn0zKA4Ji8Sj2E9SX3Pi1z2cNTHKJYDrsaASsNlNW0f50Gy01ahZ1G7IQfnk6jK60DmE7ILtNq6DQSTvjj6jQm0toE6YTjMa2sTiPxhGesTmMqrZ5SBP9p+TqNpBP2QDsBmk8rr9MQe01ecDuNjLQGSgFZTSv4ZF/+fzcbAA==",
+            "action": {
+              "type": "plugin",
+              "pluginId": "microsoft-teams",
+              "actionId": "toggle-hand",
+              "settings": {}
+            }
+          }
+        ]
+      },
+      {
+        "name": "VLC Media Player",
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "vlc.exe"
+          }
+        },
+        "rows": 5,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "Play / Pause",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Stop",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRmAAAABXRUJQVlA4TFMAAAAvf8AfEC8w//M//4ratoF6/UugIAZ5UAN4MDwOharYViKWAkRwSODWgAz2zwNuX44R/Z8AeMyKBkSfNALS9fTmahEYXPMPU2+uFsH/ckQDos+LHQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Previous",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Next",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Mute",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "hotkey",
+              "key": "M",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Volume +",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Up",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Volume -",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Down",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Full Screen",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgABAABXRUJQVlA4TPMAAAAvf8AfEF8w//M//4raNmLaG//N4IAe9ABuMAwMgcBjQTgObmPbVpWHp5TwSyCzSAv4JRC9GIdOLHXpgN/df/feZOMyE9F/R44kxVGAnZ71BDzC/cWNqGuODKGXmCP/jMUzORYSODa0ylVAK7Bdp9BeRim0jX4KbS5A6wK0AlqBrERWAquAVbhqXDWsBqwGqha0LvY+ixZd8sZp++PQyPsC22aSlOzPGebnEPNfINa/UKw1RzHWHMZY8hi95Dl6x3HUjgOpDQ+SG54kzxuSOG9IVXHckY7huCOF0XCwS44kS5vP5Cgwb5uj+IyVu+bIun/44QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Back 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Ahead 10 sec",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": true,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Back 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Left",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Ahead 1 min",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRgACAABXRUJQVlA4TPQBAAAvf8AfEJVIciPJkaT+/6c5ojwFEHWb3c3VInYGEZIAACDbqJ1t27Zt27Zt27Zt27bt7Wfb2zHNBJwv/n9LHbYfYCS2z1G/dlANl86qt1HomqwP+P6zCZz1mnD2KLdNvIA1yRmyvYe4PzVB8jjUBHZg99A1MexxZRuIeO6ijEz4hLGMvV9dFArARHNYBFdDD9ciEjhrbQkoC7dd1jfHQXVo3HNQWNnp2VLI9bUHaO6CgjkuwPlS/gQ5R0bw9r7BVEFw/AQ8B3to1usUoSuIG/Da7jnHarCwyn/hB01BNgLfB+Sc76GxrXFF6lSEq6/9Q3TOge0nyF4BUAb/lCQ36D2vNQTPkOeM4z6v64HkKdC7IB+a2QRrlbjOdT2M+vofpAtQp8H0xGg9RoO8B+RaTGiMN4ESEPAF1GBB2k2I6mv7J5sI7iHeAqjTwH+AeWgGt0C+r/1DPADVWzB2C5rCWjC0NwDHry0t4Qa49143EOqztalpl4endxsoT/42wHtxkD1va9HFMemI4QGZBecyuPiozViw8YDMSw1NrTTUgCBgAY6kuzQxfQ2GasGxHfxDWtg3Z8HiWck/tLDCKHbkuQSp/8HJt7o0h+8fS47R0BTKgut3MHXWskjayuLRkfMi6L6CPwirsh3+I1h01IUWWNUX/7+VDQ==",
+            "action": {
+              "type": "hotkey",
+              "key": "Right",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Faster",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRk4AAABXRUJQVlA4TEIAAAAvf8AfEC8w//M//woCEEDUAJPMNTOAH0UwGIoiSXFIFvhjAin4dwMXXrki+j8B8K9tkfdFozDzHpKUVaMw8/3hmxo=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Slower",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "Minus",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Normal Speed",
+            "color": "#b45309",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "Equal",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Record",
+            "color": "#9f2828",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 16,
+            "label": "Open File",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Open Folder",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Open Network",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 19,
+            "label": "Playlist",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Subtitles",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "V",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Audio Track",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfELXIkiRbtZU3/0kncvpIxF5/yMLdYeEQAQUCAALO2/ZsG2m3ZNu2bdtmsm3btrJtmxPQD/1/D3V4b/4juWMm53LyS+A2WUVRVnZ4/VgSsdnLoyR5u2xUBOZ615AtiPHsV1yQwQOeYQ7s5xe89Fqx+j0wnMoRPUctVwNoN6gIQ6IYCrPtCspFUFSM2vCjZQUPv0pBeBxINpEwbEvh4X/bVndbCmZLsRr4dze3MIQLIT7bvtG6G/5xkFuI/KCr71Yb3IKXAeYmMNigGIZFGUxm+xvYBqD9YKIMQ0HBDWBbXBh8RWDzG0gHHP6CjCLEzLadzkaDS9ASnj0OAnewDMOohL+z7Rt9B6SHYLgE9eHc/7gKeOn9kpFUAM+51hnI+qxfNHSXR3Ku1rs8hZf5/b24L24vG7GLYzYR7w3gKJDj4Ojv2gwHq31cehgaS8PxIgg6gWjSsbR/s+0P+wltI/jGtLBnDoK5PvNNGBELozyR9ymY/AR7z9alIbz4c0obCkNpWYg+gvE+l1XSvCxeE7meBO0l+ERdlY3wA+WkVh1G8Koe+v+e2QA=",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Snapshot",
+            "color": "#92400e",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpwCAABXRUJQVlA4TI8CAAAvf8AfEDXIkm03bJv9r/rMmJAEjIGk/QoUAVfb9vPNdQVlbNuavCUnUGuzOdmdov9e4xBsjm5wALXbmNP/gyBJctumF1AGeXIASD5h/2CLYpJCFI2A7AoUskhDeq2N6NU2oI9pnKlwxS7iMhnR2LhyFX8DKMQvY7bS1x8o5BuKPd9aqfVK66TUa60ZaRvPsV7su6/1RKnS3+R5W+T9/wOrwQB+Dhyjan3G3lXNCNedTfCKkD5D0GhXElyydjUidEZ7KuB9gsktCR6y3Jh9kR3m7sHoEweJiC1M2yfmwesR6xa2E5CMY6y2wziUIdwWROMFRFAhS4Z16jBsWRh6KcQT5YgN0VyWFhGTBNdSCE2Jxlr8UA6AEx/L86PcV4MKkY8PsdqDcQYOn6zPBbH5igNgujMIDgG8TJ0EwqEkfc1hSxw+Pj3VwkMxzN4gYQTLJsMWBnC3hiR98Gw6kDADI3SmFXz4R85DDTvV2JmDw9gWYuqw2xj8eQ7FqyCEnqdwfTGFXdSKDXtg7EvtYbHG8qG6L/2HoRrDYerry/iho+YN/xjNaa/RGcx/0vwjFmoshY9M3pBQ2FD3eQ+3giDOe93nfaMVJrvP+6v18IeUhyIS1r3+6z53Hn//dX8hhxxzFms87plw3OcdJwfPJ/gQxxxx3OseJ9UFRhz3LoxzEB4yP2PxAQ4n7Y/7F9cbCAO4H/aDzBPPe7xgDzjvoxMBIf6M4t6MMub/UgvNiOs+dPHh+0IFLBjSrsOQRQHopRAvNEOuO+E6B8k4wxlz3QvGoETGGoSZdN0NGyL9RBqy0677IWl1IH3zigOtSCOvO8IzqdVv/NW/TPDzr/v+v5K20SLSX9Mo/2s4m2XH589//zEWAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Quit VLC",
+            "color": "#7f1d1d",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlYBAABXRUJQVlA4TEoBAAAvf8AfEIcw//M//wbZRk5eKe4B3uUdPpAPAAAeUAAcAAAWrmRbbRtU7DQX7X+5cUAWvPeVFtF/R5IkNQ5knVbeC34g/1HnnCJGmoHGrT0CpEe7AtWeAmowLq0FyEs7JsjB9HoflhTQIwmYkMBk5xacRLLmfiMROYfJNTSr0/0pqxGqNbuFzCloZbgVNZGiOdwsfMMxGAzb1o65lTM3yIjFQJyqFZFqtutXA8es2qnYMNa5p3vt3ghGnTiZkaJNZHo9rxElO1LkSTUGcRptNvoLoq2qC9sqayIG1iyFaJSt82KrGmNdfHEqq3qdn/zdS1QROYmpAbT/+5TM0hCOhpGveywZtUW9sl2WnbBzWnbDzg3tuqeScHOEmjPydf9HwumhXssB2y54kbqodzLvvpfcY/b9DjcRFDH7nosK5GDMvu9F6Off//EmGQI=",
+            "action": {
+              "type": "hotkey",
+              "key": "Q",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 24,
+            "label": "Global Previous",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqABAABXRUJQVlA4TJMBAAAvf8AfEJVAchvJkTT//7TW9Aw6e0qndbHeBLCIcCIAgJOw90wQoaFWMJ8+QHzA+ID4gfGB8YE92urbpmQ1KlGbJPdWNo4kxSkinyEN9g/yAupAArTFuBKYNZR/W9pXgcoI4IaNXzVYKq0aFl7VQMnxrhoabqtGkmPVkOm1akTYVw2CIr9usGDmRJB1e4/XB8ivEg73brDFTIxQGbUbVGCihI3fDQ7ETlCMYL/aDYYoUcLC6wY3nGRVx2SmLAlkXYdkhu8nRBZ2RGbYAZKVHZAZukhZ2zgzn68nKIsbZwYtyxtn5gStb5wZgWFmFGaZcdifmbdYDDKjsS8zrL4jRf5C5qQSwucHpK0CS+3CMkcqIX75RfJ5jzKMVIDJyOf9JITOu0cWRCoQlOTdT0L0fN1DwirI9LsddJCkElLydW8S9PN1P4V/lb0hMtkdIpHdIWKAojEJkcUsRA6jELHBVBiHSGAaIuaC736zEMm/+9K3mIXILui4CuMQCcxDZBdYass7JkQA/39P+39fYJjox4v/HkIEAA==",
+            "action": {
+              "type": "media",
+              "command": "previous"
+            }
+          },
+          {
+            "index": 25,
+            "label": "Global Play",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRroBAABXRUJQVlA4TK4BAAAvf8AfEFVAjiRJkqK/1L4LdHHGe4u2CLfZ/jnJc7GD/o4F0grgEKTaAUiVdfZwCkKpA5BmADcQBwBLqHh05EaSIsUy3iIaZl6wL9UuYB4HARDH0V+F1bkmdp17ZaQ614dZ59rckDj36ql1rkUAxLlXhWXx8vt4NbGr2FN0x5syUpQFJNZ7FCDKLsN7KECURT1sZwGi7Nr5DgWIsmTlUIAou/yhAFV2LECUBcRDAaLs0qcCRFlUOhQgyi5rKkCOrxQgyi7PfBagyuLaoQBRFhANBYiySzcMBYiyCDEUIMouyzgUIMqSFUMBouxyhwJUWVwzFCDKAkLLWYAouzT9UIA6RBNAcLwwRl9g6vvxIo9+hWM6/ogT7Z78eFcd7R7z7L6w2X3E/Rz3aM1xj2YYbG/Oe4TW0/bovE8z2Z6Eaz5tj877FYPt0XXPZHtz3UcMtkfXvZPtzXW/aLS9CK6dbE/CG2yP7Xt9xfb4vp8QaO57Sgfb4/u+RHPfFxAPtlf3/Sfbk3gOtseP+6ix+HEvYfa412R7k8n2KoPtWQ7bw3y0Pc0/Fj/vQwjkz3t5QX9Z",
+            "action": {
+              "type": "media",
+              "command": "play-pause"
+            }
+          },
+          {
+            "index": 26,
+            "label": "Global Next",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRo4BAABXRUJQVlA4TIEBAAAvf8AfEDVAjiRJkbT6K+2f7l7MY8iKcJvtn5NgzqnySuj0aq8/FjgWEBcAFxAWEBfIoQsL5BJqsfVK6aQyZ/+O3DZyJM7M5t3jqsMP+g/qIfkkSujMyL+GsYCewhjMDPoiAB9LN6MjlW5wJN34MITCzbCJ6caJmm7GTCHd8MixbNjr6ccSDWUsxPBZH3DhUK2K/Xq601NVUgeshwUUqsUc15OPpaqiOVgPHalQLd19PXEkVWEu2EMUqqIsvz1EoVoybw9RqsqbHkIUqqU67SFKVeIpRKF6DFGoFsH3EKWq1ClEia6GKFUhi0OI4twSojS3hSgdMxQt9snVgZCeVPgPUTJ/SFI7+n/vNBHwUG8TCWp4r5cdnN19f63Q7quGj3vkTcLHfajDNu5VCx33a/qtF4d0ESIp254yE4kWO++7ITPh835K6LqHdvS6x7XMJDpmJnTd75SZ9HXPd3rd95SZaBxS+L4HU+hd3/fRy973WjLzLPn7nm/Avm/88e+/7xAFAA==",
+            "action": {
+              "type": "media",
+              "command": "next"
+            }
+          },
+          {
+            "index": 27,
+            "label": "Global Mute",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrQBAABXRUJQVlA4TKcBAAAvf8AfEGehoG0bxvxJtzsg5n/+1baRpCZv7p4x/wgTksGEAwAe4CMCNPBxoQAZwIOPggWwAQwgocLDAAwQbNtNG3m4zMyM2v/+5hx9SUn6hyGi/xDcSFIkuTOXD4dnfpD+YR1PpVLpntnLVkRK7JUSdRXmasQFvEW0NbDWQtztRiHuy0ohbtKIC3iLaEtlZY09lotYAxtWHoRUu4WLNKx8llFA7SL9ogXqcCoydtUvIoXHb9jDSf1ik0hFysU7lmA8Jpc9hQNpXEXUxCjewVgefZF/8jTS22ZH/50z0LzCnHDrItN5rrSuMBk4eP/qhdVZunnR3LWxTOypvcY5gEA48JMYpfbVKqfUgSzvWLXB4tUb8IT9I3NGTf8bvbPrvYa13odMudRD270Jk/oFZzY7Yx61izurNY39Ho79virsdkVmw9FN7fc+573fe72J/V438ZvKGebywKzYu7HjnmfvZSfj0HFP4U0SSPzLKsOUIune1HGvEdrj/h3ExBoLbQy8QcQBxFnr876sYT/vvTOxxkIbA28QcQBzNPaU3oDrvvTj33/fSBIA",
+            "action": {
+              "type": "media",
+              "command": "mute"
+            }
+          },
+          {
+            "index": 28,
+            "label": "System Vol -",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRnIBAABXRUJQVlA4TGUBAAAvf8AfEDVAbCRJkXT+O53SNSzc5DP0RLittu14gtLW99dRa9sYIENkl5wMkPPVsblATjrbLo3udeS2kSOx7Nm8t8k/mH9YByGOvWGbQbAE9sbhblA3MTcTt/C20rZhbUfcoZOICwFOxH2QMnELbyttVcDdsK11AbqpPQ0/kTWd6Wn4+fPFsKQTPdAX2Bzhrei4p6F8dm/Sq+KGowyCOQ8yeSAGz6LYNevjBQONQaArNljSAzaxoRpImaEN3KGKDVNg743OjEQgbkYskDRDF8iZIQu0zJAn/hf+r7znf8TEvt1DDTzxgCpGJYDHC3M+ExYf99AP9MTHfeTSI77lj3tB56HiH8gIjvtB518Q4A9sjvAN5z2go6/04YvRcd4HOv9HBIiuf97bxH7eD9IaUE1HFxYlWoO0phKGeUkhDm3vdV8kzPrrvtK0rLEbxEwb3lTeMLEbREwycxjbDbx031c///77RjIA",
+            "action": {
+              "type": "media",
+              "command": "volume-down"
+            }
+          },
+          {
+            "index": 29,
+            "label": "System Vol +",
+            "color": "#215c45",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrADAABXRUJQVlA4TKQDAAAvf8AfEAXkSJLDNsg/6a7iAQuAOpafjpAD2bZpW/vZtm3btm3bymxltl9oW9+2bdv/+t4JQZLcuE0T8O0EuSgKzAsG+bdusMb9cQLQjH49ATR/PQEUfZgIrILNuynyPHnyJHldm5wCPpJviaqnAMDzvjp1U9jH1TMn98PMFGpa5lsIe1AwGDbMxQuDGSoAgKN+eQtvrEHRVKG4bnlLgAcUE1wuFG+J9MrgfLpzk1gqgxXW9JZWmVzMtvbj8c5g8Zlgs/TU4Tlcrk6FqUtI+gUAoLhZUjV7cUHF64LFNVWis3iBp1cOsjgbDP2Zvk6C6RCBAgAgtlfeGUTSVJ2mVIihYr1V3hrEREGlFdCbJl8yjfIeCZ8AAMykQlz64QLEbBperhkdDxnTN5p6oLQ49xuQxprHBAiNn8oNAAD9AVlMAMAm+RMneUwAGgrHVIX44g+hUMc0TQn/iYPc2M223pIJcE+/oxJ2CyDdP7HPY4ymJa6FVK+aYivgUtz8GZ94LoPcIOdwWZm+MXwD6jgAgEF4hc//eoLYr3gV/x7P7xBxp7iUCnEOAIBfKMMJAAC2DaXBdbriHmgpOgIjRUpDcdgqpgOexclAVdHSG7viF54VQeyHD4GQYq6hPDwEAGAfyvAKAIDo5tDjQnN6i7LdVMcizLzF3eYk7eZ6M5vKCBQvm2NfLAcGirBQBsbDt+boF/u71Z6kwI8HenMMdnTt+Fm+f+fzL/Hqj/tAHnx93mMDD7/P533BH5j3bRaz58c9lUVra1xgV4nm3XHfcPvjPhG3iyupEGeP1j3sOq/7LE/X/ANq23Wffw8c4r9f91I5x3ha91pM9arerXs5w8OtDut+Kud3BNa6n2xa93tSJAZqi54W5z1Udi/JgcIpVSGu0XnPQWw+UA5hsQjXt+d9GNN5X5PzXiqvnPdKgwcm9UAJPJxvc95P5QXEfZznwMDFJp0nKmvcMz71PWgHdJa+R4PwZIlbEgBgs+FioNhs0feivMZl38vvbd+LHEqj1i9lj5d4oe/HLVWiY1pz4x2kVzi47nuqj31PP4uSNn1fSh5d930Fzn3f7fM+ExqkW8wPH4eb8QjHAquoHWSQbnH1NoEe5r7/1IDwjkirjQeKHr667yF/qlD8IIO0DJ5vlMgUZdn36RYevLfv5f405TLqt/FGwYO3mF73/RqG++9QO6UDXC03Xsm8uu/7/X3vzxK47vt/OOb/e/h2GB3k44MN7kH+Rx+DAA==",
+            "action": {
+              "type": "media",
+              "command": "volume-up"
+            }
+          },
+          {
+            "index": 32,
+            "label": "Main",
+            "color": "#334155",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkABAABXRUJQVlA4TDMBAAAvf8AfEBdhIG2b+De97Tcx//OvOJKkNMoJ7vB1SIjMAAAQBQYD8GAUAD4UAAcRCAAAkKAB6IgwIAAATgHBtt20kcqMU+Z2/6tMI0ex9IdJdkT/zaZt49h07R301+PGGb37fwbv4f8ZvKfQlQWOOYItJG7bHRO2VgY18ci5Q9SCYlYhYpgOQ2E6vAUSeBtiJRQpsThhOghVxwFGNUWotvaLoPWiaLs49i0XTbtF1GqY5lBRvdoxXwNF114KWktFOx2KIpvK9tRJ5fyFou//wdRPEa52mgTUTRULzh9PTloEXvakeJYF64mITlcwF5E3BQtyVVfNkYj9Q7AkYtRcKec+a5Au1JiS+rRxf8s4JraMSpfY0m9YnPcVu0i47Ct2NoVolYj2gaTdFa/BaSTx/gl+f6DjAA==",
+            "action": {
+              "type": "page",
+              "page": 0
+            }
+          },
+          {
+            "index": 33,
+            "label": "Chrome",
+            "color": "#4285f4",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "page",
+              "page": 1
+            }
+          },
+          {
+            "index": 34,
+            "label": "Cursor",
+            "color": "#252525",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjYBAABXRUJQVlA4TCkBAAAvf8AfEJXIUmzbtZX+t7pechmnOUzelzBFIuAAAEAwmW3b2bZt18Xb1mW7q8u2bZuvbdtNQP/4/yeI7NXQDMfV/8zwAA632RcFH27zrIQk3OZXF7Nw22wIBA+3uZSEHgeUn43T5kMF1TBtWeo/bTPOBShMS0GZj9NmRyhsmBZDmtvT5lEBQZgWSpDt0+ZHK6MwLRA3s6dtVjHDtKWr2c9pVPO0hIo9h2sRxTsLh6fAUzRqan3vGIitkd3TgPK3tbs/fahR4MU62d2bUrJNiivf0+5OJSI36X81vne3yve1SdkY3t2vDiZN+srP1u6elRA3K9fdHYqGb9qbBT4gzXvwo4leI7/Bgzz8hn7BrjCYxv67meIG1ODs1dDoT81l7b3/+97tj/9/AAcA",
+            "action": {
+              "type": "page",
+              "page": 2
+            }
+          },
+          {
+            "index": 35,
+            "label": "Outlook",
+            "color": "#1473e6",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRg4CAABXRUJQVlA4TAECAAAvf8AfEHVAUiNJklT//7ROnhUNkbdZYhgCIuAAAFhGyr1t27Zt27Zt+3/TZNu2bVubbaPHCZhf/3/hjICmdB223fuC9OPRnl5Z9BFeh7JaXzDnvrVSvQphU1tpkfQ9RIO2FkoenDv8q996i6huAEsHzCcdoL+AQpjP2kDYHmeYUyviyGGFj4YIB62+DlZjd5h9Htil8oD8pwIqLevmtMFklbDnmLG/5BpBa8ShkyKweUkLFFZ0axo32oIzryUnl7AaQ+wnQBCb93DshGXUGMeNuqeSS1LVmMrEuASh9+CmMcfBK+ySUR8WZ1uIoIOJqRWWWLVFaKPsIqpJSluMEpciVElpWzwToyLYSV9bghOVovEdTLUlNhGrchMstyUxEa/yGKy0JSpRq/IfzLQlIDEtgr/RYFusEq8iLElFW+SS/CImSUZbKJKlImmJfVvjLPhFVGM44etLc1juJeghgidYfXFJFkvEbdQ4faMChWVQgMJNYtXYaE2ukL9Ts9ED3M4opjUE/w3fzdIf0LqBtCaQnAmFTp6R9obXb1qXrA5wGtxDXtO8sINdB9IpYoWHmgh3A6A9NDjtqzkpdYKiP3j6PuIUxwMuCEftB+xhecAdBfipUoXwAbfEpg26wi6NB9wUv0IPL0D6GT3gtrApidVq3Z1vKP9enBiWzQL5/Pr/62YA",
+            "action": {
+              "type": "page",
+              "page": 3
+            }
+          },
+          {
+            "index": 36,
+            "label": "Excel",
+            "color": "#217346",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM4BAAAvf8AfEJVIkiTJsZV3/0v7R2R/1bVDlP0dJCICDgCAZaSz723btv2bbdu2bU3+n2xrsm3btpUJ2J/+/9Y6KyALfpbeRjeor7Y6k3dcz+DY/O8BuTsmz6EGQY/Qe0i/9vY8U/8faW/0hPF6H4aSZywHrJq57f3x+AjVl9C4TQY+BlgRqRyCRiB6x7kTQphP7tF9hTGQBe+MxP2Eav0ChctkGnyIlZHKbHdVNfom/IBMCWMruUK1dJol7JxU/IeqRuYsWYEaZBWlmmn0R2YnReIkHcp9QGal8zy7cMOs2uf8p77Tonb7DCU7L5szp0gHWj1HdHdiLJ4P1DwgI0PbPpA5k7Qe+iE5EYk/J7UEOc9HgXNx84jvM30RnIaw7+fUFPgsv830+UJmEdHsM3nHNQk+H8ks7VRDoHOAGW/0Q3SVp/KaQyCQJe8idZa8YJ0Cp7dkHXp3GaTqHwLUYKM/8vulhlSOM/ACssL9Klp3yQP6CbB4Tg7gv7bsU7VOoL+Z9gOS9acyvx/nZpV7iPVvco3qdhg8JhfITpZfqprb6WhmtMdgxlPp3o1Ns8Z9Jn6fyRnSm6Fxm9yhfc6KTVV+M03N7PfZkJZSaV3sp/+/TQ0=",
+            "action": {
+              "type": "page",
+              "page": 4
+            }
+          },
+          {
+            "index": 37,
+            "label": "Word",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRpgCAABXRUJQVlA4TIwCAAAvf8AfELXIkW1btZXf/06P4O21b7JDZOPucHCIgAIAAMFm1m3bNpptm8m2bdu2bdu2bduYgH3o/3ukq/NfO74g6GTtF+ycWsIgnMJB2jPa8ATSgn8ijUEIJOotGL4bh2CLQkI4yFsvQWSL4ulyawkONnZSvcFgS3xLa0t3kD2KgOAVuGO55fFbA9BDYDQKyXBwNxCdPv4G1hNRjwLtR2DeoH+BS4NZcLyzmg7yG3IvaG7IDEqHER+sNRxc8ACULAYWw1AP/mAF9Kf2Uh28AZqfgHUYhOGQCsyDsMApEPVfu3k2zNoKfIPqyu1zv5XGwCOo32nlBi3Vs2+VmjVTuftbfQ1fxmEWXFd4Ts1yRVYHd+Us4B8HfTjoCq4B45IKHAqUp/YMMs46DwwKHZXjXUgflfqCdtC1874Lkm7AvFYKdldf5RbwRlzgMxD7YPKGyKkZ7i7v6uC8MRr+DYQv+ATfXUEB6e4SCux2F9R79RJiIODf1SG8u8Yqa7u73zxUancX/6mN7MQ/AoddGL4ryTeroXINuMsmCBuJX1C+S+nUVAu21cGxqySQG4lYsL8rofILu8ASnu3arl7AGgnKV3UQ3gEsV6a2dlqpWXinNrczmwyUEZ1aeFBUuVoKQeJQYoJQ+oFEYFIdbIICjaGoBr3yKh9vArLASldANBT84MlR9X+zjUq1++rvTm29yrwaUqpPp5Y91p8rhBrUqsx4rN8XPAI3Xvq5gHostBc0btdUz/HO7bTHriWsp3QwlT2sLRI9FoOxbTnf9hfvrfeD4W4p6a2ejhvAwYDedJhd4NHRsJPr6KC8QKDDaTTejad78a+7xufRiDRkXFl1yTPIaBA+E61LrNKPfej/e60D",
+            "action": {
+              "type": "page",
+              "page": 5
+            }
+          },
+          {
+            "index": 38,
+            "label": "Teams",
+            "color": "#6264a7",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkgAAABXRUJQVlA4TDwAAAAvf8AfEC8w//M//0Tatrnx2Rm8iAf4EI4gFDWSpCychTO24N/M8b04Ef2fAPjWVq+NyyUt7h5g5v+HH2o=",
+            "action": {
+              "type": "page",
+              "page": 6
+            }
+          },
+          {
+            "index": 39,
+            "label": "VLC",
+            "color": "#e86f00",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrYBAABXRUJQVlA4TKkBAAAvf8AfEHXIcSNJkqT6/6eppGeWkKHNEbO7MRsBBQAAQ9KcbV9zZXvbtm3/R/9X27Zt219dbVszAf3t/w/WHYOR1iviJ0q6mKyk6BUrwR/hxciTc8gX8P0Fc31zu2HovyB6oqCrSUzKXrAQfKJdjeAnuII6wvEb9PXdzYZhfCR8IqfLCUqqjswEj3CXQ/MR3EIfYPoJ6vr2+sIwPxA8kfH1OCX1ByaCM8jrwXkM7mG20H0H+Q+4v7owrLf4T6QpgHHSvGUkOOwCIZ0FT3AbKD6D9Apafhj2G7zBSFoCTdK+YSDY6hodBi8IAcl7EFfE3zCcA3dw7RevCNKkO+gJph5Qpe3gDWmB4DXwK0N8GO4LzuDaO0oZeH6D/oWOoKvrNB18oDygG85zYF+IgDB8uvt31u5hC0H1EQx3t5aguivVE3yh93+PgX4pHMIIaNazdgJRCqyHYLw1BNldq5rgG89doCiGYRg94NpeFwvpNGTJ1bTcI6JyqE6sdb32D0QVJHXPD3ZBxHvGHlCxjS3eJYnd8YZUEu7vhvYH1Gxyg3VRfJNbmKK+/f9RNAA=",
+            "action": {
+              "type": "page",
+              "page": 7
+            }
+          }
+        ]
+      }
+    ],
+    "keyPx": {
+      "5x8": 78
+    }
+  }
+}

--- a/decks/profiles/word-shortcuts-waveshare-v3.json
+++ b/decks/profiles/word-shortcuts-waveshare-v3.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v3",
+    "name": "Word Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "winword.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "winword.exe"
+          }
+        },
+        "name": "Word Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Document",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Bold",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Italic",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Underline",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Align Left",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Center",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Align Right",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Justify",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoAAABXRUJQVlA4TM0AAAAvf8AfEIXbNpIcafJPms72nmzvRQSUbduOSc/Y6NPtyY5GnuRJNvLa+wO8ybZt23W/tDbeCRj4+/8jtG1orf7vD3X1VNVyHJSUwKXkEtdo0KG7HVdBsYRvaOkPccNjECrhfgURJCwocpZwGngTYyIuoSdYSeqCD+QSYgFSXJF6DWYGSpIlSCcNDiq+jAco8rQYsJCOwtBqMJ3FPdBT0zk6BoqiWjvDMHKTAVSth/ypRBgoy2Z1y59xqoHC1NKGnMF8+4A50C6MN/D3/2d3AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Clear Format",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Heading 1",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4TJwAAAAvf8AfEJW4jSRJkfy3Op+5n2HkbyXCaQQASHSQqBwLcFStTmIMdxJHZw/e/bfw7j6B+zeXCZif/9+e6/pvVt7PrZtFh7HsunkucsMB9dIJGw7vGQ7u0GwY52ZjuzcaWL075wFQbJsMRDPuvmkE3T+XdjoJLJuPeKDRrEgTzVcWMpfqiLtpoGc9FV0BNZtT7fqcojx7/7/l+Pn/HTY=",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Heading 2",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRoABAABXRUJQVlA4THMBAAAvf8AfEHXAbSTJkXT+Ox3K1PHSnvSTBiLgAABYRjr73vZPtv8n27an32zbtm3btm3bNjMB8+3/D88NAmeFt3kEzhxvQctejjnHXn25sKaRC5FGxNT4Bq41zRC0DIJkf3urVpRVkJjYOzrCUgTS5N7VGrIePPfOimpg9HYv/0Rb8NrohiduWDh8Aj2H/W9hNdjBOEecroMb8A7YN5KcSD8sjg50gqnJoK4DmQ78grArRmeg3wEfax7ileu35o7VNaoCtQ531RPwtwLzcPIF04r6ng1MK6OBw5t44P3Y79kjYinSPgK/6YTf/Z4dwHXC63rP/ilMJQJuNoqaSsTdb9QFUYmsl40mES+Q96FwbvZ4P5o+NppBNo2Y+tloHOk0YuNvo064acTa/0aVUNOIib+N0sCmEVXfG4VeIG/zuQh73chjKqFzupHbVAI3BESZ0+l3o3XoThi9p9uZlJCz5dD5bsdn21luhwFoR7fe7/v69v9H2AA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Normal Style",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Insert Link",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "K",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Page Break",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvABAABXRUJQVlA4TOQBAAAvf8AfEJVAkiTJkbL//7SjakRv9Q1RKxEFWAQcAQAIKGfbRq7JWrsPZNu2bXOyMdm2bdu23QTUh/9fNzfhf7k/Pz48ubRrVrsc9qhrDPRqv768uv42oVoYJcBclvpWTWKnhQ5YAOXU7YvzIN1GUZPqljhK2ybIqrmO0qZAs/JOYpQWl1VrHOYX8/gUVlUBnaFRSBKJdrLAL+4qpfUcEAgEHBqZBP2vqAUkEUIri5rfRgt5RnpyqbOGSM1e9RU4S6bw/QR2d2MceMumTAYed6MUuEtHVeAPeC9qgcV01EeAe3EM5KVjJbjVTiAWAprZUOnQwk6gSvpl04DJgBuOVGz2DwaDTomXrX7ZD43KBUNrx8xXbc27sgAEhcYmT0+2p449wg7h568y2FpcjWDqq/KyBz2EQwmYaXmlVEN030QC5+SJqEbp1nPNyAzZA2Cg1gWSjg12P7WJ0nr5DIGAR4GWeGdRC0zCn2/v7hxZ0Cn/j/IBsHZdeJMSeUU6NoW182ZVcoLmMyv030DnrMpU4GpaqoNPwFlpD/zOCsR14Komxb5DfZNi4i0SMhugOzQaOZY6/Md+iU1iR7U1OZ+kZsejJiej5uaDZ03NpyoSB8B8/Pn+8uLepSMbprXJZIR0AHz4/xV0",
+            "action": {
+              "type": "hotkey",
+              "key": "Enter",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Spelling",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "F7",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Track Changes",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQBAABXRUJQVlA4TNcBAAAvf8AfELXIkiRbtZX5jzqx3ucc2OsPWbg7LJyIgAMAAIEmu9m2bdvXbtu2bdu2bdu2bduagH7k//tLQ1ATosWaWx9+PNk3IIkWgg288H85qQP4FDyd5Y9aqdaCTsOcaBBXIYy9zqk+2FQBJG1OF1/DP0VzIf8SRMylFAugOYsOxZBFCw4HOxODK/Yh7511DsFLnwjfefLG+2tHSp/TsN2emIkeSPQqMivJEcjmkD4JPgj3OvpvYahujsdEbn30WZK/OZvB2ddDkB5m5qMZcZ8Q7g3bRMF9/LdhoX9ge5cXsEv4T9jrBUqDe8Cq/gf9XdXnILsqRBMFVoUzsa+KcGJR1Y/EtCqSiXVVBBLXqjAlEVU9SUqqapfBeFm6gzeQE2h9ogtdgPAwxE5QMuNZAfnnu6OQRByDdDe3OxSCZW+gHoIL8EOMJuraW0sL8/vIV9uJ/uZw+QveCRwQNtHb4821yjBuCS4xmiy9d4fRaxjPz4ADhOjJ3lBsr9mmGVuCiH0DRfBLgPNZFNH761cLZ5p7W8FbPRd4wNAV9FtNp7ki0jU00H8/59jG3FV0PzV1go+/kF1INw0dH9eciUTfO70rupHSkWHIseePfx5bUs2NLHA/8v/90gEA",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Word Count",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQEAABXRUJQVlA4TBgEAAAvf8AfEJVQkm1btlK9/nd6FNhr38vhFX+yzZWNGiEBAACybVK3s23btm3btm3btm3bNm/bn711AuZ///9TNSQ1SYY889eNB2fem1PAAsFZeqBrny9I2Gz0gjdby7uAT52zbf8wTPUkAWFR9Cw3nIG2EG1k2EKnD/pG87jOIZwYtGC7byyRFs2EpMPRJfStbngdA+oiSG/R2q6QlsTgxWRgJXu73FPGdDDfktsy3DIZVCZgDfuKYk8RF76BdBy2nL43gJwE1knavirFQyiFxddAun1CDRwb0QV62/RRFlm0EHCwczLf8R7qDJjuA9cGiwuCGuyDzw+ghu97ciUSYuL7z7S8zxibQW1D9QWDDeVBc5C10QmJ6SJzlHwCPUNu8Kzhw4V34GQ/cKuQfgpuCE8f/XtYqmcwCJ7gBkxbu6iWQIDpIeCohG0U8gCu8ktqz0ASlnLgGqQEAYEcdO0PUOVl8A3iEpST3fVgSw49hGeMV0F00Fn5i8hjpT8IC3ofQIlto8S5/tuiZKqwH8C5qoOhCsifStfYqvz7U+kNAio+Cf8Np7MPfle/tuY+0qvFV/kWCFWag/9Abw5TWIyF4IBlKAd+BZqtnYNWjoLZefu+B5aFscrnBzBQbiq9BZNgYuqfQeUT0BUUvAB3WambGTOVv0Av5ARRFaKN4p8A32D9BdmtWc2MyGrxvLAc/lY4E98nQDC4hZgZCQHFzBANfB7ADJjr6itkRThxewIgzqslNjNWKs9mZkCcVLpnhtDWlqYmlTg/gTER+M3Adl8pfDH6Kr+BZngFKYFk4vkMxAStM7Sha3oF72pxz2gK1AOBJPgZkA/ez8irPMIrsIfPM15XX+AGTEnaM4DhrlokD8BhZWNqXytdg3BrOxOhkqZnMNYDHaRbSw0aKr8eAM0gP42fwepTkBUkswgUA9tqcUoIDBsmgyvQG1j8ZA3zMHrBtJrKDWRAGXiYCEgbUsMSu0HTrnN15IFOQhSc+VT9nexFpdP/yotpUkjSrkH5ty99lITlnPG8yiIaiio3W6vsgDkJfkBc4gAdTRz05wrRBv0qs+mMkrCCr/zyOrE9iM0FpyANeB4uoGvh8hRcE7ggZaMr2AdhuKB/ujZ6Pj+Avvaw/hJscdisdE72tcenJaWn+QJGl2Gd8wMJkDI3u0Jx1JcejhbFHrcLwzvteiWB2DsYgg9xvkM3pc3Rf1p/pw3huvXjymhu3Gnn21n4Wpp6Y6rjD9Clb19ewQmGORvYaYf9BWEdfQ/gOqSB2/wiMqcb66C5QLgj4Ib5I87DPV5jnuNFNj7PxT/+NQjfMUPQxg1uJEHN+WQbyq6MnuQc9J4ZGsZ+9HyTjn7eIqTbxPgSj2Ri7kfK6t2Cz79//B4HOoX8BXkA//v/n80B",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/word-shortcuts-waveshare-v4.json
+++ b/decks/profiles/word-shortcuts-waveshare-v4.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "waveshare-esp32-s3-touch-lcd-4-v4",
+    "name": "Word Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "winword.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "winword.exe"
+          }
+        },
+        "name": "Word Shortcuts",
+        "rows": 5,
+        "cols": 5,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Document",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Bold",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Italic",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Underline",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Align Left",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Center",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Align Right",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Justify",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoAAABXRUJQVlA4TM0AAAAvf8AfEIXbNpIcafJPms72nmzvRQSUbduOSc/Y6NPtyY5GnuRJNvLa+wO8ybZt23W/tDbeCRj4+/8jtG1orf7vD3X1VNVyHJSUwKXkEtdo0KG7HVdBsYRvaOkPccNjECrhfgURJCwocpZwGngTYyIuoSdYSeqCD+QSYgFSXJF6DWYGSpIlSCcNDiq+jAco8rQYsJCOwtBqMJ3FPdBT0zk6BoqiWjvDMHKTAVSth/ypRBgoy2Z1y59xqoHC1NKGnMF8+4A50C6MN/D3/2d3AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Clear Format",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Heading 1",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4TJwAAAAvf8AfEJW4jSRJkfy3Op+5n2HkbyXCaQQASHSQqBwLcFStTmIMdxJHZw/e/bfw7j6B+zeXCZif/9+e6/pvVt7PrZtFh7HsunkucsMB9dIJGw7vGQ7u0GwY52ZjuzcaWL075wFQbJsMRDPuvmkE3T+XdjoJLJuPeKDRrEgTzVcWMpfqiLtpoGc9FV0BNZtT7fqcojx7/7/l+Pn/HTY=",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Heading 2",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRoABAABXRUJQVlA4THMBAAAvf8AfEHXAbSTJkXT+Ox3K1PHSnvSTBiLgAABYRjr73vZPtv8n27an32zbtm3btm3bNjMB8+3/D88NAmeFt3kEzhxvQctejjnHXn25sKaRC5FGxNT4Bq41zRC0DIJkf3urVpRVkJjYOzrCUgTS5N7VGrIePPfOimpg9HYv/0Rb8NrohiduWDh8Aj2H/W9hNdjBOEecroMb8A7YN5KcSD8sjg50gqnJoK4DmQ78grArRmeg3wEfax7ileu35o7VNaoCtQ531RPwtwLzcPIF04r6ng1MK6OBw5t44P3Y79kjYinSPgK/6YTf/Z4dwHXC63rP/ilMJQJuNoqaSsTdb9QFUYmsl40mES+Q96FwbvZ4P5o+NppBNo2Y+tloHOk0YuNvo064acTa/0aVUNOIib+N0sCmEVXfG4VeIG/zuQh73chjKqFzupHbVAI3BESZ0+l3o3XoThi9p9uZlJCz5dD5bsdn21luhwFoR7fe7/v69v9H2AA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Normal Style",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Insert Link",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "K",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Page Break",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvABAABXRUJQVlA4TOQBAAAvf8AfEJVAkiTJkbL//7SjakRv9Q1RKxEFWAQcAQAIKGfbRq7JWrsPZNu2bXOyMdm2bdu23QTUh/9fNzfhf7k/Pz48ubRrVrsc9qhrDPRqv768uv42oVoYJcBclvpWTWKnhQ5YAOXU7YvzIN1GUZPqljhK2ybIqrmO0qZAs/JOYpQWl1VrHOYX8/gUVlUBnaFRSBKJdrLAL+4qpfUcEAgEHBqZBP2vqAUkEUIri5rfRgt5RnpyqbOGSM1e9RU4S6bw/QR2d2MceMumTAYed6MUuEtHVeAPeC9qgcV01EeAe3EM5KVjJbjVTiAWAprZUOnQwk6gSvpl04DJgBuOVGz2DwaDTomXrX7ZD43KBUNrx8xXbc27sgAEhcYmT0+2p449wg7h568y2FpcjWDqq/KyBz2EQwmYaXmlVEN030QC5+SJqEbp1nPNyAzZA2Cg1gWSjg12P7WJ0nr5DIGAR4GWeGdRC0zCn2/v7hxZ0Cn/j/IBsHZdeJMSeUU6NoW182ZVcoLmMyv030DnrMpU4GpaqoNPwFlpD/zOCsR14Komxb5DfZNi4i0SMhugOzQaOZY6/Md+iU1iR7U1OZ+kZsejJiej5uaDZ03NpyoSB8B8/Pn+8uLepSMbprXJZIR0AHz4/xV0",
+            "action": {
+              "type": "hotkey",
+              "key": "Enter",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Spelling",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "F7",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Track Changes",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQBAABXRUJQVlA4TNcBAAAvf8AfELXIkiRbtZX5jzqx3ucc2OsPWbg7LJyIgAMAAIEmu9m2bdvXbtu2bdu2bdu2bduagH7k//tLQ1ATosWaWx9+PNk3IIkWgg288H85qQP4FDyd5Y9aqdaCTsOcaBBXIYy9zqk+2FQBJG1OF1/DP0VzIf8SRMylFAugOYsOxZBFCw4HOxODK/Yh7511DsFLnwjfefLG+2tHSp/TsN2emIkeSPQqMivJEcjmkD4JPgj3OvpvYahujsdEbn30WZK/OZvB2ddDkB5m5qMZcZ8Q7g3bRMF9/LdhoX9ge5cXsEv4T9jrBUqDe8Cq/gf9XdXnILsqRBMFVoUzsa+KcGJR1Y/EtCqSiXVVBBLXqjAlEVU9SUqqapfBeFm6gzeQE2h9ogtdgPAwxE5QMuNZAfnnu6OQRByDdDe3OxSCZW+gHoIL8EOMJuraW0sL8/vIV9uJ/uZw+QveCRwQNtHb4821yjBuCS4xmiy9d4fRaxjPz4ADhOjJ3lBsr9mmGVuCiH0DRfBLgPNZFNH761cLZ5p7W8FbPRd4wNAV9FtNp7ki0jU00H8/59jG3FV0PzV1go+/kF1INw0dH9eciUTfO70rupHSkWHIseePfx5bUs2NLHA/8v/90gEA",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Word Count",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQEAABXRUJQVlA4TBgEAAAvf8AfEJVQkm1btlK9/nd6FNhr38vhFX+yzZWNGiEBAACybVK3s23btm3btm3btm3bNm/bn711AuZ///9TNSQ1SYY889eNB2fem1PAAsFZeqBrny9I2Gz0gjdby7uAT52zbf8wTPUkAWFR9Cw3nIG2EG1k2EKnD/pG87jOIZwYtGC7byyRFs2EpMPRJfStbngdA+oiSG/R2q6QlsTgxWRgJXu73FPGdDDfktsy3DIZVCZgDfuKYk8RF76BdBy2nL43gJwE1knavirFQyiFxddAun1CDRwb0QV62/RRFlm0EHCwczLf8R7qDJjuA9cGiwuCGuyDzw+ghu97ciUSYuL7z7S8zxibQW1D9QWDDeVBc5C10QmJ6SJzlHwCPUNu8Kzhw4V34GQ/cKuQfgpuCE8f/XtYqmcwCJ7gBkxbu6iWQIDpIeCohG0U8gCu8ktqz0ASlnLgGqQEAYEcdO0PUOVl8A3iEpST3fVgSw49hGeMV0F00Fn5i8hjpT8IC3ofQIlto8S5/tuiZKqwH8C5qoOhCsifStfYqvz7U+kNAio+Cf8Np7MPfle/tuY+0qvFV/kWCFWag/9Abw5TWIyF4IBlKAd+BZqtnYNWjoLZefu+B5aFscrnBzBQbiq9BZNgYuqfQeUT0BUUvAB3WambGTOVv0Av5ARRFaKN4p8A32D9BdmtWc2MyGrxvLAc/lY4E98nQDC4hZgZCQHFzBANfB7ADJjr6itkRThxewIgzqslNjNWKs9mZkCcVLpnhtDWlqYmlTg/gTER+M3Adl8pfDH6Kr+BZngFKYFk4vkMxAStM7Sha3oF72pxz2gK1AOBJPgZkA/ez8irPMIrsIfPM15XX+AGTEnaM4DhrlokD8BhZWNqXytdg3BrOxOhkqZnMNYDHaRbSw0aKr8eAM0gP42fwepTkBUkswgUA9tqcUoIDBsmgyvQG1j8ZA3zMHrBtJrKDWRAGXiYCEgbUsMSu0HTrnN15IFOQhSc+VT9nexFpdP/yotpUkjSrkH5ty99lITlnPG8yiIaiio3W6vsgDkJfkBc4gAdTRz05wrRBv0qs+mMkrCCr/zyOrE9iM0FpyANeB4uoGvh8hRcE7ggZaMr2AdhuKB/ujZ6Pj+Avvaw/hJscdisdE72tcenJaWn+QJGl2Gd8wMJkDI3u0Jx1JcejhbFHrcLwzvteiWB2DsYgg9xvkM3pc3Rf1p/pw3huvXjymhu3Gnn21n4Wpp6Y6rjD9Clb19ewQmGORvYaYf9BWEdfQ/gOqSB2/wiMqcb66C5QLgj4Ib5I87DPV5jnuNFNj7PxT/+NQjfMUPQxg1uJEHN+WQbyq6MnuQc9J4ZGsZ+9HyTjn7eIqTbxPgSj2Ri7kfK6t2Cz79//B4HOoX8BXkA//v/n80B",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/decks/profiles/word-shortcuts.json
+++ b/decks/profiles/word-shortcuts.json
@@ -1,0 +1,390 @@
+{
+  "stream32Deck": 5,
+  "profile": {
+    "boardId": "elecrow-crowpanel-advanced-10-1-esp32-p4",
+    "name": "Word Shortcuts",
+    "appMatches": {
+      "win32": {
+        "kind": "executable",
+        "value": "winword.exe"
+      }
+    },
+    "activePage": 0,
+    "defaultPage": 0,
+    "pages": [
+      {
+        "appMatches": {
+          "win32": {
+            "kind": "executable",
+            "value": "winword.exe"
+          }
+        },
+        "name": "Word Shortcuts",
+        "rows": 3,
+        "cols": 8,
+        "keys": [
+          {
+            "index": 0,
+            "label": "New Document",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 1,
+            "label": "Open",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvIAAABXRUJQVlA4TOUAAAAvf8AfEDVAjiRJkTT6K+2P3OPLY+iMgGrbtrIMd5K7e3eXN/AIybU6NBKZQYNncBqRQXSi/O7ucibg/IOSE7xM33aKCN22maG0m3Y9X6iviFf7Z+8VbKN7RXTOs19w/vvvS49ucDXTC95i0K5Cs5goSE9otdBc3JhWK0hDcKdQKXlwt0eCShTew6V/sM2kki7Y5olWOcZeCNlbCF8ISNPQKcQDtlmfc5jCsZBUaFyIc44LsA25j2JIhHng9lEPkTAN4r9heLV/zh7Drf02n4HxOrxkZ5DtFE45PZhqvixkoS/EfycBAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "O",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 2,
+            "label": "Save",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRggBAABXRUJQVlA4TPwAAAAvf8AfEFVAjiRJkbT6K+2P2sPqPoac6gi3kW2rjShiZjLbZagUlaLcUIPKcMjM2Y/MjK+DPwH5/yyKLdeYffrh1H3h1lewzXDmcHtTbC+tWaB6K7T/CnxRnTgzM0AnCVQc8kpPgZIEwDPD7iRXdG5EEkmR5pWeciWJTpH7Qx5weKWzrtf96dT1xwk58curLU46Ly/7DDOQPbf2NiR5bvHn2nXOOeSd6czMyH2UOdJ3N7a0fRHsythQtxWhfRkr6rYisi9jSdlW5BzKWJC3FTnHMvY6iUOBkgQUE53H2xQPnSeCJUTesXTuFwWn3UXReXe5nHcXklxnzBL+sw4=",
+            "action": {
+              "type": "hotkey",
+              "key": "S",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 3,
+            "label": "Print",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRu4AAABXRUJQVlA4TOIAAAAvf8AfEFVAjiRJkXT6K+3HzY/l3uwIt7W2rUnS+gY5/wjx2hZIiUPNFC41E3wT4NppzUmZEnd3ZwL2S5Ui/p2eC5eNQdOsQGg3fT+XB0mqahUa/ODspueHwS5UlcANwuvhP013riGo3pnoIY+glKnKjWA/F7sRksQEmuJJklEM9hTP5YfJsZWBrwzr4J8IrIyUJLIrQ5gnYa1s4zX1hT+wpQ1/SYJone55iaTTc+HSA033CoR20/e9CRdQyO6FDQpdRqrbQ91LDK0m6AXQao5QVaSXs6d9IbAxaJoV9HjBek0R",
+            "action": {
+              "type": "hotkey",
+              "key": "P",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 4,
+            "label": "Undo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEAUkt40kSfX/TxOTEd2TWQj3cuoISZBkm7Z1+Wzbtm3btme2bdu2bY5s237v2/4LgiNJjqIoCm8KOPOHC/EDJdTAioYt0GR5yzNo3ro9C0Y0S2SENg5ctvp8BM/jQgaRJCikeQt2Yo8LdAhYET6C3TjhCJmAmC1wEjNY5uPjJ3jgQAlnCphRIESDiw5fHV7BQ3ziNhysGtDjpwoCz9dB0tDsF+iRBTkZElOg8UsO+o2BmJX6A1q0w50LpU3QWCG4OZGwBdCiF2oq1HZA8VfU/u83tBT/2jKFQ6G133+y6R+tZN5/K/iPhN5x/wOL/3Sm7+23gtBAaHudYDzeyag9vQ2YcVDZb3WI/oahgttAEdOgsA2Ko1v+v0IaKd4jmUW/9VbnGO5ZiskXsCJ2kCdxfds/FeHFBwTzuMdx21SE3oAVduN4xnvjVrHF0Di6JPwXZCcw+wcA8Av5mKu3g+1orHmwwiCZyCI+GfliJBnS4nIIdNy2g+hsrdfFxwuRHCeL/1DJ2v8JFMnsFKTJXBboYJC+AwB8Sj7FAhabyVgUHckUFSHJt7R7kgpGqeotdDCtRVlwsftbKAbTkf6sNEBhkwulu2IHKhaMiXZKOfdPjsZWdblV1uoYUXh9IRpev+mE1192sXdS2svhO6+SXvbfeRV/+E3/X6PoKyjb2Cr8BuoPm9gq+Oorv5f1h15Zj41Fz88qqwsRHHp+tkYffPlreFBdiN8xuRAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Z",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 5,
+            "label": "Redo",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRjgCAABXRUJQVlA4TCsCAAAvf8AfEHVIctxIkqT/v9qAdM8V7o3OU3svMRMhCZJs07bCtm3btm3bM9u2bds2R7Zt2/pcjhxJcpSoRJzM4uEL81XLkNEWpUavSesWTOiSxpkopEtUgrUW+arwSnQIjudFOzOojUBiawNcmQfxCJqAwMouuDovAiF3gNYouDPL+Otj7xXsuNXIjSpmpLAQoiHJRq5NsJsfrsVBkLy/f6opfB8fEE6Ff7sjUgqlMmgaQOKPHFRzPhRS/VpphuHUBVE7SEzinmvDZW6lWUJYlux0t/wTA+n654Fgf9ORWUFcFI90p3zTnzuj4TUdm3WkJf33K/gid/PgcDhK2UReEBRL6fppz92hspuyhbQegen+8H7g+FD8pgO0hqgauJ6Cnme+j+3k20FQjHCw8Y5qHhlKBynzOkqB6Tnwn4eGzulKK4UF2Lj7N08Nk4t69ASh89ywuakGgd9gLf9Q3wFf5Nm0VEMLbIzNHejX6aoRGQR2pi+Q6MxxgNeZV7CW27kFNvvLQ17kh77/G9vTeAjT53hn8NOvqc4gBQfTed42PiF0ZnmttdB0pjHQ64xfkNEZkWC/9QU9RMQ6pyCo7IxU+tOBrnOWInWdMQMxCo1BtBacIWwc2XRmAHLjlKdUQugLtt2UvMbh894+qn63j7m/uek7Vm8glh9Gcj/1sfgwkvMGkt045i8iWZ3/jbyIZDaO6SvIn5SMdx+TnKTu+aE2rUun1nmnNs2HeL5k2QAA",
+            "action": {
+              "type": "hotkey",
+              "key": "Y",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 6,
+            "label": "Find",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRj4DAABXRUJQVlA4TDEDAAAvf8AfEDVIkiRJbBv+/9MZsTMAgYleyT4JiIBD27Zp5yu2bbOybdu2Vdm2bdulbTvpbBsvB4LbRo4k1nj38tXknn7C8zdM4WYty4gtp958u3ZgXi0/kvB3Q0C8Q/ClPKunDbcR6qbApXIpHPEmyJkCl8uVYNgNIJQNAWe8u3bm+bwPiwTjEbMHDuVaC3cSyKoVOPyMZFsHh/LJP/1vegaNfwMMvh3mBKV7PHwgHyYZBz+gMUDsSk/IxXjrTelCkIt5P8Sc0L/aFjaDhyX2Q/I+22oZRnOjM0G++zdD4XTfVkoh9L3j0kvrjX8kaGNtlaTe7Y5EW3wSTCSoRdXAmdm+aRE2D2bvxQK8se0jOI8isHjBMdJh+z+uEKfB4qsInWkRW7v+CE8jGyz2p44mMe0uDJcFxnnhONUk8nYLoJ2FKliczZ1M0ov6LMqLtLkuCbaRGPwo9grxwTbbMIBkEqQQ8L6uoafPEn5JKINFz2SfjIraJLyL5En4i/kkIgqXSXCQxUESmYXxaKOewfu6TqKyUB/lbPGdREWhM8r14i2J3MJilPfFaRJRRcAkZO9iKwn7NuCcRKIYSUKqmJrEvchKgsA3eN8H0SAthXXUfc88WMVg8LLnuuCOIqbonMMALA6fKESKLwxjDBTxYeNOK6NHMjH/hUAYrsUblqn3fpaGQeC0PVHPoA/6XSqteLW1YTUBjZP+HgfOZhvM4h14PDb8LhBygc+9pNqkh2P0tykERXbkg7+UtkY27i5SW3P2EEaCNQHah3jvgKeqT8ISy5x3weL4MMXL6jocFlpjfqhHp/1TLBf3i1AvrSsIh/i8rzdZGC58xNH+YeaTeXQeE4cPfOlkcDoMgCYuzdmhIffks4MFVsrJNLNvUwoFsKBDnTEXyXpcg2MZwxmeuv7YBDfKuyDo/DwPHC+nV/lShDl0wvN1dMjJTZCrlSucy8byQaXny0BIjHnfZyD2lFOF+aC2ycmvk2IvSq4KlTJF8KaMdE31p+e5uVN3COZt4/B/IA7/0YNp+zj4H4gDTP/lwbh97P/uwbB7HoMt9jF+UNvyunsek7vnwW3Sq0EMH9TfN/UAAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "F",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 7,
+            "label": "Replace",
+            "color": "#2b579a",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRkoBAABXRUJQVlA4TD0BAAAvf8AfEHVAkiTJkbL//7SvyhVA3hCFKCwCigAABJyzbdu2L6mx3R6wZDsZjdU2k71qRdv2NgHz5f931837v9+PNw+OrZnUKJkesNWNjmRDltu1T99u3bO2Wyeo7VZbPb+ULbTMdUBgMGhUdiXO0qppE9EsJDulBtlj8AtdajSFJW4lP9G3Up4IWhlJ0KVI/AQ7B0AnbPsb1bYBBIPDphNS63WjP8oWj9d1AJRzgFjOCfV0s4Q71ayJT8OHuTCmmGY6PswO47RMWgYQHJNXqYewvuT2uYpiOexqBKw0UFbT/nUaLDdpFXYasRv88HQaXWkdwHRCdplWQ6eRcIM/rk5jIq1NkE44HtPK6jQSb/CM1WlMpdVTiuA/LV+nkXSDPdBOgObTyus0xF6TF9xOIyOtgVJAVtMKvmVf/n+PGgA=",
+            "action": {
+              "type": "hotkey",
+              "key": "H",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 8,
+            "label": "Bold",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "B",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 9,
+            "label": "Italic",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "I",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 10,
+            "label": "Underline",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "U",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 11,
+            "label": "Align Left",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqQAAABXRUJQVlA4TJgAAAAvf8AfEJ8w//M//2oj2aDz3vOLxEasDhUIyIFDAQCAAQAkFgAAPICGA2DcRpKiWWbOP9i7ey4eR/RfYdu2TSx1tw/0A/h1ChO9m7Ls3FI2OncHd27x6IqTroGue+G20953mm4l179RN5FatpRKTqUGMKlJaOPIAB66cqHDwN6I9P7V4m5D0MThVyIZQ99kBdA1h30j4P85AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "L",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 12,
+            "label": "Center",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoBAABXRUJQVlA4TM0BAAAvf8AfEAUkt40kSfH/T7NncVY2EL7NEiGJtm3Tjk5s27ZtO620bdu2bdu2bads24r5Rp0JGPj3/0/OqFnLNOmpP64QTryzqpw91j6UtTqBxwhTrLoQNgovWiNfhIdzeNWVwBZIVcPrSjog1Q7fKKWCXPhWZgXYwUMfFDIihAojGZ7WTrxDsx4W35ILCagGInMfEhS0nkIYHdEdOMXtcfIR+XK4XARXNAbOiTgKkNVyYmEUPfBUaNKynBfBV1SP0DiCECIcKmaHbTfSMMoYeK7FhixWGAbWF5yoXCipK/iHpJXHwcpAa1dBQyvsMEprRS4JaUUj8W1FP/FqRS8JaEU1iWpFPMlthSbpbDXgR7BTy0JwgfwCewuc0BWQEyDtCzohdKqVCZLtmCa5z9D4C7/6IJPkbigcBd9RPeIOo/ndBlQHKOoJKq8Sl+XI+x9cUn0gG0YXGJYb0BegP9SOuMOsZmB7Ys4DdCoUWUCtAGYXeNcbEJQg9FI6bbwosNKW6hs8lDtQUNfBTXdRN0Bt8Q2OiA5URG38mp80B0oilYq44xWJgZ7U7F9wJRPNQFW2ZhFnvsojMlAXF0e11n1yinDqk4cGRDNCNvDv/5/bAQA=",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 13,
+            "label": "Align Right",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqoAAABXRUJQVlA4TJ4AAAAvf8AfEKcw//M//0oiSXKjl9HhDE/HK/gAHPGAcCAQCwTCcEAgEB+IAEKBYBxJcpoTs2TKP1f6WWuGiP6rcds2sqWt890X0A9UjQaP7TsN7jBAwyexYXm4ElF7TroZkYTb25B4GGivHHwVbVZlqKRrMlQGejr0dBJ2SEGf/cP1r8Ld9d13pttOBm8+BuorThI9uESuXwrNKP6/nz/nEg==",
+            "action": {
+              "type": "hotkey",
+              "key": "R",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 14,
+            "label": "Justify",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRtoAAABXRUJQVlA4TM0AAAAvf8AfEIXbNpIcafJPms72nmzvRQSUbduOSc/Y6NPtyY5GnuRJNvLa+wO8ybZt23W/tDbeCRj4+/8jtG1orf7vD3X1VNVyHJSUwKXkEtdo0KG7HVdBsYRvaOkPccNjECrhfgURJCwocpZwGngTYyIuoSdYSeqCD+QSYgFSXJF6DWYGSpIlSCcNDiq+jAco8rQYsJCOwtBqMJ3FPdBT0zk6BoqiWjvDMHKTAVSth/ypRBgoy2Z1y59xqoHC1NKGnMF8+4A50C6MN/D3/2d3AA==",
+            "action": {
+              "type": "hotkey",
+              "key": "J",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 15,
+            "label": "Clear Format",
+            "color": "#1f4e79",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRh4CAABXRUJQVlA4TBECAAAvf8AfEJeCoG3bmD/pbY/OYf7nn3HbRo5zJ3lzet464JuBAKAhEKIiCAoAEKADdAyAguCBHwLr4EdBx0AHWBVQIRrEgaigKQZoApF+KAClKABESbZNO+sZcfIQ27ZtPuz//5p79jl3p+qtGBH9h+BGkiIpMmMpl4/vCfifJoXp7ZP72t3hUomT4kpN/BxVCRl/lnC2MmQkFiU2x21cLoumeX/T8Jsh9HgiD6Qq6w098rmQhE7fpXoeVTJfJoNfg6pHXNb6EUyfGktU6xxisu5Yonqgg2wMFcchicam3Nk7Ds29EZEai/X5W0vvI+5ZHEOPoflmxAmNsHRCIrZptDR57Jhm0dQF9a2wQKKpk+oprDA4Cpja/+J4LnJo6lxNHOMcxjeURQ5f0+UEhaaSC8yzO1b/IDvyIXH0o+zw1721IdgY+cpzmMfBrzwHYGOI3tp7J1bY7fT+kdrLKmbEy36JU6xLIJu5OAYpxIWEctFrt9WXp0evj2WrLb9spKu7Td1em62/zAIoneoxZ5Fg6UKUzI6+M8UAjR0SceX9/1y3RCWm1QKdjBr3qcSaXryU1J31MolzvfjZVT8CgrIsAaoS979kkmUzRPoxRpZlzqdrduMpLM3S7W1XdCvQLhHX6J7bdBuhmHI8XEtsVmjEqhhysT7TCZ6cvWKjWUKcr013gC5T9o1qOVudagdt9tz2D04AAA==",
+            "action": {
+              "type": "hotkey",
+              "key": "Space",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 16,
+            "label": "Heading 1",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRqgAAABXRUJQVlA4TJwAAAAvf8AfEJW4jSRJkfy3Op+5n2HkbyXCaQQASHSQqBwLcFStTmIMdxJHZw/e/bfw7j6B+zeXCZif/9+e6/pvVt7PrZtFh7HsunkucsMB9dIJGw7vGQ7u0GwY52ZjuzcaWL075wFQbJsMRDPuvmkE3T+XdjoJLJuPeKDRrEgTzVcWMpfqiLtpoGc9FV0BNZtT7fqcojx7/7/l+Pn/HTY=",
+            "action": {
+              "type": "hotkey",
+              "key": "1",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 17,
+            "label": "Heading 2",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRoABAABXRUJQVlA4THMBAAAvf8AfEHXAbSTJkXT+Ox3K1PHSnvSTBiLgAABYRjr73vZPtv8n27an32zbtm3btm3bNjMB8+3/D88NAmeFt3kEzhxvQctejjnHXn25sKaRC5FGxNT4Bq41zRC0DIJkf3urVpRVkJjYOzrCUgTS5N7VGrIePPfOimpg9HYv/0Rb8NrohiduWDh8Aj2H/W9hNdjBOEecroMb8A7YN5KcSD8sjg50gqnJoK4DmQ78grArRmeg3wEfax7ileu35o7VNaoCtQ531RPwtwLzcPIF04r6ng1MK6OBw5t44P3Y79kjYinSPgK/6YTf/Z4dwHXC63rP/ilMJQJuNoqaSsTdb9QFUYmsl40mES+Q96FwbvZ4P5o+NppBNo2Y+tloHOk0YuNvo064acTa/0aVUNOIib+N0sCmEVXfG4VeIG/zuQh73chjKqFzupHbVAI3BESZ0+l3o3XoThi9p9uZlJCz5dD5bsdn21luhwFoR7fe7/v69v9H2AA=",
+            "action": {
+              "type": "hotkey",
+              "key": "2",
+              "alt": true,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 18,
+            "label": "Normal Style",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRrICAABXRUJQVlA4TKYCAAAvf8AfEFVIchtJkqT6/6fZPTOe4VHtc9sM3hESAAAsG6m9eTvbtm3btm3btm3bxtu27T/bvssE5L///zRNVIhujy3YdW7fvA9uKWaH9esZB37tPvjoe39N+QBOhE/AoZusIYdY7u/B2iLQ6AOxIayieAOwCqDXiaAZVt0bqAHaeczggsw1zkC/cxojrOeILiG1dmF9hBxhBVySAJQuzfIgigISMQ5m2hxXK3AGm2ju+Fr4SiY1Hp8rz2dY7VewAr92gCVPMdku9nsGl5RvMC5MvKDn4iuuM6x3kBe4F3oP0LkspAyxIi9wLCzBPYtPheYp7GLso1GsPuhnX/9oDfRhrdZHtpATWSyWdlu8rXYtKacCMQ6HylfoNolPdtemQX44Z0Gvp1hJbUgsPfvZL3X0oAeJncIh9q5wOttd25oojvGChBVrsi0KOnbXM6ZTQHhTLJM2sLqeXTPoZwgFl4XfcF0Jd7s9a57oDNFSrOy+oFbqqGUt45wBtY3CCd6+BIVQ7zrWM8gRwrdY124kwSvKbadHK2gGsCfFsr2TBDETlb4d+I9ohJB0UZhHfOtnXMI9erJUZ4jqYpW8QxJirjyQMQRyy4UzV98jUV4ZHSJciocFYkKMBCow4IllLkew/heeThF3u7wBfq3pKLoKn8Yg5KxJa2EF6khl4c0YUdQkuFgOR24Vrs+B2HwP4cpfhAMCLgolc4RNT7wq1gTkI6RebslskLjaI7Rat7E9IOAlUNqAngSP4xbE5qt1ooc9LiQQyAlyMeIUqGW9oEkiqyWsH7RaRToLnF8t0X/DJaPMEsY90GYviMs0MdESOP1dToW+oHmwOWhJ2Fpr8ZpMBorEpiDm68WJc9dYgV/QbxYPZxXu+mTRgXP7Vr03pYglmhf03/9/RAY=",
+            "action": {
+              "type": "hotkey",
+              "key": "N",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 19,
+            "label": "Insert Link",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRlgAAABXRUJQVlA4TEsAAAAvf8AfEB8w//M//0ICMuWZC6YI8CEyqIlkq/kmqJGCCb4OzOdc5VBBFdH/CYDXUtJPB8eqE1glbbEMZHfhWHUCq6StUVKY/L94EAEA",
+            "action": {
+              "type": "hotkey",
+              "key": "K",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 20,
+            "label": "Page Break",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvABAABXRUJQVlA4TOQBAAAvf8AfEJVAkiTJkbL//7SjakRv9Q1RKxEFWAQcAQAIKGfbRq7JWrsPZNu2bXOyMdm2bdu23QTUh/9fNzfhf7k/Pz48ubRrVrsc9qhrDPRqv768uv42oVoYJcBclvpWTWKnhQ5YAOXU7YvzIN1GUZPqljhK2ybIqrmO0qZAs/JOYpQWl1VrHOYX8/gUVlUBnaFRSBKJdrLAL+4qpfUcEAgEHBqZBP2vqAUkEUIri5rfRgt5RnpyqbOGSM1e9RU4S6bw/QR2d2MceMumTAYed6MUuEtHVeAPeC9qgcV01EeAe3EM5KVjJbjVTiAWAprZUOnQwk6gSvpl04DJgBuOVGz2DwaDTomXrX7ZD43KBUNrx8xXbc27sgAEhcYmT0+2p449wg7h568y2FpcjWDqq/KyBz2EQwmYaXmlVEN030QC5+SJqEbp1nPNyAzZA2Cg1gWSjg12P7WJ0nr5DIGAR4GWeGdRC0zCn2/v7hxZ0Cn/j/IBsHZdeJMSeUU6NoW182ZVcoLmMyv030DnrMpU4GpaqoNPwFlpD/zOCsR14Komxb5DfZNi4i0SMhugOzQaOZY6/Md+iU1iR7U1OZ+kZsejJiej5uaDZ03NpyoSB8B8/Pn+8uLepSMbprXJZIR0AHz4/xV0",
+            "action": {
+              "type": "hotkey",
+              "key": "Enter",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 21,
+            "label": "Spelling",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRvoBAABXRUJQVlA4TO4BAAAvf8AfEHVIchtJkqT8/6fZm0dEAeG3nhmfxQYRcAAALCOlp7dtW5P9k23btv2Tbdu2bdu2bU7A/PL/N854OSkx7tSTHy9OrOgTQwdtOzC4WfO/qZcmRCs0neWgFXx9gCTmrE8ObUjNcWZNMMx5P6RbgOv6BbEK0QE//6U/bczwIoCAjYGKfB9V2Hdgs7CJf2os1ivTDaDN117RzCoqD0X+349iofEB63wrxvdjWijbQOavEHQ/+oVzGGtjrZBzP9JFlEOtNYq2ilXaEC2NxSpxLoE4eEP8V5K4U8UGYzdwnK99tiedDFQnw2AviQfZRBoZkSeSmKLcB0j6mUQr8i5mmHo6Eyd42xjE4rwfiQuMbcwg4GzpRExB9DEzWHno97UVDq3MDGxKkmxtOAZr5jMmrsZWQqKhmcGnY0FYTzMSKnW3g42LAnuRKk24YLQF3XFh8nYW8rXsrVFcWLudvMIl5JakwsLtOBaht6Wv0H073JVDWBs4/BZibzfmimiEWIJrNiWV63Guoh/dAg6z/ku3UNeD7aSKT6V0McEBh4+TkVpf/msRD7g/zYWjruA2MCpe4Y/CdAil7QV8pkcYf0/54vyANmm7PmIe/zQKm7WZHT+6aIAe0CwWhhINWnPm1Y8XV5Y1i6aO5AG//P99Mw==",
+            "action": {
+              "type": "hotkey",
+              "key": "F7",
+              "alt": false,
+              "ctrl": false,
+              "meta": false,
+              "shift": false
+            }
+          },
+          {
+            "index": 22,
+            "label": "Track Changes",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRuQBAABXRUJQVlA4TNcBAAAvf8AfELXIkiRbtZX5jzqx3ucc2OsPWbg7LJyIgAMAAIEmu9m2bdvXbtu2bdu2bdu2bduagH7k//tLQ1ATosWaWx9+PNk3IIkWgg288H85qQP4FDyd5Y9aqdaCTsOcaBBXIYy9zqk+2FQBJG1OF1/DP0VzIf8SRMylFAugOYsOxZBFCw4HOxODK/Yh7511DsFLnwjfefLG+2tHSp/TsN2emIkeSPQqMivJEcjmkD4JPgj3OvpvYahujsdEbn30WZK/OZvB2ddDkB5m5qMZcZ8Q7g3bRMF9/LdhoX9ge5cXsEv4T9jrBUqDe8Cq/gf9XdXnILsqRBMFVoUzsa+KcGJR1Y/EtCqSiXVVBBLXqjAlEVU9SUqqapfBeFm6gzeQE2h9ogtdgPAwxE5QMuNZAfnnu6OQRByDdDe3OxSCZW+gHoIL8EOMJuraW0sL8/vIV9uJ/uZw+QveCRwQNtHb4821yjBuCS4xmiy9d4fRaxjPz4ADhOjJ3lBsr9mmGVuCiH0DRfBLgPNZFNH761cLZ5p7W8FbPRd4wNAV9FtNp7ki0jU00H8/59jG3FV0PzV1go+/kF1INw0dH9eciUTfO70rupHSkWHIseePfx5bUs2NLHA/8v/90gEA",
+            "action": {
+              "type": "hotkey",
+              "key": "E",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          },
+          {
+            "index": 23,
+            "label": "Word Count",
+            "color": "#2563eb",
+            "labelColor": "#ffffff",
+            "image": "data:image/webp;base64,UklGRiQEAABXRUJQVlA4TBgEAAAvf8AfEJVQkm1btlK9/nd6FNhr38vhFX+yzZWNGiEBAACybVK3s23btm3btm3btm3bNm/bn711AuZ///9TNSQ1SYY889eNB2fem1PAAsFZeqBrny9I2Gz0gjdby7uAT52zbf8wTPUkAWFR9Cw3nIG2EG1k2EKnD/pG87jOIZwYtGC7byyRFs2EpMPRJfStbngdA+oiSG/R2q6QlsTgxWRgJXu73FPGdDDfktsy3DIZVCZgDfuKYk8RF76BdBy2nL43gJwE1knavirFQyiFxddAun1CDRwb0QV62/RRFlm0EHCwczLf8R7qDJjuA9cGiwuCGuyDzw+ghu97ciUSYuL7z7S8zxibQW1D9QWDDeVBc5C10QmJ6SJzlHwCPUNu8Kzhw4V34GQ/cKuQfgpuCE8f/XtYqmcwCJ7gBkxbu6iWQIDpIeCohG0U8gCu8ktqz0ASlnLgGqQEAYEcdO0PUOVl8A3iEpST3fVgSw49hGeMV0F00Fn5i8hjpT8IC3ofQIlto8S5/tuiZKqwH8C5qoOhCsifStfYqvz7U+kNAio+Cf8Np7MPfle/tuY+0qvFV/kWCFWag/9Abw5TWIyF4IBlKAd+BZqtnYNWjoLZefu+B5aFscrnBzBQbiq9BZNgYuqfQeUT0BUUvAB3WambGTOVv0Av5ARRFaKN4p8A32D9BdmtWc2MyGrxvLAc/lY4E98nQDC4hZgZCQHFzBANfB7ADJjr6itkRThxewIgzqslNjNWKs9mZkCcVLpnhtDWlqYmlTg/gTER+M3Adl8pfDH6Kr+BZngFKYFk4vkMxAStM7Sha3oF72pxz2gK1AOBJPgZkA/ez8irPMIrsIfPM15XX+AGTEnaM4DhrlokD8BhZWNqXytdg3BrOxOhkqZnMNYDHaRbSw0aKr8eAM0gP42fwepTkBUkswgUA9tqcUoIDBsmgyvQG1j8ZA3zMHrBtJrKDWRAGXiYCEgbUsMSu0HTrnN15IFOQhSc+VT9nexFpdP/yotpUkjSrkH5ty99lITlnPG8yiIaiio3W6vsgDkJfkBc4gAdTRz05wrRBv0qs+mMkrCCr/zyOrE9iM0FpyANeB4uoGvh8hRcE7ggZaMr2AdhuKB/ujZ6Pj+Avvaw/hJscdisdE72tcenJaWn+QJGl2Gd8wMJkDI3u0Jx1JcejhbFHrcLwzvteiWB2DsYgg9xvkM3pc3Rf1p/pw3huvXjymhu3Gnn21n4Wpp6Y6rjD9Clb19ewQmGORvYaYf9BWEdfQ/gOqSB2/wiMqcb66C5QLgj4Ib5I87DPV5jnuNFNj7PxT/+NQjfMUPQxg1uJEHN+WQbyq6MnuQc9J4ZGsZ+9HyTjn7eIqTbxPgSj2Ri7kfK6t2Cz79//B4HOoX8BXkA//v/n80B",
+            "action": {
+              "type": "hotkey",
+              "key": "G",
+              "alt": false,
+              "ctrl": true,
+              "meta": false,
+              "shift": true
+            }
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Splits the exported 8-page CrowPanel profile into 22 installable community
decks: 8 for the 10.1in CrowPanel and 7 mini variants for each of the two
Waveshare revisions.

## How the split works

The source profile is a cohesive set. Every page carries an app's shortcuts on
indices 0-23 (30 for VLC) plus a shared eight-key navigation strip on the bottom
row that jumps between pages. Split naively, that strip points at pages that no
longer exist.

So:

- **Windows Workspace** publishes the complete profile unchanged, navigation
  intact, for anyone who wants the whole thing.
- **Seven per-app decks** drop the navigation strip and keep only that app's
  keys, with the row count shrunk to fit.

Each standalone deck carries the app match on the profile as well as the page. A
single-app deck is a whole profile, so without the profile-level match it would
never be selected when that app took focus.

## Mini variants

Six of the seven apps already occupy indices 0-23, so they drop onto a Waveshare
5x5 grid untouched. VLC has 30 keys and spills onto a second page behind a
navigation key rather than losing any.

Both Waveshare revisions get their own copies, because `addImportedProfile`
requires an exact board id match.

## Verification

- `build-catalog.js --validate-only` passes all 22 through the desktop importer
- Every profile was installed onto a matching device registry via the real
  `registerDevice` / `addImportedProfile` path: **22 of 22 install, 0 failures**
- Grid, board-cap, and page-reference checks: no overflows, no dangling page refs
- Key counts reconcile exactly against the source (207 = 33 + 24x6 + 30)

## Notes

- Audited for personal data before publishing: the only non-hotkey actions are
  seven generic `start "" <app>` launches. No URLs, no Type Text, no paths,
  no credentials.
- The Teams deck's five plugin actions resolve against the bundled
  `microsoft-teams` plugin, so they work for everyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)